### PR TITLE
chore(aahp): sync canonical gate scripts from improvements

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,71 +2,71 @@
   "aahp_version": "3.0",
   "project": "scg",
   "last_session": {
-    "agent": "handoff-refresh",
-    "session_id": "cli-1783837833",
-    "timestamp": "2026-07-12T06:30:33Z",
-    "commit": "c4865d3",
-    "phase": "idle",
+    "agent": "claude-opus-4-8",
+    "session_id": "cli-1783874782",
+    "timestamp": "2026-07-12T16:46:22Z",
+    "commit": "8f9237e",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:bd5ca2db433e41073dfbb8d18b40427c448fe97d5241b7c0879c44a0f171a375",
-      "updated": "2026-07-12T06:30:33Z",
-      "lines": 500,
+      "checksum": "sha256:bde27716e0d39308335fb32d79df9113478ef77a16713324ad01c0d5d9f41bb2",
+      "updated": "2026-07-12T16:46:15Z",
+      "lines": 502,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:d449cbabd3fb9e0d5aa8eebd76fe3fb4d0acd49465add7ed0670f32ee944015f",
-      "updated": "2026-07-12T06:16:44Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 59,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:4857852ccff64736bd99820b8d4113477b27d81b06aa452e5298ae92318db88b",
-      "updated": "2026-07-12T06:16:44Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 129,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:5d6ecd3b44b6088e95f48ce30d7e3f62392eac197b6640473b6ead6f17c9cece",
-      "updated": "2026-07-12T06:16:44Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 8,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-12T06:16:44Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 4,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:2626fd19bdf29b91bc9247716a78d2b1782a4c07fb6ad295be48fc18c395b39f",
-      "updated": "2026-07-12T06:30:33Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 65,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:7e1c151814b16a7d3cf9e17726614ff87444a1b91f38466e5e844f466b305282",
-      "updated": "2026-07-12T06:30:33Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 35,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:5e7619ead3856a679ee035ef6cc06cd955218b291fbaa2601b7c474eb154aa46",
-      "updated": "2026-07-12T06:16:44Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 99,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:32c578aad3967b583ac152adcf022269f902146083b84545c0bee76bef2fcaa9",
-      "updated": "2026-07-12T06:16:44Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 130,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-12T06:16:44Z",
+      "updated": "2026-07-12T16:44:28Z",
       "lines": 4,
       "summary": "{"
     }
@@ -74,7 +74,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 7472,
-    "full_read": 11295
+    "manifest_plus_core": 7503,
+    "full_read": 11326
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,5 +1,7 @@
 # supply-chain-guard - Project Status
 
+> Note (2026-07-12, claude-opus-4-8): synced canonical AAHP gate scripts from homeofe/improvements (adds the realpath-relative PII validator invocation that fixes the Windows/MSYS artifact; AAHP_HANDOFF_FILES preserved).
+
 > Note (2026-07-12, claude-opus-4-8): Fixed the recurring "AAHP Verify" Layer 1 failure on deploy. handoff:refresh (aahp-dashboard.mjs) now regenerates MANIFEST.json in lockstep with DASHBOARD.md + TRUST.md via aahp-manifest.sh, and check:handoff (prebuild) now also verifies the manifest checksums (CR-stripped, matching aahp_checksum), so a version bump can no longer leave the manifest stale and surface only in CI.
 
 > Note (2026-07-11, claude-fable-5): Released v5.12.0 - issue #54 hardening, the

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -2,7 +2,17 @@
 # _aahp-lib.sh -Shared functions for AAHP tooling
 # Not intended to be run directly. Source this from other scripts.
 
-# Standard AAHP handoff files, in canonical order
+# Standard AAHP handoff files, in canonical order.
+#
+# PER-REPO CONFIG: this single line is the one legitimate point of variation
+# across consumer repos. It is the DEFAULT / superset used for a fresh install;
+# a consumer that tracks fewer files (e.g. no LOG-ARCHIVE.* or no
+# pii-allowlist.json) keeps its own narrower list. scripts/sync-gate-scripts.sh
+# treats exactly this line as per-repo-preserved: when it copies the canonical
+# gate scripts into a consumer it reads the consumer's existing
+# AAHP_HANDOFF_FILES=(...) line and substitutes it back in, so a sync never
+# overwrites a repo's tracked-file set. aahp-manifest.sh only indexes files that
+# actually exist, so listing a file a repo does not have is harmless.
 # shellcheck disable=SC2034
 AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md LOG-ARCHIVE.md LOG-ARCHIVE.index.json DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
 
