### PR TITLE
fix(aahp): keep MANIFEST.json in lockstep with handoff docs (fixes recurring Layer 1 on deploy)

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -1,72 +1,72 @@
 {
   "aahp_version": "3.0",
-  "project": "supply-chain-guard",
+  "project": "scg",
   "last_session": {
-    "agent": "cli-tool",
-    "session_id": "cli-1783782215",
-    "timestamp": "2026-07-11T15:03:35Z",
-    "commit": "e43dcef",
+    "agent": "handoff-refresh",
+    "session_id": "cli-1783837833",
+    "timestamp": "2026-07-12T06:30:33Z",
+    "commit": "c4865d3",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:194a79c3446d9d68be874ea0634d7d16c82cf70aa8380bab1fc7ee9f224e5177",
-      "updated": "2026-07-11T15:03:35Z",
-      "lines": 498,
+      "checksum": "sha256:bd5ca2db433e41073dfbb8d18b40427c448fe97d5241b7c0879c44a0f171a375",
+      "updated": "2026-07-12T06:30:33Z",
+      "lines": 500,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:d449cbabd3fb9e0d5aa8eebd76fe3fb4d0acd49465add7ed0670f32ee944015f",
-      "updated": "2026-07-11T14:42:15Z",
+      "updated": "2026-07-12T06:16:44Z",
       "lines": 59,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:4857852ccff64736bd99820b8d4113477b27d81b06aa452e5298ae92318db88b",
-      "updated": "2026-07-01T17:19:57Z",
+      "updated": "2026-07-12T06:16:44Z",
       "lines": 129,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:5d6ecd3b44b6088e95f48ce30d7e3f62392eac197b6640473b6ead6f17c9cece",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-07-12T06:16:44Z",
       "lines": 8,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-07-12T06:16:44Z",
       "lines": 4,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:d3bd13e361c212be3709459e9f0577ab6ff3566ebe491c3e8144a74d40f42e04",
-      "updated": "2026-07-11T15:03:01Z",
+      "checksum": "sha256:2626fd19bdf29b91bc9247716a78d2b1782a4c07fb6ad295be48fc18c395b39f",
+      "updated": "2026-07-12T06:30:33Z",
       "lines": 65,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
-      "checksum": "sha256:2949d2bed5c555bf7dc2f110de3fdc7dc9679f69240ce3eb382be82b5d0bd7d8",
-      "updated": "2026-07-11T15:03:01Z",
+      "checksum": "sha256:7e1c151814b16a7d3cf9e17726614ff87444a1b91f38466e5e844f466b305282",
+      "updated": "2026-07-12T06:30:33Z",
       "lines": 35,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:5e7619ead3856a679ee035ef6cc06cd955218b291fbaa2601b7c474eb154aa46",
-      "updated": "2026-07-01T17:39:24Z",
+      "updated": "2026-07-12T06:16:44Z",
       "lines": 99,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:32c578aad3967b583ac152adcf022269f902146083b84545c0bee76bef2fcaa9",
-      "updated": "2026-07-01T17:39:34Z",
+      "updated": "2026-07-12T06:16:44Z",
       "lines": 130,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-07-12T06:16:44Z",
       "lines": 4,
       "summary": "{"
     }
@@ -74,9 +74,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 7400,
-    "full_read": 11223
+    "manifest_plus_core": 7472,
+    "full_read": 11295
   }
