### PR TITLE
fix(action): PR-comment crash on findings containing backticks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,11 +120,15 @@ runs:
       if: inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' && steps.scan.outputs.findings-count != '0'
       uses: actions/github-script@v7
       continue-on-error: true
-      env:
-        SCG_REPORT: ${{ steps.scan.outputs.report }}
       with:
         script: |
-          const report = process.env.SCG_REPORT || '';
+          const fs = require('fs');
+          let report = '';
+          try {
+            report = fs.readFileSync('/tmp/scg-report.txt', 'utf8');
+          } catch (err) {
+            console.error('Failed to read report file:', err);
+          }
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/action.yml
+++ b/action.yml
@@ -119,9 +119,12 @@ runs:
     - name: Comment on PR
       if: inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' && steps.scan.outputs.findings-count != '0'
       uses: actions/github-script@v7
+      continue-on-error: true
+      env:
+        SCG_REPORT: ${{ steps.scan.outputs.report }}
       with:
         script: |
-          const report = `${{ steps.scan.outputs.report }}`;
+          const report = process.env.SCG_REPORT || '';
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
The `Comment on PR` step interpolated the scan report directly into a github-script template literal:

```
const report = `${{ steps.scan.outputs.report }}`;
```

When a finding renders inline-code containing literal backticks (e.g. the medium `GHA_OIDC_WRITE_PERM` finding showing `id-token: write`), those backticks land inside the template literal and break the JS parse with `SyntaxError: Unexpected template string`, failing the whole job even though the scan itself exited 0 (0 critical, 0 high).

The comment step only runs when `findings-count != 0`, so it stayed dormant until a PR produced backtick-bearing findings.

**Fix:** pass the report via `env: SCG_REPORT` and read `process.env.SCG_REPORT` (injection-safe), plus `continue-on-error: true` so a comment-rendering failure can never fail an otherwise-passing scan.

Surfaced by the OIDC-publishing PRs in homeofe/aahp-runner (#51) and elvatis/elvatis-mcp (#36): their `id-token: write` is exactly what produced the backtick-bearing finding.