@@ -50,6 +60,9 @@ aahp_line_count() {
 aahp_auto_summary() {
     local filepath="$1"
     local summary
+    # Strip CR so a CRLF working tree (Windows) yields the same summary as an
+    # LF checkout (Linux CI). The summary is written to the non-checksummed
+    # "summary" field, so this is a cosmetic robustness fix, not a gate change.
     summary=$(head -5 "$filepath" \
         | tr -d '\r' \
         | grep -v '^#' | grep -v '^>' | grep -v '^---' | grep -v '^$' \

--- a/scripts/aahp-manifest.sh
+++ b/scripts/aahp-manifest.sh
@@ -76,7 +76,18 @@ esac
 
 # ─── Detect project metadata ─────────────────────────────────
 
-PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+# Project name: PRESERVE the existing MANIFEST.json "project" value on
+# regeneration; only derive it from the directory basename on first-ever
+# generation. Without this, regenerating inside a differently-named checkout
+# (e.g. the gate-sync bot's mktemp working copy, or any tarball/CI dir) would
+# overwrite a consumer's real project name with the temp-dir basename.
+PROJECT_NAME=""
+if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
+    PROJECT_NAME="$(aahp_manifest_field "$HANDOFF_DIR/MANIFEST.json" "project")"
+fi
+if [ -z "$PROJECT_NAME" ]; then
+    PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+fi
 COMMIT=$(cd "$PROJECT_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -145,17 +156,17 @@ if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
     # Extract tasks block and next_task_id if they exist
     if command -v node &>/dev/null; then
         EXISTING=$(node -e "
-            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
             if (m.tasks) process.stdout.write(JSON.stringify(m.tasks));
-        " 2>/dev/null || true)
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING" ]; then
             TASKS_JSON="$EXISTING"
         fi
         EXISTING_ID=$(node -e "
-            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
             if (m.next_task_id) process.stdout.write(String(m.next_task_id));
-        " 2>/dev/null || true)
-        if [ -n "$EXISTING_ID" ] && [[ "$EXISTING_ID" =~ ^[0-9]+$ ]]; then
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
+        if [ -n "$EXISTING_ID" ]; then
             NEXT_TASK_ID="$EXISTING_ID"
         fi
     fi
@@ -188,7 +199,7 @@ MANIFEST
 
     # Append v3 task fields if they exist
     if [ -n "$NEXT_TASK_ID" ]; then
-        echo "  ,\"next_task_id\": $NEXT_TASK_ID"
+        echo "  ,\"next_task_id\": \"$NEXT_TASK_ID\""
     fi
     if [ -n "$TASKS_JSON" ]; then
         echo "  ,\"tasks\": $TASKS_JSON"

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -37,6 +37,18 @@ PROJECT_ROOT="."
 HANDOFF_DIR=".ai/handoff"
 VIOLATIONS=0
 
+# Resolve validate-pii-allowlist.py as a path RELATIVE to the (post-cd) cwd, so
+# native-Windows python is handed a relative path rather than an absolute MSYS
+# one. An absolute /c/Users/... path intermittently fails MSYS->Windows argv
+# conversion and surfaces as a mangled "C:\c\Users\...: can't open file"
+# artifact (a false Check-3 failure). realpath --relative-to is coreutils
+# (present on git-bash and Linux CI); where it is unavailable (e.g. BSD realpath
+# on macOS) we keep the absolute path, which opens fine there.
+PII_VALIDATOR="$SCRIPT_DIR/validate-pii-allowlist.py"
+if PII_VALIDATOR_REL="$(realpath --relative-to="$PWD" "$SCRIPT_DIR/validate-pii-allowlist.py" 2>/dev/null)"; then
+    PII_VALIDATOR="$PII_VALIDATOR_REL"
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -136,7 +148,7 @@ if [ -f "$ALLOWLIST_FILE" ]; then
         VIOLATIONS=$((VIOLATIONS + 1))
     else
         ALLOWLIST_ERR="$(mktemp)"
-        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$SCRIPT_DIR/validate-pii-allowlist.py" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
+        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$PII_VALIDATOR" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
             echo -e "  ${GREEN}OK Valid PII allowlist.${NC}"
         else
             ALLOWLIST_MESSAGE="$ALLOWLIST_ENTRIES"
@@ -170,6 +182,14 @@ PY
     fi
 fi
 
+# Locale-robustness (T-027): use grep -E (POSIX ERE), never grep -P (PCRE). GNU
+# grep -P aborts under a non-UTF-8 locale ("supports only unibyte and UTF-8
+# locales") and the pipeline then finds nothing, a silent FALSE PASS that made
+# the gate non-deterministic by locale. LC_ALL=C.UTF-8 pins byte-for-byte
+# identical detection across Windows git-bash, the commit hook, and Linux CI.
+# Per-MATCH filtering (T-029): grep -o extracts each address, awk excludes per
+# ADDRESS (not per line), so an excluded token (noreply / example.com /
+# placeholder) elsewhere on the same line can no longer mask a real address.
 EMAIL_MATCHES=$(LC_ALL=C.UTF-8 grep -rHnoE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' "$HANDOFF_DIR"/*.md 2>/dev/null | awk -F: '{ addr=$NF; if (addr ~ /\.noreply\./ || addr ~ /^no-?reply@/ || index(addr,"example.com") || index(addr,"placeholder")) next; print }' || true)
 UNAPPROVED=""
 if [ -n "$EMAIL_MATCHES" ]; then


### PR DESCRIPTION
## What

Sync the canonical AAHP gate scripts from `homeofe/improvements` (main, the merged superset) into this consumer via `scripts/sync-gate-scripts.sh`. This closes the drift between the vendored gate copies here and the canonical source.

## Scripts changed

- `scripts/lint-handoff.sh` - resolve `validate-pii-allowlist.py` as a path **relative to the current directory** before invoking python. On Windows/git-bash an absolute MSYS path (`/c/Users/...`) intermittently fails MSYS to Windows argv conversion and surfaces as the mangled `can't open file` artifact in Check [3/6]. The realpath-relative invocation makes the PII validator call stable across git-bash, the commit hook, and Linux CI. Also adopts the locale-robust `grep -E` email scan.
- `scripts/aahp-manifest.sh` - preserve the existing `MANIFEST.json` project name on regeneration (only derive from the directory basename on first-ever generation), and pass the MANIFEST path via `node` argv instead of string-interpolating it.
- `scripts/_aahp-lib.sh` - document the per-repo `AAHP_HANDOFF_FILES` line and strip CR in the auto summary for CRLF working trees.

`scripts/verify-handoff.sh` was already byte-identical to canonical, so it is unchanged. `scripts/validate-pii-allowlist.py` was already present and identical to canonical (no copy needed).

## Windows PII path-fix

The headline fix in this sync is the realpath-relative PII validator invocation in `lint-handoff.sh`. It removes the `C:\...\validate-pii-allowlist.py: can't open file` false Check-3 artifact that appeared under native-Windows python.

## Config preserved

The consumer's own `AAHP_HANDOFF_FILES=(...)` line was preserved verbatim by the sync tool (this repo tracks `STATUS.md NEXT_ACTIONS.md LOG.md LOG-ARCHIVE.md LOG-ARCHIVE.index.json DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json`). The tracked-file set is unchanged.

## AAHP handoff

STATUS.md got a dated note and `MANIFEST.json` was regenerated in lockstep in the same commit. Gate verified green after the sync: `verify-handoff.sh . --level ci` passes (exit 0) and `lint-handoff.sh` reports 0 checksum mismatches. (The Layer 3 "manifest behind HEAD" line is the normal advisory warning that the manifest points at the parent of the commit carrying it; it is non-blocking.)

## Acceptance criteria

- [x] Canonical gate scripts synced (`_aahp-lib.sh`, `lint-handoff.sh`, `aahp-manifest.sh`; `verify-handoff.sh` already identical)
- [x] Per-repo `AAHP_HANDOFF_FILES` config preserved
- [x] Gate green (verify-handoff ci level exit 0, 0 checksum mismatches)
- [x] `scripts/validate-pii-allowlist.py` present (already vendored, identical to canonical)