-  ,"next_task_id": 8
-  ,"tasks": {"T-001":{"title":"Add solana-monitor unit tests","status":"done","priority":"high","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-002":{"title":"Add reporter unit tests (SARIF, JSON, markdown)","status":"done","priority":"high","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-003":{"title":"Add CLI integration tests","status":"done","priority":"medium","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-004":{"title":"SBOM export (CycloneDX/SPDX)","status":"done","priority":"medium","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-005":{"title":"--fail-on severity threshold flag for CI","status":"done","priority":"medium","depends_on":[],"created":"2026-03-26T09:30:00Z"},"T-006":{"title":"Cargo/Go module scanner","status":"done","priority":"low","depends_on":[],"created":"2026-03-26T09:30:00Z","github_issue":30,"github_repo":"homeofe/supply-chain-guard"},"T-007":{"title":"Rate-limit handling in Solana monitor","status":"done","priority":"low","depends_on":["T-001"],"created":"2026-03-26T09:30:00Z","github_issue":31,"github_repo":"homeofe/supply-chain-guard"}}
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,5 +1,7 @@
 # supply-chain-guard - Project Status
 
+> Note (2026-07-12, claude-opus-4-8): Fixed the recurring "AAHP Verify" Layer 1 failure on deploy. handoff:refresh (aahp-dashboard.mjs) now regenerates MANIFEST.json in lockstep with DASHBOARD.md + TRUST.md via aahp-manifest.sh, and check:handoff (prebuild) now also verifies the manifest checksums (CR-stripped, matching aahp_checksum), so a version bump can no longer leave the manifest stale and surface only in CI.
+
 > Note (2026-07-11, claude-fable-5): Released v5.12.0 - issue #54 hardening, the
 > follow-up GPT-5.6-Sol/codex filed after PR #55. (1) FILE_TOO_LARGE_SKIPPED
 > (info): core/VSIX/npm/PyPI scanners surface every oversized scannable file

--- a/scripts/aahp-dashboard.mjs
+++ b/scripts/aahp-dashboard.mjs
@@ -19,6 +19,8 @@
 // source) and dependabot.
 
 import { readFileSync, readdirSync, writeFileSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -155,6 +157,29 @@ const targets = [
 ];
 const norm = (s) => s.replace(/\r/g, ""); // CRLF-agnostic (Windows working tree)
 
+// MANIFEST.json stores a sha256 checksum per handoff file; "AAHP Verify"
+// Layer 1 (lint-handoff.sh) fails if any stored checksum does not match the
+// file on disk. Regenerating DASHBOARD.md/TRUST.md here (e.g. on a version
+// bump) changes those files, so the manifest MUST be regenerated in the same
+// step or CI goes red on the next push - the recurring on-deploy failure. We
+// keep both in lockstep on write, and gate on it in --check (CI parity,
+// offline). See scripts/_aahp-lib.sh -> aahp_checksum() for the hash contract.
+const manifestPath = join(handoff, "MANIFEST.json");
+// Mirror aahp_checksum() EXACTLY: strip CR, sha256 the bytes, prefix "sha256:".
+const diskChecksum = (name) => {
+  const lf = readFileSync(join(handoff, name)).toString("latin1").replace(/\r/g, "");
+  return "sha256:" + createHash("sha256").update(Buffer.from(lf, "latin1")).digest("hex");
+};
+const staleManifestFiles = () => {
+  if (!existsSync(manifestPath)) return [];
+  const m = JSON.parse(readFileSync(manifestPath, "utf8"));
+  return Object.keys(m.files || {}).filter(
+    (name) =>
+      existsSync(join(handoff, name)) &&
+      m.files[name].checksum !== diskChecksum(name),
+  );
+};
+
 if (process.argv.includes("--check")) {
   const stale = targets.filter(([name, content]) => {
     const p = join(handoff, name);
@@ -169,11 +194,50 @@ if (process.argv.includes("--check")) {
     );
     process.exit(1);
   }
-  console.log("Handoff docs up to date: DASHBOARD.md, TRUST.md.");
+  const staleManifest = staleManifestFiles();
+  if (staleManifest.length > 0) {
+    console.error(
+      `\n  MANIFEST.json checksums are stale: ${staleManifest.join(", ")}.\n` +
+        `  The handoff docs are current but the checksum manifest was not\n` +
+        `  regenerated - this is the exact cause of "AAHP Verify" Layer 1\n` +
+        `  failing in CI after a version bump / release.\n` +
+        `  Fix: run \`npm run handoff:refresh\`, then re-commit.\n`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    "Handoff docs up to date: DASHBOARD.md, TRUST.md; MANIFEST.json checksums in sync.",
+  );
 } else {
   for (const [name, content] of targets) writeFileSync(join(handoff, name), content);
+  // Regenerate MANIFEST.json so its checksums match the docs we just wrote.
+  // Delegate to the canonical writer (keeps token budget / context / last
+  // session authoritative and re-checksums every tracked file, not only these
+  // two). Override the interpreter with AAHP_BASH if `bash` is not on PATH.
+  try {
+    execFileSync(
+      process.env.AAHP_BASH || "bash",
+      [
+        join(repoRoot, "scripts", "aahp-manifest.sh"),
+        repoRoot,
+        "--agent",
+        "handoff-refresh",
+        "--phase",
+        "idle",
+        "--quiet",
+      ],
+      { stdio: "inherit", cwd: repoRoot },
+    );
+  } catch (err) {
+    console.error(
+      `\n  DASHBOARD.md + TRUST.md were written, but MANIFEST.json regen failed:\n` +
+        `  ${err.message}\n` +
+        `  Run manually: bash scripts/aahp-manifest.sh . --quiet\n`,
+    );
+    process.exit(1);
+  }
   console.log(
-    `handoff:refresh OK - DASHBOARD.md + TRUST.md regenerated ` +
+    `handoff:refresh OK - DASHBOARD.md + TRUST.md + MANIFEST.json regenerated ` +
       `(modules=${modules.length}, testFiles=${testFiles.length}, types:[node]=${typesNode}).`,
   );
 }


### PR DESCRIPTION
## Symptom
"AAHP Verify" fails Layer 1 on many deploys, e.g. [run 29181951325](https://github.com/homeofe/supply-chain-guard/actions/runs/29181951325/job/86621162025) on the last commit:
```
[Layer 1] MANIFEST checksum integrity
  FAIL: MANIFEST.json checksums do not match file contents.
    ! Checksum mismatch: DASHBOARD.md
    ! Checksum mismatch: TRUST.md
```
(Layer 3 in that log is only a WARN, not the failure.)

## Root cause
`DASHBOARD.md` and `TRUST.md` embed the package version. Every release regenerates them via `handoff:refresh` (aahp-dashboard.mjs), but **nothing regenerated `MANIFEST.json`**, whose stored sha256 checksums then no longer match. And `prebuild` -> `check:handoff` only validated the doc *content*, not the manifest, so the desync first appeared in CI (the only place that checks it) - forcing a manual manifest-only commit each release.

## Fix (no re-release / no extra commit going forward)
- **handoff:refresh** now regenerates `MANIFEST.json` in the same step, delegating to the canonical `aahp-manifest.sh` (keeps token budget / context authoritative, re-checksums every tracked file).
- **check:handoff** (prebuild) now also verifies the manifest checksums against disk, replicating `aahp_checksum()` exactly (strip CR, then sha256) so it is CRLF-agnostic and offline - the desync now fails **locally**, at CI parity, instead of surfacing in CI.
- This PR also carries the corrected `MANIFEST.json`, so it lands `main` green.

## Verification
- `check:handoff` **fails** on the stale state (reproducing CI), **passes** after `handoff:refresh`.
- Regenerated checksums (`2626fd19…` / `7e1c1518…`) equal exactly the values CI reported as *Actual*.
- `lint-handoff.sh`: **zero** checksum mismatches. `check:changelog` / `check:version-sync` green. No version bump (published behavior unchanged).
- DASHBOARD.md / TRUST.md content unchanged (regenerated identically).

## Acceptance criteria
- [x] handoff:refresh regenerates MANIFEST.json in lockstep with the docs
- [x] prebuild (check:handoff) catches a stale manifest locally, CRLF-agnostic
- [x] Corrected manifest included so main lands green
- [x] No version bump; no doc content churn; portable (AAHP_BASH override documented in-code)