### PR TITLE
fix(gate): sync Layer 3 tolerance (WARN on non-ancestor pointer)

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,71 +2,71 @@
   "aahp_version": "3.0",
   "project": "supply-chain-guard",
   "last_session": {
-    "agent": "cli-tool",
-    "session_id": "cli-1783925440",
-    "timestamp": "2026-07-13T06:50:41Z",
-    "commit": "7455316",
-    "phase": "idle",
+    "agent": "claude-opus-4-8",
+    "session_id": "cli-1784010028",
+    "timestamp": "2026-07-14T06:20:29Z",
+    "commit": "c549b63",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:3385fdf651e4f8a2848119eac8ac7e98b003262808d1b5b7bf58241d5926f68d",
-      "updated": "2026-07-13T06:50:22Z",
-      "lines": 527,
+      "checksum": "sha256:c2fc6c9feb9346d40177ac4618f8adad460a0553b848c5c36895f30be727297f",
+      "updated": "2026-07-14T06:20:28Z",
+      "lines": 529,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:d449cbabd3fb9e0d5aa8eebd76fe3fb4d0acd49465add7ed0670f32ee944015f",
-      "updated": "2026-07-11T14:42:15Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 59,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:4857852ccff64736bd99820b8d4113477b27d81b06aa452e5298ae92318db88b",
-      "updated": "2026-07-01T17:19:57Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 129,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:5d6ecd3b44b6088e95f48ce30d7e3f62392eac197b6640473b6ead6f17c9cece",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 8,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 4,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:88ed7d20fbab4d206b2f2e135dd11c7e60d2f01beefa6b09d01a250b7f306ab9",
-      "updated": "2026-07-13T06:50:04Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 65,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:14188a27cdd441bc2983d77f38c4065d616d54121d156f4541917b2d8e65dd71",
-      "updated": "2026-07-13T06:50:04Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 35,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:5e7619ead3856a679ee035ef6cc06cd955218b291fbaa2601b7c474eb154aa46",
-      "updated": "2026-07-01T17:39:24Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 99,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:32c578aad3967b583ac152adcf022269f902146083b84545c0bee76bef2fcaa9",
-      "updated": "2026-07-01T17:39:34Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 130,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-07-14T06:20:27Z",
       "lines": 4,
       "summary": "{"
     }
@@ -74,7 +74,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 7850,
-    "full_read": 11673
+    "manifest_plus_core": 7906,
+    "full_read": 11729
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,5 @@
+> Note (2026-07-14, claude-opus-4-8): Synced the canonical Layer 3 tolerance fix from homeofe/improvements. verify-handoff.sh now downgrades a non-ancestor MANIFEST.last_session.commit from FAIL to WARN so a squash-merge or rebase-merge no longer trips AAHP Verify Layer 3 on main; Layers 1-2 still gate real staleness.
+
 # supply-chain-guard - Project Status
 
 > Note (2026-07-13, claude-opus-4-8): Released v5.12.2 - daily threat-intel refresh

--- a/scripts/verify-handoff.sh
+++ b/scripts/verify-handoff.sh
@@ -240,8 +240,7 @@ if [ "$LEVEL" != "precommit" ]; then
             # Layer 2 already enforced that. Here we just inform.
             log_warn "MANIFEST commit ($MANIFEST_COMMIT) is behind HEAD ($HEAD_SHORT). Run /handoff if code changed."
         else
-            log_fail "MANIFEST commit ($MANIFEST_COMMIT) is not an ancestor of HEAD ($HEAD_SHORT). Stale manifest. Run /handoff."
-            FAILURES=$((FAILURES + 1))
+            log_warn "MANIFEST commit ($MANIFEST_COMMIT) is not an ancestor of HEAD ($HEAD_SHORT). A squash-merge or rebase-merge orphans the branch-local pointer; Layers 1-2 gate real staleness. Run /handoff if code changed."
         fi
     fi
 fi


### PR DESCRIPTION
Syncs the canonical Layer 3 tolerance fix from [homeofe/improvements#12](https://github.com/homeofe/improvements/pull/12). `verify-handoff.sh` Layer 3 now downgrades a non-ancestor `MANIFEST.last_session.commit` from FAIL to WARN, so a squash-merge or rebase-merge no longer trips `AAHP Verify` on main. Layers 1-2 keep gating real staleness; the missing-MANIFEST hard-fail is unchanged. Manifest regenerated against the base commit. Verified locally: 0 checksum mismatches, bash -n clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>