### PR TITLE
fix(scanner): harden archive extraction and IOC scanning

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -13,8 +13,8 @@
 |-------|-------|
 | Version | 5.11.1 |
 | Node engines | >=20.0.0 |
-| Source modules | 61 under `src/` |
-| Test files | 73 under `src/__tests__/` |
+| Source modules | 62 under `src/` |
+| Test files | 75 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit | verified continuously in CI - see below |
 
@@ -39,9 +39,9 @@ Overrides: none.
 
 ---
 
-## Source Modules (61)
+## Source Modules (62)
 
-`active-validation.ts`, `agentic-workflow-scanner.ts`, `attack-graph.ts`, `cargo-scanner.ts`, `cli.ts`, `composer-scanner.ts`, `config-scanner.ts`, `continuous-monitor.ts`, `correlation-engine.ts`, `dependency-confusion.ts`, `dependency-governance.ts`, `dependency-risk-analyzer.ts`, `diff-scanner.ts`, `dockerfile-scanner.ts`, `entropy.ts`, `feed.ts`, `git-scanner.ts`, `github-actions-scanner.ts`, `github-trust-scanner.ts`, `go-scanner.ts`, `index.ts`, `install-guard.ts`, `install-hook-scanner.ts`, `ioc-blocklist.ts`, `lockfile-checker.ts`, `mcp-scanner.ts`, `mcp-server.ts`, `metrics.ts`, `npm-scanner.ts`, `nuget-scanner.ts`, `openclaw-plugin-scanner.ts`, `org-scanner.ts`, `patterns.ts`, `playbooks.ts`, `policy-engine.ts`, `posture-engine.ts`, `publishing-anomaly-detector.ts`, `pypi-scanner.ts`, `release-scanner.ts`, `remediation-engine.ts`, `reporter.ts`, `risk-engine.ts`, `risk-forecast.ts`, `rubygems-scanner.ts`, `sbom-generator.ts`, `scanner.ts`, `secret-simulator.ts`, `skills-scanner.ts`, `sla-engine.ts`, `slsa-verifier.ts`, `soc-exporter.ts`, `solana-monitor.ts`, `threat-intel.ts`, `triage-engine.ts`, `trust-breakdown.ts`, `trust-signals.ts`, `types.ts`, `vscode-scanner.ts`, `workflow-ast.ts`, `workflow-graph.ts`, `workflow-modeler.ts`
+`active-validation.ts`, `agentic-workflow-scanner.ts`, `archive-extractor.ts`, `attack-graph.ts`, `cargo-scanner.ts`, `cli.ts`, `composer-scanner.ts`, `config-scanner.ts`, `continuous-monitor.ts`, `correlation-engine.ts`, `dependency-confusion.ts`, `dependency-governance.ts`, `dependency-risk-analyzer.ts`, `diff-scanner.ts`, `dockerfile-scanner.ts`, `entropy.ts`, `feed.ts`, `git-scanner.ts`, `github-actions-scanner.ts`, `github-trust-scanner.ts`, `go-scanner.ts`, `index.ts`, `install-guard.ts`, `install-hook-scanner.ts`, `ioc-blocklist.ts`, `lockfile-checker.ts`, `mcp-scanner.ts`, `mcp-server.ts`, `metrics.ts`, `npm-scanner.ts`, `nuget-scanner.ts`, `openclaw-plugin-scanner.ts`, `org-scanner.ts`, `patterns.ts`, `playbooks.ts`, `policy-engine.ts`, `posture-engine.ts`, `publishing-anomaly-detector.ts`, `pypi-scanner.ts`, `release-scanner.ts`, `remediation-engine.ts`, `reporter.ts`, `risk-engine.ts`, `risk-forecast.ts`, `rubygems-scanner.ts`, `sbom-generator.ts`, `scanner.ts`, `secret-simulator.ts`, `skills-scanner.ts`, `sla-engine.ts`, `slsa-verifier.ts`, `soc-exporter.ts`, `solana-monitor.ts`, `threat-intel.ts`, `triage-engine.ts`, `trust-breakdown.ts`, `trust-signals.ts`, `types.ts`, `vscode-scanner.ts`, `workflow-ast.ts`, `workflow-graph.ts`, `workflow-modeler.ts`
 
 ---
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,18 +2,18 @@
   "aahp_version": "3.0",
   "project": "supply-chain-guard",
   "last_session": {
-    "agent": "cli-tool",
-    "session_id": "cli-1783618256",
-    "timestamp": "2026-07-09T17:30:56Z",
-    "commit": "aa685e9",
-    "phase": "idle",
-    "duration_minutes": 0
+    "agent": "codex",
+    "session_id": "codex-issue-53",
+    "timestamp": "2026-07-11T11:36:06Z",
+    "commit": "5ddd637",
+    "phase": "implementation",
+    "duration_minutes": 30
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:56eefccb9b019a20afad37c6b5e7fd9cf2d42240a3cd679adc5cc64aa83c3946",
-      "updated": "2026-07-09T17:30:45Z",
-      "lines": 442,
+      "checksum": "sha256:82bd331a42ba0464006e6e1bf87c19f95d2ba88d495cc4e2c65cbeb962c4ae61",
+      "updated": "2026-07-11T11:35:31Z",
+      "lines": 453,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
@@ -41,14 +41,14 @@
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:569ce924a7e2ef8e84474ac87ec11075afce1473963a52c66373385143964a34",
-      "updated": "2026-07-09T17:08:16Z",
+      "checksum": "sha256:3dbe5da7e1e419584eddf549ee904459cb0045ba5ef7e5ebc0b18e8e0b7e6f6c",
+      "updated": "2026-07-11T11:33:17Z",
       "lines": 65,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
-      "checksum": "sha256:b5f62eb5b4a74136cd5c2c785523b0bdf8dedb4f9dedcc167aa8f6febe9c6908",
-      "updated": "2026-07-09T17:08:16Z",
+      "checksum": "sha256:775465386db0362585adaddc3011870f608910e501ab2f5c5658b85ff20c251b",
+      "updated": "2026-07-11T11:33:17Z",
       "lines": 35,
       "summary": "(no summary available)"
     },
