### PR TITLE
chore(aahp): sync canonical gate scripts and hook tooling from improvements

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,70 +3,70 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1784010028",
-    "timestamp": "2026-07-14T06:20:29Z",
-    "commit": "c549b63",
-    "phase": "implementation",
+    "session_id": "cli-1784032744",
+    "timestamp": "2026-07-14T12:39:04Z",
+    "commit": "d4a3eb8",
+    "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:c2fc6c9feb9346d40177ac4618f8adad460a0553b848c5c36895f30be727297f",
-      "updated": "2026-07-14T06:20:28Z",
-      "lines": 529,
+      "checksum": "sha256:735d3bf8dc0e5fcaa9eb2ee71cff90a28c047e0626caf1060230aa7754257f62",
+      "updated": "2026-07-14T12:32:46Z",
+      "lines": 531,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:d449cbabd3fb9e0d5aa8eebd76fe3fb4d0acd49465add7ed0670f32ee944015f",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 59,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:4857852ccff64736bd99820b8d4113477b27d81b06aa452e5298ae92318db88b",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 129,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:5d6ecd3b44b6088e95f48ce30d7e3f62392eac197b6640473b6ead6f17c9cece",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 8,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 4,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:88ed7d20fbab4d206b2f2e135dd11c7e60d2f01beefa6b09d01a250b7f306ab9",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 65,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:14188a27cdd441bc2983d77f38c4065d616d54121d156f4541917b2d8e65dd71",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 35,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:5e7619ead3856a679ee035ef6cc06cd955218b291fbaa2601b7c474eb154aa46",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 99,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:32c578aad3967b583ac152adcf022269f902146083b84545c0bee76bef2fcaa9",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 130,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-14T06:20:27Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 4,
       "summary": "{"
     }
@@ -74,7 +74,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 7906,
-    "full_read": 11729
+    "manifest_plus_core": 7951,
+    "full_read": 11774
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,5 @@
+> Note (2026-07-14, claude-opus-4-8): Synced the canonical AAHP gate scripts from homeofe/improvements (v3.5.0 fixes: aahp-manifest.sh --phase documentation + cross_repo_ref preservation, lint-handoff.sh SC2034), AAHP_HANDOFF_FILES preserved, and refreshed the local hook tooling (scripts/hooks/, install-hooks.sh, verify-hooks.sh). Fleet re-sync.
+
 > Note (2026-07-14, claude-opus-4-8): Synced the canonical Layer 3 tolerance fix from homeofe/improvements. verify-handoff.sh now downgrades a non-ancestor MANIFEST.last_session.commit from FAIL to WARN so a squash-merge or rebase-merge no longer trips AAHP Verify Layer 3 on main; Layers 1-2 still gate real staleness.
 
 # supply-chain-guard - Project Status

--- a/scripts/aahp-manifest.sh
+++ b/scripts/aahp-manifest.sh
@@ -7,7 +7,7 @@
 # Options:
 #   --agent NAME       Agent identifier (default: "cli-tool")
 #   --session-id ID    Session identifier (default: auto-generated)
-#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle (default: "idle")
+#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle|documentation (default: "idle")
 #   --context "TEXT"    Quick context string (default: auto-generated from file summaries)
 #   --duration MIN     Session duration in minutes (default: 0)
 #   --quiet            Suppress output except errors
@@ -67,9 +67,9 @@ fi
 
 # Validate phase
 case "$PHASE" in
-    research|architecture|implementation|review|fix|idle) ;;
+    research|architecture|implementation|review|fix|idle|documentation) ;;
     *)
-        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle" >&2
+        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle, documentation" >&2
         exit 1
         ;;
 esac
@@ -151,6 +151,7 @@ FULL_TOKENS=$((MANIFEST_TOKENS + TOTAL_TOKENS))
 
 TASKS_JSON=""
 NEXT_TASK_ID=""
+CROSS_REPO_REF=""
 
 if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
     # Extract tasks block and next_task_id if they exist
@@ -168,6 +169,15 @@ if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
         " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING_ID" ]; then
             NEXT_TASK_ID="$EXISTING_ID"
+        fi
+        # Preserve the optional cross_repo_ref field (v3.4+), like tasks it is
+        # agent-managed and must survive regeneration.
+        EXISTING_CRR=$(node -e "
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+            if (m.cross_repo_ref) process.stdout.write(JSON.stringify(m.cross_repo_ref));
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
+        if [ -n "$EXISTING_CRR" ]; then
+            CROSS_REPO_REF="$EXISTING_CRR"
         fi
     fi
 fi
@@ -203,6 +213,9 @@ MANIFEST
     fi
     if [ -n "$TASKS_JSON" ]; then
         echo "  ,\"tasks\": $TASKS_JSON"
+    fi
+    if [ -n "$CROSS_REPO_REF" ]; then
+        echo "  ,\"cross_repo_ref\": $CROSS_REPO_REF"
     fi
 
     echo "}"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# AAHP pre-commit hook - fast handoff gate.
+#
+# Runs: aahp verify --level precommit
+#   Layer 1: MANIFEST checksum integrity
+#   Layer 2: content-drift gate (code changed => STATUS.md + MANIFEST.json must change)
+#
+# This is intentionally fast (no TTL parse, no network). The full gate runs in
+# pre-push and in CI.
+#
+# Escape hatch: AAHP_SKIP_VERIFY=1 git commit ...   (caught by the required CI
+# check; do NOT use it to bypass CI). Never use `git commit --no-verify`.
+#
+# Installed by: scripts/install-hooks.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+VERIFY="$REPO_ROOT/scripts/verify-handoff.sh"
+
+if [ ! -x "$VERIFY" ] && [ ! -f "$VERIFY" ]; then
+    echo "AAHP pre-commit: scripts/verify-handoff.sh not found, skipping gate." >&2
+    exit 0
+fi
+
+bash "$VERIFY" "$REPO_ROOT" --level precommit

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# AAHP pre-push hook - full handoff gate.
+#
+# Runs: aahp verify --level prepush
+#   Layer 1: MANIFEST checksum integrity
+#   Layer 2: content-drift gate
+#   Layer 3: commit-pointer freshness (MANIFEST.last_session.commit vs HEAD)
+#   Layer 4: TRUST-TTL expiry (advisory)
+#
+# Escape hatch: AAHP_SKIP_VERIFY=1 git push ...   (caught by the required CI
+# check; do NOT use it to bypass CI). Never use `git push --no-verify`.
+#
+# Installed by: scripts/install-hooks.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+VERIFY="$REPO_ROOT/scripts/verify-handoff.sh"
+
+if [ ! -f "$VERIFY" ]; then
+    echo "AAHP pre-push: scripts/verify-handoff.sh not found, skipping gate." >&2
+    exit 0
+fi
+
+bash "$VERIFY" "$REPO_ROOT" --level prepush

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# install-hooks.sh - Install the AAHP git hooks (pre-commit + pre-push) into a
+# target repository so the canonical "aahp verify" gate runs locally.
+#
+# Usage: ./scripts/install-hooks.sh [path-to-target-repo]
+#        Defaults to the repo this script lives in.
+#
+# What it does:
+#   - Copies scripts/hooks/pre-commit and scripts/hooks/pre-push into the
+#     target repo's .git/hooks/ (respecting core.hooksPath if set).
+#   - Makes them executable.
+#   - Does NOT overwrite a non-AAHP hook without backing it up first.
+#
+# The hooks call <target>/scripts/verify-handoff.sh, so the target repo must
+# also have scripts/verify-handoff.sh + scripts/_aahp-lib.sh + lint-handoff.sh
+# (copied as part of AAHP propagation).
+#
+# Exit codes:
+#   0 = hooks installed
+#   1 = error (not a git repo, source hooks missing, etc.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_HOOKS="$SCRIPT_DIR/hooks"
+
+TARGET="${1:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+if [ ! -d "$SRC_HOOKS" ]; then
+    echo "Error: source hooks dir not found: $SRC_HOOKS" >&2
+    exit 1
+fi
+
+if ! git -C "$TARGET" rev-parse --git-dir &>/dev/null 2>&1; then
+    echo "Error: $TARGET is not a git repository." >&2
+    exit 1
+fi
+
+# Respect core.hooksPath if configured, else use .git/hooks.
+HOOKS_DIR=$(git -C "$TARGET" config --get core.hooksPath 2>/dev/null || true)
+if [ -n "$HOOKS_DIR" ]; then
+    # core.hooksPath may be relative to the repo root.
+    case "$HOOKS_DIR" in
+        /*) : ;;
+        *) HOOKS_DIR="$TARGET/$HOOKS_DIR" ;;
+    esac
+else
+    GIT_DIR=$(git -C "$TARGET" rev-parse --git-dir)
+    case "$GIT_DIR" in
+        /*) : ;;
+        *) GIT_DIR="$TARGET/$GIT_DIR" ;;
+    esac
+    HOOKS_DIR="$GIT_DIR/hooks"
+fi
+
+mkdir -p "$HOOKS_DIR"
+
+install_one() {
+    local name="$1"
+    local src="$SRC_HOOKS/$name"
+    local dest="$HOOKS_DIR/$name"
+
+    if [ ! -f "$src" ]; then
+        echo "  skip: $name (source missing)" >&2
+        return 0
+    fi
+
+    # If an existing hook is present and is NOT an AAHP hook, back it up.
+    if [ -f "$dest" ] && ! grep -q "AAHP pre-" "$dest" 2>/dev/null; then
+        cp "$dest" "$dest.pre-aahp.bak"
+        echo "  note: backed up existing $name to $name.pre-aahp.bak"
+    fi
+
+    cp "$src" "$dest"
+    chmod +x "$dest"
+    echo "  installed: $name"
+}
+
+echo "Installing AAHP hooks into: $HOOKS_DIR"
+install_one "pre-commit"
+install_one "pre-push"
+echo "Done. The 'aahp verify' gate now runs on commit (fast) and push (full)."
+echo "Escape hatch: AAHP_SKIP_VERIFY=1 (caught by the required CI check; do NOT use to bypass CI)."

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -196,7 +196,7 @@ if [ -n "$EMAIL_MATCHES" ]; then
     while IFS= read -r match; do
         address="${match##*:}"
         allowed=0
-        while IFS=$'\t' read -r value owner expires reason; do
+        while IFS=$'\t' read -r value owner expires _; do
             [ -z "$value" ] && continue
             if [ "$address" = "$value" ]; then
                 echo -e "  ${GREEN}OK Allowed PII email '$address' via pii-allowlist.json (owner: $owner, expires: $expires).${NC}"

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# verify-hooks.sh - Read-only verification of local AAHP git-hook coverage.
+#
+# Given a target repository checkout, this classifies each REQUIRED local hook
+# (from the coverage registry in docs/hook-coverage.md) as one of:
+#   INSTALLED - hook present and byte-identical to the canonical scripts/hooks/ source
+#   DRIFTED   - hook present but its content differs from canonical
+#   EXEMPT    - hook declared exempt for this repo in the registry
+#   UNKNOWN   - required hook not installed, or the repo has no registry contract
+#
+# It MODIFIES NOTHING: it never installs, copies, backs up, or edits a hook. To
+# install or repair hooks, use scripts/install-hooks.sh instead.
+#
+# Usage:
+#   verify-hooks.sh [target-repo-path] [--repo owner/name] [--registry FILE] [--quiet]
+#
+# Options:
+#   --repo owner/name   Registry key to look up. Default: derived from the
+#                       target's origin remote, falling back to the dir basename.
+#   --registry FILE     Coverage registry to read. Default: docs/hook-coverage.md
+#                       next to this script.
+#   --quiet             Suppress the banner and info lines; keep the per-hook
+#                       report and the RESULT line.
+#   --help, -h          Show this help.
+#
+# Exit codes:
+#   0 = every required hook is INSTALLED or EXEMPT
+#   1 = at least one required hook is DRIFTED or UNKNOWN (coverage gap)
+#   2 = usage error (bad option, not a git repo, registry missing)
+#
+# The drift comparison uses aahp_checksum (SHA-256, CR-stripped) so a hook
+# checksums identically on a CRLF (Windows) or LF (Linux) working tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aahp-lib.sh
+source "$SCRIPT_DIR/_aahp-lib.sh"
+
+CANON_HOOKS="$SCRIPT_DIR/hooks"
+DEFAULT_REGISTRY="$SCRIPT_DIR/../docs/hook-coverage.md"
+REGISTRY_BEGIN="<!-- BEGIN hook-coverage-registry -->"
+REGISTRY_END="<!-- END hook-coverage-registry -->"
+
+TARGET=""
+REPO_SLUG=""
+REGISTRY=""
+QUIET=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)     REPO_SLUG="$2"; shift 2 ;;
+        --registry) REGISTRY="$2"; shift 2 ;;
+        --quiet)    QUIET=true; shift ;;
+        --help|-h)
+            sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown option: $1" >&2
+            echo "Usage: verify-hooks.sh [target-repo-path] [--repo owner/name] [--registry FILE] [--quiet]" >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$TARGET" ]; then
+                TARGET="$1"; shift
+            else
+                echo "Unexpected argument: $1" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+TARGET="${TARGET:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+REGISTRY="${REGISTRY:-$DEFAULT_REGISTRY}"
+
+info() { [ "$QUIET" = true ] || echo "$@"; }
+
+# --- Validate inputs ---------------------------------------------------------
+if [ ! -f "$REGISTRY" ]; then
+    echo "Error: coverage registry not found: $REGISTRY" >&2
+    exit 2
+fi
+if ! git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Error: $TARGET is not a git repository." >&2
+    exit 2
+fi
+
+# --- Resolve the repo slug ---------------------------------------------------
+if [ -z "$REPO_SLUG" ]; then
+    ORIGIN_URL="$(git -C "$TARGET" remote get-url origin 2>/dev/null || true)"
+    if [ -n "$ORIGIN_URL" ]; then
+        REPO_SLUG="$(printf '%s' "$ORIGIN_URL" \
+            | sed -E 's#^[a-zA-Z]+://[^/]+/##; s#^git@[^:]+:##; s#^ssh://git@[^/]+/##; s#\.git$##')"
+    fi
+    if [ -z "$REPO_SLUG" ]; then
+        REPO_SLUG="$(basename "$(cd "$TARGET" && pwd)")"
+    fi
+fi
+
+# --- Look up the repo row in the registry ------------------------------------
+# Emit a TSV of every registry row, then select the one matching REPO_SLUG.
+ROW="$(awk -v b="$REGISTRY_BEGIN" -v e="$REGISTRY_END" '
+    index($0, b) { inblock = 1; next }
+    index($0, e) { inblock = 0 }
+    inblock && $0 ~ /^[[:space:]]*\|/ {
+        n = split($0, c, "|")
+        for (i = 1; i <= n; i++) { gsub(/^[ \t]+|[ \t]+$/, "", c[i]) }
+        repo = c[2]
+        if (repo == "" || tolower(repo) == "repo") next   # header / stray
+        if (repo ~ /^:?-+:?$/) next                        # separator row
+        printf "%s\t%s\t%s\t%s\t%s\n", repo, c[3], c[4], c[5], c[6]
+    }
+' "$REGISTRY" | awk -F'\t' -v r="$REPO_SLUG" '$1 == r { print; exit }')"
+
+info ""
+info "========================================="
+info "  AAHP hook coverage verify"
+info "========================================="
+info "  Target:   $TARGET"
+info "  Repo:     $REPO_SLUG"
+info "  Registry: $REGISTRY"
+
+if [ -z "$ROW" ]; then
+    echo "  UNKNOWN  repo '$REPO_SLUG' is not declared in the coverage registry."
+    echo "-----------------------------------------"
+    echo "  RESULT: FAIL - no coverage contract for '$REPO_SLUG' (1 unknown)."
+    exit 1
+fi
+
+IFS=$'\t' read -r R_REPO R_TYPE R_REQUIRED R_EXEMPT R_REASON <<< "$ROW"
+: "$R_REPO" "$R_REASON"   # referenced for clarity; not otherwise used
+info "  Type:     $R_TYPE"
+
+# --- Resolve the target's hooks directory (read-only) ------------------------
+HOOKS_DIR="$(git -C "$TARGET" config --get core.hooksPath 2>/dev/null || true)"
+if [ -n "$HOOKS_DIR" ]; then
+    case "$HOOKS_DIR" in
+        /*) : ;;
+        *)  HOOKS_DIR="$TARGET/$HOOKS_DIR" ;;
+    esac
+else
+    GIT_DIR="$(git -C "$TARGET" rev-parse --git-dir)"
+    case "$GIT_DIR" in
+        /*) : ;;
+        *)  GIT_DIR="$TARGET/$GIT_DIR" ;;
+    esac
+    HOOKS_DIR="$GIT_DIR/hooks"
+fi
+info "  Hooks:    $HOOKS_DIR"
+info ""
+
+# --- Build the required-hook list --------------------------------------------
+REQUIRED_LIST=()
+if [ "$R_REQUIRED" != "none" ] && [ "$R_REQUIRED" != "-" ] && [ -n "$R_REQUIRED" ]; then
+    IFS=',' read -r -a REQUIRED_LIST <<< "$R_REQUIRED"
+fi
+
+hook_is_exempt() {
+    local h="$1" x
+    case "$R_EXEMPT" in
+        ""|"-") return 1 ;;
+        "all")  return 0 ;;
+    esac
+    local ex=()
+    IFS=',' read -r -a ex <<< "$R_EXEMPT"
+    for x in "${ex[@]}"; do
+        [ "$(printf '%s' "$x" | tr -d ' ')" = "$h" ] && return 0
+    done
+    return 1
+}
+
+n_installed=0
+n_drifted=0
+n_exempt=0
+n_unknown=0
+
+if [ "${#REQUIRED_LIST[@]}" -eq 0 ]; then
+    echo "  EXEMPT     (no local hooks required for this repo)"
+    n_exempt=$((n_exempt + 1))
+else
+    for raw in "${REQUIRED_LIST[@]}"; do
+        hook="$(printf '%s' "$raw" | tr -d ' ')"
+        [ -z "$hook" ] && continue
+
+        if hook_is_exempt "$hook"; then
+            echo "  EXEMPT     $hook (declared exempt: $R_REASON)"
+            n_exempt=$((n_exempt + 1))
+            continue
+        fi
+
+        canon="$CANON_HOOKS/$hook"
+        if [ ! -f "$canon" ]; then
+            echo "  UNKNOWN    $hook (no canonical reference in scripts/hooks/)"
+            n_unknown=$((n_unknown + 1))
+            continue
+        fi
+
+        dest="$HOOKS_DIR/$hook"
+        if [ ! -f "$dest" ]; then
+            echo "  UNKNOWN    $hook (required hook not installed)"
+            n_unknown=$((n_unknown + 1))
+            continue
+        fi
+
+        if [ "$(aahp_checksum "$dest")" = "$(aahp_checksum "$canon")" ]; then
+            echo "  INSTALLED  $hook"
+            n_installed=$((n_installed + 1))
+        else
+            echo "  DRIFTED    $hook (content differs from canonical scripts/hooks/$hook)"
+            n_drifted=$((n_drifted + 1))
+        fi
+    done
+fi
+
+info "-----------------------------------------"
+FAIL=$((n_drifted + n_unknown))
+SUMMARY="installed=$n_installed drifted=$n_drifted exempt=$n_exempt unknown=$n_unknown"
+if [ "$FAIL" -gt 0 ]; then
+    echo "  RESULT: FAIL - $SUMMARY"
+    exit 1
+else
+    echo "  RESULT: PASS - $SUMMARY"
+    exit 0
+fi


### PR DESCRIPTION
Fleet re-sync of the v3.5.0 canonical AAHP gate-script fixes from homeofe/improvements, plus the local hook tooling (AC#6 of homeofe/improvements#8).

## What changed

- **scripts/aahp-manifest.sh**: accept `--phase documentation` and preserve the optional `cross_repo_ref` field across regeneration (v3.5.0 fixes).
- **scripts/lint-handoff.sh**: SC2034 fix (unused `read` variable renamed to `_`).
- **scripts/hooks/pre-commit**, **scripts/hooks/pre-push**, **scripts/install-hooks.sh**, **scripts/verify-hooks.sh**: refreshed local hook tooling (these were previously absent in this repo).

`scripts/verify-handoff.sh` and `scripts/_aahp-lib.sh` were already in sync (no content change).

## Preserved per-repo config

The consumer's own `AAHP_HANDOFF_FILES=(...)` line in `scripts/_aahp-lib.sh` was preserved by the canonical sync tool; only the shared gate-script logic was updated. The manifest was regenerated with this repo's own `scripts/aahp-manifest.sh` so its tracked task state is untouched.

## Gate

CI (`aahp-verify`) gates this change. Locally, `scripts/verify-handoff.sh . --level ci` passes all four layers (checksum integrity, content-drift, commit-pointer freshness, TRUST-TTL).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>