@@ -71,11 +71,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "(no summary available) (no summary available) ",
+  "quick_context": "Issue #53 shell and IOC hardening ready for review",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 6599,
-    "full_read": 10420
+    "manifest_plus_core": 6747,
+    "full_read": 10570
   }
   ,"next_task_id": 8
   ,"tasks": {"T-001":{"title":"Add solana-monitor unit tests","status":"done","priority":"high","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-002":{"title":"Add reporter unit tests (SARIF, JSON, markdown)","status":"done","priority":"high","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-003":{"title":"Add CLI integration tests","status":"done","priority":"medium","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-004":{"title":"SBOM export (CycloneDX/SPDX)","status":"done","priority":"medium","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-005":{"title":"--fail-on severity threshold flag for CI","status":"done","priority":"medium","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-006":{"title":"Cargo/Go module scanner","status":"done","priority":"low","depends_on":[],"created":"2026-03-26T09:30:00Z","github_issue":30,"github_repo":"homeofe/supply-chain-guard"},"T-007":{"title":"Rate-limit handling in Solana monitor","status":"done","priority":"low","depends_on":["T-001"],"created":"2026-03-26T09:30:00Z","github_issue":31,"github_repo":"homeofe/supply-chain-guard"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,4 +1,15 @@
 # supply-chain-guard - Project Status
+> Note (2026-07-11, codex): Issue #53 security hardening is ready for review.
+> All VSIX, npm, and PyPI archive extraction now goes through one argv-only
+> helper that resolves paths before invoking unzip/tar, preventing both shell
+> metacharacter execution and leading-dash option injection. IOC and protestware
+> self-scan suppression is now gated by the package's physical real path and an
+> explicit exact relative-path allowlist; arbitrary reporter/test-style target
+> paths are scanned. Added focused regressions; build, lint, self-scan (0/100,
+> 0 findings), 43 focused tests, and all 1,225 non-zip-dependent tests pass.
+> The 13 legacy VSIX integration tests remain Windows-environment-only failures
+> because this host has no zip binary; CI on Ubuntu provides zip.
+
 
 > Note (2026-07-09, claude-opus-4-8): Post-v5.11.1 repo hygiene (no release, no
 > shipped-artifact change - docs/ and Dockerfile are not in the npm tarball).

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -17,8 +17,8 @@
 | Property | Value | Source |
 |----------|-------|--------|
 | package.json version | 5.11.1 | package.json |
-| Source modules present | 61 | src/ file list |
-| Test files present | 73 | src/__tests__/ file list |
+| Source modules present | 62 | src/ file list |
+| Test files present | 75 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json (load-bearing under TS6) |
 | Runtime dependency | commander ^14.0.3 | package.json (CommonJS line; 15+ is ESM-only) |
 

--- a/src/__tests__/archive-extractor-hardening.test.ts
+++ b/src/__tests__/archive-extractor-hardening.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const childProcess = vi.hoisted(() => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: childProcess.execFileSync,
+}));
+
+import { extractTarGz, extractZip } from "../archive-extractor.js";
+
+describe("archive extraction shell hardening", () => {
+  beforeEach(() => {
+    childProcess.execFileSync.mockReset();
+  });
+
+  it("passes a shell-metacharacter VSIX path as one literal argv element", () => {
+    const archivePath = path.join(
+      os.tmpdir(),
+      "payload$(printf injected).vsix",
+    );
+    const extractDir = path.join(os.tmpdir(), "extract-target");
+
+    extractZip(archivePath, extractDir, true);
+
+    expect(childProcess.execFileSync).toHaveBeenCalledOnce();
+    expect(childProcess.execFileSync).toHaveBeenCalledWith(
+      "unzip",
+      ["-q", "-o", archivePath, "-d", extractDir],
+      { stdio: "pipe" },
+    );
+  });
+
+  it("uses argv arrays for zip and tar extraction", () => {
+    const archivePath = "-package;&.tar.gz";
+    const extractDir = "-extract;&";
+    const resolvedArchivePath = path.resolve(archivePath);
+    const resolvedExtractDir = path.resolve(extractDir);
+
+    extractTarGz(archivePath, extractDir);
+    extractZip(archivePath, extractDir);
+
+    expect(childProcess.execFileSync).toHaveBeenNthCalledWith(
+      1,
+      "tar",
+      ["xzf", resolvedArchivePath, "-C", resolvedExtractDir],
+      { stdio: "pipe" },
+    );
+    expect(childProcess.execFileSync).toHaveBeenNthCalledWith(
+      2,
+      "unzip",
+      ["-q", resolvedArchivePath, "-d", resolvedExtractDir],
+      { stdio: "pipe" },
+    );
+  });
+
+  it("keeps production archive scanners free of shell-string execution", () => {
+    const sourceRoot = path.resolve(__dirname, "..");
+    for (const filename of [
+      "vscode-scanner.ts",
+      "npm-scanner.ts",
+      "pypi-scanner.ts",
+    ]) {
+      const source = fs.readFileSync(path.join(sourceRoot, filename), "utf8");
+      expect(source).not.toMatch(/\bexecSync\b/);
+    }
+  });
+});

--- a/src/__tests__/issue-24-ioc-evasion.test.ts
+++ b/src/__tests__/issue-24-ioc-evasion.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { scan } from "../scanner.js";
+
+describe("issue #24 IOC filename-evasion regression", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "scg-ioc-evasion-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("scans IOC payloads in scanner-like and test-like target paths", async () => {
+    const testsDir = path.join(tempDir, "tests");
+    fs.mkdirSync(testsDir, { recursive: true });
+
+    const knownC2 = "147.45.197.92";
+    fs.writeFileSync(
+      path.join(tempDir, "reporter.js"),
+      `export const endpoint = "${knownC2}";\n`,
+    );
+    fs.writeFileSync(
+      path.join(testsDir, "payload.test.js"),
+      `export const endpoint = "${knownC2}";\n`,
+    );
+
+    const report = await scan({
+      target: tempDir,
+      format: "json",
+      noHistory: true,
+    });
+
+    const detectedFiles = report.findings
+      .filter((finding) => finding.rule === "IOC_KNOWN_C2_IP")
+      .map((finding) => finding.file);
+
+    expect(detectedFiles).toEqual(
+      expect.arrayContaining(["reporter.js", "tests/payload.test.js"]),
+    );
+  });
+});

--- a/src/archive-extractor.ts
+++ b/src/archive-extractor.ts
@@ -1,0 +1,31 @@
+/**
+ * Archive extraction helpers.
+ *
+ * Archive paths can originate from user input. Resolve them to absolute paths
+ * and invoke extraction tools directly with an argv array so option-like
+ * prefixes and shell metacharacters remain literal path characters.
+ */
+
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+
+export function extractZip(
+  archivePath: string,
+  extractDir: string,
+  overwrite = false,
+): void {
+  const resolvedArchivePath = path.resolve(archivePath);
+  const resolvedExtractDir = path.resolve(extractDir);
+  const args = ["-q"];
+  if (overwrite) args.push("-o");
+  args.push(resolvedArchivePath, "-d", resolvedExtractDir);
+  execFileSync("unzip", args, { stdio: "pipe" });
+}
+
+export function extractTarGz(archivePath: string, extractDir: string): void {
+  const resolvedArchivePath = path.resolve(archivePath);
+  const resolvedExtractDir = path.resolve(extractDir);
+  execFileSync("tar", ["xzf", resolvedArchivePath, "-C", resolvedExtractDir], {
+    stdio: "pipe",
+  });
+}

--- a/src/npm-scanner.ts
+++ b/src/npm-scanner.ts
@@ -9,9 +9,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as https from "node:https";
-import { execSync } from "node:child_process";
 import type { Finding, NpmPackageInfo, ScanReport, ScanOptions } from "./types.js";
 import { SEVERITY_SCORES } from "./types.js";
+import { extractTarGz } from "./archive-extractor.js";
 import {
   FILE_PATTERNS,
   SUSPICIOUS_SCRIPTS,
@@ -253,7 +253,7 @@ async function downloadAndScanTarball(
     // Extract tarball
     const extractDir = path.join(tempDir, "extracted");
     fs.mkdirSync(extractDir, { recursive: true });
-    execSync(`tar xzf "${tarballPath}" -C "${extractDir}"`, { stdio: "pipe" });
+    extractTarGz(tarballPath, extractDir);
 
     // Scan extracted files
     const files = collectFilesRecursive(extractDir);

--- a/src/pypi-scanner.ts
+++ b/src/pypi-scanner.ts
@@ -9,9 +9,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as https from "node:https";
-import { execSync } from "node:child_process";
 import type { Finding, ScanReport, ScanOptions } from "./types.js";
 import { SEVERITY_SCORES } from "./types.js";
+import { extractTarGz, extractZip } from "./archive-extractor.js";
 import {
   FILE_PATTERNS,
   PYPI_FILE_PATTERNS,
@@ -232,13 +232,9 @@ async function downloadAndScanSdist(
 
     // Determine archive type and extract
     if (url.endsWith(".zip") || url.includes(".zip")) {
-      execSync(`unzip -q "${archivePath}" -d "${extractDir}"`, {
-        stdio: "pipe",
-      });
+      extractZip(archivePath, extractDir);
     } else {
-      execSync(`tar xzf "${archivePath}" -C "${extractDir}"`, {
-        stdio: "pipe",
-      });
+      extractTarGz(archivePath, extractDir);
     }
 
     scanExtractedFiles(extractDir, findings);
@@ -262,7 +258,7 @@ async function downloadAndScanWheel(
 
     const extractDir = path.join(tempDir, "extracted");
     fs.mkdirSync(extractDir, { recursive: true });
-    execSync(`unzip -q "${wheelPath}" -d "${extractDir}"`, { stdio: "pipe" });
+    extractZip(wheelPath, extractDir);
 
     scanExtractedFiles(extractDir, findings);
   } finally {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -84,13 +84,52 @@ import { scanAgentSkillFiles } from "./skills-scanner.js";
 
 const TOOL_VERSION = "5.2.0";
 
-/** Regex matching the scanner's own source files (pattern/IOC/threat-intel definitions). */
-const SCANNER_SOURCE_FILE =
-  /(?:patterns|scanner|playbooks|correlation-engine|ioc-blocklist|threat-intel|remediation-engine|secret-simulator|workflow-modeler|config-scanner|install-hook-scanner|github-trust-scanner|dependency-confusion|attack-graph|reporter|active-validation)\.(ts|js)$/;
+/**
+ * Exact files that contain this package's own inert detector definitions or
+ * regression fixtures.
+ * This allowlist is consulted only when the target is the package's physical
+ * root below. Basenames, suffixes, and test-directory patterns are never an
+ * exclusion boundary.
+ */
+const SELF_SCAN_INERT_FILES = new Set([
+  "src/active-validation.ts",
+  "src/attack-graph.ts",
+  "src/config-scanner.ts",
+  "src/correlation-engine.ts",
+  "src/dependency-confusion.ts",
+  "src/github-trust-scanner.ts",
+  "src/install-hook-scanner.ts",
+  "src/ioc-blocklist.ts",
+  "src/patterns.ts",
+  "src/playbooks.ts",
+  "src/remediation-engine.ts",
+  "src/reporter.ts",
+  "src/scanner.ts",
+  "src/secret-simulator.ts",
+  "src/threat-intel.ts",
+  "src/workflow-modeler.ts",
+  "src/__tests__/beacon-miner.test.ts",
+  "src/__tests__/campaigns.test.ts",
+  "src/__tests__/infostealer-patterns.test.ts",
+  "src/__tests__/ioc-blocklist.test.ts",
+  "src/__tests__/issue-24-ioc-evasion.test.ts",
+  "src/__tests__/mcp-scanner.test.ts",
+  "src/__tests__/threat-intel.test.ts",
+]);
 
 /** Detect test / spec / fixture / mock files. Shared constant (was duplicated inline). */
 const TEST_FILE_REGEX =
   /[._-](test|spec|mock|fixture|stub|fake)\.|__tests__|\/tests?\/|conftest\.py/i;
+
+const SCANNER_PACKAGE_ROOT = fs.realpathSync(path.resolve(__dirname, ".."));
+
+function isOwnPackageRoot(scanDir: string): boolean {
+  try {
+    return fs.realpathSync(scanDir) === SCANNER_PACKAGE_ROOT;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Scan a local directory or GitHub repo for malware indicators.
@@ -141,6 +180,7 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
     throw new Error(`Target is not a directory: ${scanDir}`);
   }
 
+  const scanningOwnPackage = isOwnPackageRoot(scanDir);
   // Collect files (v4.5: diff mode filters to changed files only)
   let allFiles = collectFiles(scanDir, options.maxDepth ?? 20);
   if (options.sinceCommit && fs.existsSync(path.join(scanDir, ".git"))) {
@@ -215,7 +255,7 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
       }
 
       // Check beacon and miner patterns (T-008)
-      checkBeaconMinerPatterns(content, relativePath, findings);
+      checkBeaconMinerPatterns(content, relativePath, findings, scanningOwnPackage);
 
       // Entropy analysis for obfuscated payloads (v4.0)
       const entropyFindings = analyzeEntropy(content, relativePath);
@@ -223,8 +263,9 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
 
       // IOC blocklist + threat-intel checks (skip scanner source/test files — they contain IOC definitions)
       const normForIOC = relativePath.replace(/\\/g, "/");
-      const isIOCExcluded = SCANNER_SOURCE_FILE.test(normForIOC) || TEST_FILE_REGEX.test(normForIOC);
-      if (!isIOCExcluded) {
+      const isOwnDefinitionOrFixture =
+        scanningOwnPackage && SELF_SCAN_INERT_FILES.has(normForIOC);
+      if (!isOwnDefinitionOrFixture) {
         const iocFindings = checkIOCBlocklist(content, relativePath);
         findings.push(...iocFindings);
 
@@ -839,6 +880,7 @@ function checkBeaconMinerPatterns(
   content: string,
   relativePath: string,
   findings: Finding[],
+  scanningOwnPackage: boolean,
 ): void {
   const lines = content.split("\n");
   const normalizedPath = relativePath.replace(/\\/g, "/");
@@ -871,7 +913,7 @@ function checkBeaconMinerPatterns(
   }
 
   // Multi-line protestware check: locale/timezone on one line, destructive on nearby lines
-  checkMultiLineProtestware(content, relativePath, findings);
+  checkMultiLineProtestware(content, relativePath, findings, scanningOwnPackage);
 }
 
 /**
@@ -882,10 +924,12 @@ function checkMultiLineProtestware(
   content: string,
   relativePath: string,
   findings: Finding[],
+  scanningOwnPackage: boolean,
 ): void {
-  // Skip scanner source and test files (contain protestware patterns as definitions)
+  // Only this installed package's exact source root may suppress its own
+  // definition/fixture examples. Target-controlled filenames never qualify.
   const normPath = relativePath.replace(/\\/g, "/");
-  if (SCANNER_SOURCE_FILE.test(normPath) || TEST_FILE_REGEX.test(normPath)) return;
+  if (scanningOwnPackage && SELF_SCAN_INERT_FILES.has(normPath)) return;
 
   const lines = content.split("\n");
   const PROXIMITY = 15;

--- a/src/vscode-scanner.ts
+++ b/src/vscode-scanner.ts
@@ -11,9 +11,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as https from "node:https";
-import { execSync } from "node:child_process";
 import type { Finding, ScanReport, ScanSummary, Severity } from "./types.js";
 import { SEVERITY_SCORES } from "./types.js";
+import { extractZip } from "./archive-extractor.js";
 import { FILE_PATTERNS, SCANNABLE_EXTENSIONS, MAX_FILE_SIZE } from "./patterns.js";
 
 const TOOL_VERSION = "1.0.0";
@@ -217,8 +217,9 @@ export async function scanVscodeExtension(
   const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), "scg-vscode-"));
 
   try {
-    // Extract using unzip (vsix is a zip file)
-    execSync(`unzip -q -o "${vsixPath}" -d "${extractDir}"`, { stdio: "pipe" });
+    // VSIX is a zip file. The helper uses an argv array so metacharacters in a
+    // user-supplied path are never interpreted by a command shell.
+    extractZip(vsixPath, extractDir, true);
 
     // Collect all files
     const allFiles = collectFilesRecursive(extractDir);


### PR DESCRIPTION
## Summary
- replace shell-string archive extraction in the VSIX, npm, and PyPI scanners with one argv-only helper
- resolve archive and destination paths before invoking unzip/tar, preventing shell metacharacter execution and leading-dash option injection
- remove attacker-controlled basename/test-directory IOC suppression
- retain self-scan suppression only for the package's exact physical root and an explicit exact relative-path allowlist
- add regressions for literal shell-metacharacter paths and IOC payloads under reporter/test-style names

## Security impact

Before this change, a user-controlled VSIX path reached execSync and arbitrary targets could hide known IOC content by choosing scanner-like filenames or test-style directories. Both paths are now covered by regression tests.

## Validation
- focused security tests: 4/4 pass
- focused related suites: 43/43 pass
- platform-independent suite: 1,225/1,225 pass
- TypeScript lint and build: pass
- prebuild changelog/version/handoff/feed gates: pass
- AAHP lint and full verify: pass
- self-scan: clean, 0 findings
- full local suite: 1,226 pass; 13 pre-existing Windows-only VSIX fixture failures remain because this host has no zip binary (Ubuntu CI provides it)
- git diff check: pass

## Follow-up

Oversized-file reporting and remote threat-intelligence regex hardening are intentionally tracked separately in #54. The related private estate review should remain open until that work lands and a fresh run returns ALLOW.

Closes #53