### PR TITLE
feat(threat-intel): import feed IOCs from upstream advisory databases

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -14,7 +14,7 @@
 | Version | 5.17.10 |
 | Node engines | >=20.0.0 |
 | Source modules | 64 under `src/` |
-| Test files | 82 under `src/__tests__/` |
+| Test files | 83 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit | verified continuously in CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1784965710",
-    "timestamp": "2026-07-25T07:48:30Z",
-    "commit": "d6be2ee",
+    "session_id": "cli-1784977157",
+    "timestamp": "2026-07-25T10:59:17Z",
+    "commit": "b03adc6",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:715a949052d14f71a7067ac32c6d81a503afcfee71785b92e97ebf766bf554ee",
-      "updated": "2026-07-25T07:48:30Z",
-      "lines": 1055,
+      "checksum": "sha256:d8802992ec8daacce64397b8f81273fded04b3b6399b1192738776afff5b10b7",
+      "updated": "2026-07-25T10:54:08Z",
+      "lines": 1091,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:46f93f5df485f76c6ad8b87ec95d2a03d34e83d0072165d87680e896b1d96a03",
-      "updated": "2026-07-25T07:48:30Z",
+      "updated": "2026-07-25T10:38:04Z",
       "lines": 62,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:7e876b3055ceecbfee972b32cf6aa603005d693a5446d84ae39db5b38351cebd",
-      "updated": "2026-07-25T07:48:30Z",
+      "updated": "2026-07-25T10:59:17Z",
       "lines": 114,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-07-25T07:47:28Z",
+      "updated": "2026-07-25T10:38:04Z",
       "lines": 132,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-07-25T07:47:28Z",
+      "updated": "2026-07-25T10:38:04Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:f696b76324b4917f07e0d69b96c1761a636a6051c74f94b643e188ade1e7b772",
-      "updated": "2026-07-25T07:48:30Z",
+      "checksum": "sha256:a71dee86b40d4dcc971f94b37e106a6ccc00ad358aace592f13b27b4c7d83c43",
+      "updated": "2026-07-25T10:59:17Z",
       "lines": 66,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
-      "checksum": "sha256:cce6dcc3bb3ab5eca06ba7c2d69c87271fcfc5d5d4ebda8446e2d4798ee6a0e1",
-      "updated": "2026-07-25T07:48:30Z",
+      "checksum": "sha256:6921f71fcee6f743566c2fa7673409025717049e598549101cfcc9a2a2129d3f",
+      "updated": "2026-07-25T10:59:17Z",
       "lines": 49,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:3260c91bb9b609eafcd1597268e233694f20c8e53c7fba439c4da1cea65aeedc",
-      "updated": "2026-07-25T07:47:28Z",
+      "updated": "2026-07-25T10:38:04Z",
       "lines": 108,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:94ceab2bc0623734e0c0f0a2b0140d2e1a07cac25d903c12282327c415ae94e7",
-      "updated": "2026-07-25T07:47:28Z",
+      "updated": "2026-07-25T10:38:04Z",
       "lines": 133,
       "summary": "(no summary available)"
     },
     "GROUNDING.md": {
       "checksum": "sha256:7ef8cece585dc5defb4285175b9ba560d5469675df553d4ce28ec9e7aec24343",
-      "updated": "2026-07-25T07:47:28Z",
+      "updated": "2026-07-25T10:38:04Z",
       "lines": 209,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-25T07:47:28Z",
+      "updated": "2026-07-25T10:38:04Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,7 +80,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 15807,
-    "full_read": 24145
+    "manifest_plus_core": 16364,
+    "full_read": 24702
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,39 @@
+> Note (2026-07-25, claude-opus-5): Cut the feed's dependency on the internal
+> security-news aggregator and wired real upstream sources instead. That
+> aggregator was 17 general security RSS feeds, none of them package-malware or
+> supply-chain specific, so every run needed a human to chase primary vendor
+> write-ups for atomic indicators; the app is also unmaintained (its repo was
+> deleted during the Forgejo migration). Replacement: scripts/import-threat-feed.mjs
+> imports malicious-package IOCs from the GitHub Advisory Database malware
+> advisories (public REST API, no key; GITHUB_TOKEN optional, rate limit only) and
+> corroborates each hit against OSV.dev querybatch (MAL- records from
+> ossf/malicious-packages). OSV is corroboration ONLY - it can lift confidence
+> 0.9 -> 1.0 but never discovers a package, so a MAL- record covering one version
+> of a legitimate package can never become a whole-package block. Discipline
+> carried over from the manual process: only an exact pin (= 1.2.3 -> name@1.2.3)
+> or an all-versions range (>= 0 -> bare name) is mapped, bounded ranges are
+> reported as unmappable instead of collapsed, ecosystems with no matcher are
+> skipped, family/campaign stay unset because upstream publishes neither, and
+> package names are re-validated against a charset with no quotes or backslashes
+> before being written into TypeScript. Provenance is the FeedIOC.source field
+> (0 of 430 existing entries used it); that also required adding "source" and
+> "lastSeen" to FEED_ENTRY_KEYS, otherwise our own feed.json stops passing
+> isInertThreatFeedFile() and gets scanned as ordinary content (the v5.4.0
+> phantom-findings bug). Failure mode is inert: the fetch is the only fatal step,
+> nothing is written until the batch re-parses in memory, and a rewrite that does
+> not re-parse is rolled back - a network error leaves src/threat-intel.ts and
+> feed.json byte-identical and exits non-zero. 42 offline tests
+> (src/__tests__/feed-import.test.ts) cover the mapping, dedup and that failure
+> mode with fixtures; no test touches the network. Docs in
+> docs/threat-feed-sources.md carry the required attribution (GitHub Advisory
+> Database CC BY 4.0, ossf/malicious-packages Apache-2.0). Historical arena
+> references to that host in CHANGELOG.md and this file were reworded to "news-aggregator
+> feed" so nothing points at a dead host. No IOCs were imported in this change -
+> it ships the mechanism only. NOT DONE HERE: the daily refresh still runs from a
+> local scheduled task on Emre's machine that fetches the retired aggregator URL; it
+> needs to be repointed at `npm run feed:import` (or replaced by a scheduled
+> workflow) or the dead source stays in the loop.
+
 > Note (2026-07-25): Released v5.17.10 - rule precision. Five rules that matched a
 > SHAPE without inspecting context or value are now context-aware, and one silently
 > dead config key is implemented. GHA_SECRET_EXFIL_MULTILINE is per-step instead of a
@@ -51,7 +87,7 @@
 > SECRETS_PRIVATE_KEY (PEM header only, fired on a MOCK-KEY-REPLACE-IN-PRODUCTION literal).
 >
 > Note (2026-07-25, claude-opus-4-8): Released v5.17.9 - daily threat-intel refresh
-> (scheduled task). arena.elvatis.com/api/news again carried mostly named campaigns with
+> (scheduled task). The news-aggregator feed again carried mostly named campaigns with
 > no atomic IOCs, so - per the task's STEP 1b - enriched from primary vendor write-ups.
 > Added ONE new campaign: FakeAgent / SectopRAT fake Claude Desktop malvertising (Huntress
 > + BleepingComputer + Help Net Security + cyberpress, 2026-07-21 to 07-22). Bing "Claude
@@ -76,7 +112,7 @@
 > vscode-scanner "zip" tests fail locally on Windows - known env gap, green in CI).
 >
 > Note (2026-07-24, claude-opus-4-8): Released v5.17.8 - daily threat-intel refresh
-> (scheduled task, run interactively). arena.elvatis.com/api/news carried only named
+> (scheduled task, run interactively). The news-aggregator feed carried only named
 > campaigns with no atomic IOCs this cycle, so - at the user's direction - widened the
 > net to the linked primary vendor write-ups (Socket, The Hacker News, OX, StepSecurity,
 > safedep, Rescana) and extracted concrete indicators for three developer-targeted
@@ -107,7 +143,7 @@
 > publish (npm via OIDC) and move the @v5 branch.
 
 > Note (2026-07-20, claude-opus-4-8): Released v5.17.6 - daily threat-intel refresh
-> (scheduled task). Fetched arena.elvatis.com/news (/api/news JSON feed gives excerpts +
+> (scheduled task). Fetched the news-aggregator feed (JSON gives excerpts +
 > per-item source links; pulled the linked The Hacker News article and cross-checked the
 > StepSecurity writeup for indicators) and added SleeperGem (StepSecurity + Aikido,
 > 2026-07-20). Three gem releases published to RubyGems.org on 2026-07-18/19 act as
@@ -165,7 +201,7 @@
 > --level full + aahp doctor both green (6/6 gates); check:handoff + check:aahp + check:feed
 > still pass. Build tooling only, no version bump.
 > Note (2026-07-19, claude-opus-4-8): Released v5.17.5 - daily threat-intel refresh
-> (scheduled task). Fetched arena.elvatis.com/news (/api/news JSON feed gives excerpts +
+> (scheduled task). Fetched the news-aggregator feed (JSON gives excerpts +
 > per-item source links; pulled the linked The Hacker News articles for indicators) and
 > added the NadMesh botnet (XLab, 2026-07-17). NadMesh is a Go-based botnet that scans for
 > exposed AI services (Ollama/vLLM/etc.) and CI/CD hosts, harvesting AWS keys and Kubernetes
@@ -503,7 +539,7 @@
 # supply-chain-guard - Project Status
 
 > Note (2026-07-16, claude-opus-4-8): Released v5.12.3 - daily threat-intel refresh
-> (scheduled task). Fetched arena.elvatis.com/news (/api/news JSON feed gives
+> (scheduled task). Fetched the news-aggregator feed (JSON gives
 > excerpts + per-item source links) and added the AsyncAPI npm supply-chain
 > compromise (2026-07-14). Five malicious versions across four @asyncapi packages
 > were published to npm during a ~4h window (07:10-11:18 UTC on 2026-07-14),
@@ -527,7 +563,7 @@
 > a `zip` binary - green in CI).
 
 > Note (2026-07-13, claude-opus-4-8): Released v5.12.2 - daily threat-intel refresh
-> (scheduled task). Fetched arena.elvatis.com/news (/api/news JSON feed gives
+> (scheduled task). Fetched the news-aggregator feed (JSON gives
 > excerpts + per-item source links; pulled the linked The Hacker News article and
 > cross-checked BleepingComputer / Socket / Aikido / crypto.news for the exact
 > indicators) and added the Injective Labs SDK npm compromise (2026-07-08 to 07-10).
@@ -734,7 +770,7 @@
 > 59 src modules.
 
 > Note (2026-07-04, claude-opus-4-8): Released v5.6.2 - daily threat-intel refresh
-> (scheduled task). Fetched arena.elvatis.com/news (JS-rendered; pulled the /api/news
+> (scheduled task). Fetched the news-aggregator feed (JS-rendered; pulled the
 > JSON feed + the two source THN articles for indicators) and added two new July 2026
 > developer-targeted campaigns, cross-checked against the existing blocklist first:
 > (1) Contagious Interview Rollup Polyfill (Lazarus/DPRK, JFrog via THN 2026-07-03) -

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -32,7 +32,7 @@ for the two-axis (status x provenance) model and the task-type anchor matrix.
 |----------|-------|------------|--------|
 | package.json version | 5.17.10 | tool_verified | package.json |
 | Source modules present | 64 | tool_verified | src/ file list |
-| Test files present | 82 | tool_verified | src/__tests__/ file list |
+| Test files present | 83 | tool_verified | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tool_verified | tsconfig.json (load-bearing under TS6) |
 | Runtime dependency | commander ^14.0.3 | tool_verified | package.json (CommonJS line; 15+ is ESM-only) |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Added
+
+- **Upstream threat-feed import (`npm run feed:import`).** Malicious-package
+  IOCs are now imported from public advisory databases instead of being read
+  out of a general security-news aggregator by hand. Primary source: the
+  [GitHub Advisory Database](https://github.com/advisories?query=type%3Amalware)
+  malware advisories (CWE-506), fetched over the public REST API with no
+  account and no API key; `GITHUB_TOKEN` is strictly optional and only raises
+  the rate limit from 60 to 5000 requests/hour. Secondary source:
+  [OSV.dev](https://osv.dev/) `querybatch`, used only to corroborate a package
+  GitHub already flagged (a `MAL-` record from `ossf/malicious-packages`) - it
+  can raise confidence from 0.9 to 1.0 but can never discover a package on its
+  own, and an OSV outage degrades gracefully instead of failing the run.
+- **Per-entry provenance.** Imported entries populate the previously unused
+  `FeedIOC.source` field with the advisory id they came from (`GHSA-...`, plus
+  `MAL-...` when corroborated), so every machine-added indicator is traceable
+  to a public advisory page. `source` and `lastSeen` were also added to the
+  inert-feed key allowlist in `isInertThreatFeedFile()`; without that, the
+  project's own `feed.json` would stop being recognised as its own data and
+  would be scanned as ordinary content.
+- **`docs/threat-feed-sources.md`** documents the sources, their licences and
+  attribution (GitHub Advisory Database CC BY 4.0; `ossf/malicious-packages`
+  Apache-2.0), the full upstream-to-`FeedIOC` field mapping including the
+  fields that deliberately stay unset (`family`, `campaign`, `lastSeen`) and
+  the two project constants that upstream does not publish (confidence 0.9
+  single-source / 1.0 corroborated), the ecosystem prefix table, the
+  version-range rules, and the failure mode.
+- `pypi:` is now a recognised OSV export ecosystem, so PyPI package IOCs are
+  no longer dropped from `supply-chain-guard feed osv`.
+
+### Changed
+
+- The import refuses to invent indicators. Only an exact upstream pin
+  (`= 1.2.3` -> `name@1.2.3`) or an all-versions range (`>= 0` -> bare name) is
+  mapped; a bounded range is reported as unmappable rather than collapsed into
+  a whole-package block that would cover versions upstream never called
+  malicious. Ecosystems with no matcher in this scanner are reported, not
+  imported. Package names are re-validated against a charset narrower than the
+  feed's own package shape before being serialized into TypeScript.
+- A failed import is inert: the upstream fetch is the only fatal step, nothing
+  is written until the batch has been fetched, mapped, deduplicated and
+  re-parsed in memory, and a rewrite that does not re-parse to the expected
+  entry count is rolled back. A network error leaves `src/threat-intel.ts` and
+  `feed.json` byte-identical and exits non-zero.
+
 ## [5.17.10] - 2026-07-25
 
 **Rule precision: five rules narrowed with context, none weakened**
@@ -459,7 +504,7 @@ verification. Both were confirmed genuinely new against the existing feed.
   malicious CID path is matched, never the `ipfs[.]io` gateway host, so
   legitimate IPFS usage is not flagged.
 - New "AsyncAPI npm compromise (July 2026)" campaign test block.
-- Source excerpts came from the arena.elvatis.com feed; the exact package
+- Source excerpts came from the daily news-aggregator feed; the exact package
   versions were confirmed against two independent primary reports before being
   added.
 
@@ -481,7 +526,7 @@ verification. Both were confirmed genuinely new against the existing feed.
   never a broad `injective[.]network` block, so legitimate SDK endpoints are
   not flagged) and the two SHA-256 hashes of the infostealer files to
   `ioc-blocklist.ts` and `BUNDLED_FEED`, plus a campaign test block.
-- Source excerpts came from the arena.elvatis.com feed; the exact indicators
+- Source excerpts came from the daily news-aggregator feed; the exact indicators
   were confirmed against the linked primary reports before being added.
 
 ## [5.12.1] - 2026-07-12
@@ -489,7 +534,7 @@ verification. Both were confirmed genuinely new against the existing feed.
 
 - Added a bundled-feed IOC for the compromised `jscrambler@8.14.0` npm release,
   which shipped a malicious preinstall hook that drops a Rust-based infostealer
-  during install (arena.elvatis.com feed, 2026-07-11). Version-pinned only:
+  during install (daily news-aggregator feed, 2026-07-11). Version-pinned only:
   `jscrambler` is a legitimate package, so the bare name is intentionally NOT
   blocked - only the exact compromised version matches.
 

--- a/README.md
+++ b/README.md
@@ -493,6 +493,32 @@ validate each entry against its type's shape and quarantine anything invalid -
 a malformed or hostile feed entry can neither crash a scan nor flood it with
 garbage matches, and a rejected refresh never overwrites the previous cache.
 
+### Where the feed comes from
+
+Curated entries are hand-added from vendor write-ups. Malicious-package entries
+are additionally imported from two public upstream databases, with no account
+and no API key:
+
+- **[GitHub Advisory Database](https://github.com/advisories?query=type%3Amalware)** - malware
+  advisories (CWE-506), the primary source. Licensed
+  [CC BY 4.0](https://github.com/github/advisory-database); every imported entry
+  carries its `GHSA-...` id in its `source` field.
+- **[OSV.dev](https://osv.dev/)** - corroboration only, never discovery. A package
+  that OSV also lists as malicious (a `MAL-` record from
+  [ossf/malicious-packages](https://github.com/ossf/malicious-packages),
+  Apache-2.0) is imported at confidence 1.0 instead of 0.9.
+
+```bash
+npm run feed:import -- --dry-run   # what the next refresh would add
+npm run feed:import                # import, then regenerate feed.json
+```
+
+Every imported entry is auditable: the `source` field names the public advisory
+it came from. A failed import writes nothing at all - the previous feed stays in
+effect and the process exits non-zero. The full mapping (ecosystem prefixes,
+version-range rules, which upstream fields deliberately stay unset) is in
+[docs/threat-feed-sources.md](docs/threat-feed-sources.md).
+
 ## Install Guard
 
 Block known-bad packages BEFORE the package manager runs their lifecycle scripts -

--- a/docs/threat-feed-sources.md
+++ b/docs/threat-feed-sources.md
@@ -1,0 +1,172 @@
+# Threat feed sources
+
+Where the bundled IOC feed comes from, how upstream records are mapped onto the
+feed's own entry schema, and what the import deliberately refuses to do.
+
+The feed has two kinds of entries:
+
+| Kind | How it gets in | Provenance |
+| --- | --- | --- |
+| Curated | A maintainer reads a vendor write-up and hand-adds the atomic indicators (package, domain, IP, hash, URL) | Recorded in the `CHANGELOG.md` entry for the release that shipped it |
+| Imported | `npm run feed:import` pulls malicious-package records from upstream advisory databases | Recorded per entry in the `source` field |
+
+Both land in the same place: the `BUNDLED_FEED` array in `src/threat-intel.ts`,
+which is the single source of truth. `npm run feed:generate` republishes it as
+`feed.json`, and `npm run check:feed` fails the build if the two ever drift.
+
+## Upstream sources
+
+### 1. GitHub Advisory Database (primary)
+
+`GET https://api.github.com/advisories?type=malware`
+
+Malware advisories only (CWE-506, "Embedded Malicious Code"), reviewed by
+GitHub's security team. These are the records that say "this published package
+is malware", which is exactly the indicator class this scanner blocks.
+
+- **No account and no API key required.** `GITHUB_TOKEN` / `GH_TOKEN` is read
+  from the environment if present and only raises the REST rate limit from 60
+  to 5000 requests/hour. Without a token the import still works; if the
+  unauthenticated limit is exhausted the run fails with a message that says so.
+- **Licence: CC BY 4.0** (`github/advisory-database`). Attribution is required
+  and travels with the data: every imported entry carries its `GHSA-...` id in
+  the `source` field, and this page names the database.
+
+### 2. OSV.dev (corroboration only)
+
+`POST https://api.osv.dev/v1/querybatch`
+
+One batched query per import run asks whether OSV also lists a package as
+malicious, i.e. whether it has a `MAL-` record (those originate from
+`ossf/malicious-packages`, Apache-2.0). This is **never** used for discovery:
+OSV can only raise the confidence of a package GitHub already flagged, so a
+`MAL-` record that applies to one version of an otherwise legitimate package
+can never turn into a whole-package block here.
+
+- A package listed by both databases gets `confidence: 1.0` and a `source` of
+  `GHSA-..., MAL-...`.
+- A package listed only by GitHub gets `confidence: 0.9`.
+- If OSV is unreachable the import continues at 0.9 and says so in the report.
+  Corroboration is an enrichment, not a gate.
+
+The relationship is symmetric with the export side: `supply-chain-guard feed osv`
+already emits the feed's package IOCs as OSV-schema records.
+
+## Mapping
+
+Upstream advisory to `FeedIOC`:
+
+| FeedIOC field | Source | Notes |
+| --- | --- | --- |
+| `type` | always `"package"` | Advisory databases describe packages; domain/IP/hash/URL indicators stay a curated-only concern |
+| `value` | `vulnerabilities[].package` + `vulnerable_version_range` | See the version rules below |
+| `severity` | advisory `severity` | `critical` -> `critical`, `high` -> `high`, `moderate`/`medium`/`low`/`unknown` -> `medium`. The feed schema has only three levels, so nothing is ever promoted above what upstream claimed |
+| `confidence` | **not published upstream** | Project constant: 0.9 single-source, 1.0 corroborated by OSV. Documented here rather than invented per entry |
+| `source` | `ghsa_id` (plus the OSV `MAL-` id when corroborated) | The provenance record; makes every imported entry traceable back to a public advisory page |
+| `firstSeen` | advisory `published_at`, date part only | |
+| `family` | **not published upstream** | Left unset. GitHub malware advisories name no malware family, and guessing one would put fiction in the feed |
+| `campaign` | **not published upstream** | Left unset, same reason |
+| `lastSeen` | **not populated** | Upstream `updated_at` is a record-edit timestamp, not a sighting |
+
+### Ecosystem prefixes
+
+Only ecosystems the scanner can actually resolve are imported. An entry for an
+ecosystem with no matcher would be data no scan could ever use.
+
+| Upstream ecosystem | Feed value prefix | Resolved by |
+| --- | --- | --- |
+| `npm` | *(none, bare name)* | `matchBareNpmIOC`, `checkMaliciousDependencyNames` |
+| `pip` | `pypi:` | `python-lockfile-scanner` (poetry.lock, uv.lock, Pipfile.lock) |
+| `composer` | `composer:` | `composer-scanner` |
+| `go` | `go:` | `go-scanner` |
+| `rubygems` | `ruby:` | `rubygems-scanner` |
+| `rust` | `cargo:` | `cargo-scanner` |
+| `nuget` | `nuget:` | `nuget-scanner` |
+
+Everything else (Maven, GitHub Actions, Pub, Swift, Hex, `other`) is counted in
+the run report under `unsupported-ecosystem` and skipped.
+
+### Version ranges
+
+Only two upstream shapes are mapped, and the reason is false positives:
+
+| Upstream range | Feed value | Meaning |
+| --- | --- | --- |
+| `= 1.2.3` | `name@1.2.3` | Exactly that version is malicious |
+| `>= 0`, `> 0`, `>= 0.0.0` | `name` | The whole package is malicious at every version |
+| anything else (`>= 1.0.0, <= 1.2.0`, `< 2.0.0`, empty) | *skipped* | Reported as `unmappable-version-range` |
+
+A bounded range is **not** collapsed into a bare name. Doing so would block
+versions upstream never called malicious, which is the exact over-blocking the
+curated feed avoids by hand for hijacked-but-legitimate packages.
+
+### Safety of the mapping itself
+
+Package names come from a public database that anyone can file into, and the
+importer writes them into a TypeScript source file. Names are therefore
+re-validated against a charset narrower than the feed's own package shape (no
+quotes, no backslashes, no whitespace, no control characters) before they are
+serialized, and anything that fails is reported as `unsafe-package-name` rather
+than written. Values are additionally serialized with `JSON.stringify`, and the
+rewritten file is re-parsed and entry-counted before `feed.json` is regenerated.
+
+## Running an import
+
+```bash
+npm run feed:import -- --dry-run          # report only, writes nothing
+npm run feed:import                       # last 7 days, max 250 new entries
+npm run feed:import -- --days 30 --limit 500
+npm run feed:import -- --json             # machine-readable report
+```
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `--days <n>` | 7 | Look-back window |
+| `--since <YYYY-MM-DD>` | - | Explicit start date, overrides `--days` |
+| `--until <YYYY-MM-DD>` | - | Explicit end date |
+| `--limit <n>` | 250 | Maximum new entries added in one run |
+| `--max-pages <n>` | 10 | Hard cap on upstream pages fetched |
+| `--timeout <ms>` | 15000 | Per-request timeout |
+| `--no-osv` | off | Skip the OSV corroboration query |
+| `--dry-run` | off | Report only |
+| `--json` | off | Machine-readable report |
+
+Network calls are bounded three ways: an explicit per-request timeout on every
+request, a page cap, and the fixed 100-item page size. A daily run with the
+defaults makes at most 11 requests.
+
+### Failure mode
+
+The upstream fetch is the only fatal step, and nothing is written until the
+whole batch has been fetched, mapped, deduplicated and validated in memory:
+
+- Network error, timeout, non-200, or a body that is not an advisory array:
+  the process prints one line to stderr and exits **non-zero**.
+  `src/threat-intel.ts` and `feed.json` are left **byte-identical**.
+- If the rewritten source does not re-parse to the expected entry count, the
+  source file is rolled back and `feed.json` is never regenerated.
+- Nothing new to add is not a failure: the run exits 0 having written nothing.
+
+A failed import therefore never empties, truncates or corrupts the published
+feed - the previous feed stays in effect, exactly like a failed
+`supply-chain-guard feed refresh` leaves the previous cache in place.
+
+## Deduplication
+
+Imported entries are checked against the feed that is already committed:
+
+1. **Exact duplicate** - same `type:value` (the same key `mergeFeeds` uses at
+   scan time).
+2. **Already covered** - a bare-name IOC for the same ecosystem and package
+   already fires on every version, so a version-pinned import adds nothing.
+
+Deduplication is ecosystem-aware: `pypi:foo` and the bare npm `foo` are
+different packages and are never conflated. Duplicates inside a single incoming
+batch are collapsed too.
+
+## Reviewing an import
+
+An import is a proposal, not a release. Read the diff before committing: the
+entries are appended to `BUNDLED_FEED` under a dated comment, and every one of
+them names the advisory it came from, so each line can be checked against
+`https://github.com/advisories/<GHSA-id>`.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:handoff": "node scripts/aahp-dashboard.mjs --check",
     "handoff:refresh": "node scripts/aahp-dashboard.mjs",
     "feed:generate": "node scripts/generate-feed.mjs",
+    "feed:import": "node scripts/import-threat-feed.mjs",
     "check:feed": "node scripts/generate-feed.mjs --check",
     "prebuild": "npm run check:aahp && npm run check:feed && npm run check:handoff",
     "prepublishOnly": "npm run build",

--- a/scripts/import-threat-feed.mjs
+++ b/scripts/import-threat-feed.mjs
@@ -1,0 +1,714 @@
+// import-threat-feed.mjs - Import malicious-package IOCs from upstream
+// advisory databases into the curated feed (src/threat-intel.ts BUNDLED_FEED),
+// then regenerate feed.json.
+//
+//   node scripts/import-threat-feed.mjs              -> import the last 7 days
+//   node scripts/import-threat-feed.mjs --dry-run    -> report only, write nothing
+//   node scripts/import-threat-feed.mjs --days 30 --limit 500
+//   node scripts/import-threat-feed.mjs --json       -> machine-readable report
+//
+// SOURCES (both public, no account, no API key)
+//   1. GitHub Advisory Database, malware advisories only
+//      GET https://api.github.com/advisories?type=malware
+//      Reviewed by GitHub's security team, CWE-506 "Embedded Malicious Code".
+//      Data licensed CC BY 4.0 - attribution travels with every imported entry
+//      in its `source` field and is documented in docs/threat-feed-sources.md.
+//      GITHUB_TOKEN / GH_TOKEN is OPTIONAL: it only raises the REST rate limit
+//      from 60 to 5000 requests/hour. Without it the import still works.
+//   2. OSV.dev querybatch (corroboration only, never discovery)
+//      POST https://api.osv.dev/v1/querybatch
+//      Confirms the package is also listed as malicious (a MAL- id, sourced
+//      from ossf/malicious-packages, Apache-2.0). A package confirmed by both
+//      databases gets confidence 1.0; GitHub-only gets 0.9. An OSV outage
+//      degrades gracefully - the import continues with GitHub-only provenance.
+//
+// FAILURE MODE
+//   The upstream fetch is the only fatal step. Nothing is written until the
+//   whole batch has been fetched, mapped, validated and re-parsed in memory,
+//   so a network error, a malformed page or an unmappable entry leaves
+//   src/threat-intel.ts and feed.json exactly as they were and the process
+//   exits non-zero with a one-line reason.
+//
+// DISCIPLINE (same rules the curated entries follow)
+//   - Only two upstream version shapes are mapped: an exact pin (`= 1.2.3`)
+//     becomes `name@1.2.3`, and an all-versions range (`>= 0` / `> 0`) becomes
+//     a bare name. A bounded range (`>= 1.0.0, <= 1.2.0`) is NOT collapsed into
+//     a bare name - that would block versions upstream never called malicious -
+//     it is reported as unmapped so a human can decide.
+//   - Only ecosystems this scanner can actually match are imported. Everything
+//     else (Maven, Actions, Pub, Swift, Hex, ...) is reported, not invented.
+//   - Package names are re-validated against a conservative charset before
+//     they are ever serialized into a TypeScript source file.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { buildFeed, serializeFeed, extractBundledEntries } from "./generate-feed.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const GITHUB_ADVISORIES_URL = "https://api.github.com/advisories";
+export const OSV_QUERYBATCH_URL = "https://api.osv.dev/v1/querybatch";
+
+/** Attribution required by the GitHub Advisory Database licence (CC BY 4.0). */
+export const GITHUB_ATTRIBUTION =
+  "GitHub Advisory Database (github/advisory-database), CC BY 4.0";
+/** Attribution for the corroborating database reached through OSV.dev. */
+export const OSV_ATTRIBUTION =
+  "OSV.dev / OpenSSF malicious-packages (ossf/malicious-packages), Apache-2.0";
+
+/**
+ * Upstream ecosystem -> feed value prefix.
+ *
+ * These are exactly the prefixes the scanner resolves today: bare names are
+ * npm (matchBareNpmIOC), everything else is matched by matchPackageIOC with
+ * its ecosystem prefix. An ecosystem missing from this table has no matcher,
+ * so importing it would add data no scan can ever use - those advisories are
+ * reported as skipped instead.
+ */
+export const ECOSYSTEM_PREFIX = {
+  npm: "",
+  pip: "pypi:",
+  composer: "composer:",
+  go: "go:",
+  rubygems: "ruby:",
+  rust: "cargo:",
+  nuget: "nuget:",
+};
+
+/** Feed ecosystem prefix -> OSV ecosystem name (for the corroboration query). */
+export const OSV_ECOSYSTEM = {
+  "": "npm",
+  "pypi:": "PyPI",
+  "composer:": "Packagist",
+  "go:": "Go",
+  "ruby:": "RubyGems",
+  "cargo:": "crates.io",
+  "nuget:": "NuGet",
+};
+
+/**
+ * Upstream severity -> feed severity. FeedIOC only has critical/high/medium,
+ * so `low` and `unknown` land on `medium` (the floor) rather than being
+ * promoted to a level upstream never claimed.
+ */
+export const SEVERITY_MAP = {
+  critical: "critical",
+  high: "high",
+  medium: "medium",
+  moderate: "medium",
+  low: "medium",
+  unknown: "medium",
+};
+
+/**
+ * Confidence is NOT published by either upstream database. These two project
+ * constants encode the corroboration rule the curated feed already used:
+ * a single reporting source is 0.9, two independent databases is 1.0.
+ */
+export const CONFIDENCE_SINGLE_SOURCE = 0.9;
+export const CONFIDENCE_CORROBORATED = 1.0;
+
+/**
+ * Package names are serialized into a TypeScript source file, so the charset
+ * is deliberately narrower than the feed's own package shape: no quotes, no
+ * backslashes, no control characters, nothing that could terminate a string
+ * literal. Every real npm/PyPI/Go/gem/crate/NuGet/Composer name fits.
+ */
+const SAFE_PACKAGE_NAME = /^[A-Za-z0-9][A-Za-z0-9._+~/-]*$/;
+const SAFE_SCOPED_NAME = /^@[A-Za-z0-9][A-Za-z0-9._+~-]*\/[A-Za-z0-9][A-Za-z0-9._+~-]*$/;
+/** Go module paths carry dots and slashes; still no quotes or spaces. */
+const SAFE_MODULE_PATH = /^[A-Za-z0-9][A-Za-z0-9._+~/-]*$/;
+const SAFE_VERSION = /^[A-Za-z0-9][A-Za-z0-9.+~!-]*$/;
+/** Advisory ids are echoed into the `source` field. */
+const SAFE_ADVISORY_ID = /^[A-Za-z0-9-]{1,64}$/;
+
+// ---------------------------------------------------------------------------
+// Mapping (pure, offline)
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify an upstream version range.
+ *
+ * @returns {{kind: "exact", version: string} | {kind: "all"} | {kind: "unmappable"}}
+ */
+export function parseVersionRange(range) {
+  const raw = typeof range === "string" ? range.trim() : "";
+  if (raw === "") return { kind: "unmappable" };
+  // Whole package is malicious: ">= 0", "> 0", ">= 0.0.0".
+  if (/^>=?\s*0(\.0)*$/.test(raw)) return { kind: "all" };
+  // Exact pin: "= 1.2.3".
+  const exact = raw.match(/^=\s*(\S+)$/);
+  if (exact) return { kind: "exact", version: exact[1] };
+  // Anything else (bounded ranges, "< 2.0.0", comma-joined clauses) is not
+  // collapsible without over-blocking.
+  return { kind: "unmappable" };
+}
+
+/** True if a package name is safe to serialize into the TypeScript feed. */
+export function isSafePackageName(name) {
+  if (typeof name !== "string" || name.length === 0 || name.length > 214) return false;
+  return SAFE_SCOPED_NAME.test(name) || SAFE_PACKAGE_NAME.test(name) || SAFE_MODULE_PATH.test(name);
+}
+
+/** Build the feed `value` for a package coordinate. */
+export function feedValue(prefix, name, version) {
+  return version ? `${prefix}${name}@${version}` : `${prefix}${name}`;
+}
+
+/**
+ * Map one GitHub malware advisory to feed entries.
+ *
+ * @returns {{entries: Array<object>, skipped: Array<{reason: string, detail: string}>}}
+ */
+export function mapAdvisory(advisory) {
+  const entries = [];
+  const skipped = [];
+  const id = advisory?.ghsa_id;
+
+  if (!id || !SAFE_ADVISORY_ID.test(id)) {
+    return { entries, skipped: [{ reason: "unusable-advisory-id", detail: String(id) }] };
+  }
+  if (advisory.withdrawn_at) {
+    return { entries, skipped: [{ reason: "withdrawn", detail: id }] };
+  }
+  if (advisory.type !== undefined && advisory.type !== "malware") {
+    return { entries, skipped: [{ reason: "not-malware", detail: `${id} (${advisory.type})` }] };
+  }
+
+  const severity = SEVERITY_MAP[String(advisory.severity ?? "unknown").toLowerCase()] ?? "medium";
+  const firstSeen =
+    typeof advisory.published_at === "string" && /^\d{4}-\d{2}-\d{2}/.test(advisory.published_at)
+      ? advisory.published_at.slice(0, 10)
+      : undefined;
+
+  const vulns = Array.isArray(advisory.vulnerabilities) ? advisory.vulnerabilities : [];
+  if (vulns.length === 0) {
+    skipped.push({ reason: "no-affected-package", detail: id });
+  }
+
+  for (const vuln of vulns) {
+    const ecosystem = String(vuln?.package?.ecosystem ?? "").toLowerCase();
+    const name = vuln?.package?.name;
+    const prefix = ECOSYSTEM_PREFIX[ecosystem];
+
+    if (prefix === undefined) {
+      skipped.push({ reason: "unsupported-ecosystem", detail: `${id} (${ecosystem || "none"})` });
+      continue;
+    }
+    if (!isSafePackageName(name)) {
+      skipped.push({ reason: "unsafe-package-name", detail: `${id} (${JSON.stringify(name)})` });
+      continue;
+    }
+
+    const range = parseVersionRange(vuln.vulnerable_version_range);
+    if (range.kind === "unmappable") {
+      skipped.push({
+        reason: "unmappable-version-range",
+        detail: `${id} ${ecosystem}/${name} (${String(vuln.vulnerable_version_range ?? "")})`,
+      });
+      continue;
+    }
+    if (range.kind === "exact" && !SAFE_VERSION.test(range.version)) {
+      skipped.push({ reason: "unsafe-version", detail: `${id} ${name}@${range.version}` });
+      continue;
+    }
+
+    const entry = {
+      type: "package",
+      value: feedValue(prefix, name, range.kind === "exact" ? range.version : undefined),
+      severity,
+      confidence: CONFIDENCE_SINGLE_SOURCE,
+      source: id,
+    };
+    if (firstSeen) entry.firstSeen = firstSeen;
+    // Carried for the OSV corroboration query and the report; stripped before
+    // the entry is serialized into the feed.
+    entry._ecosystemPrefix = prefix;
+    entry._name = name;
+    entries.push(entry);
+  }
+
+  return { entries, skipped };
+}
+
+/** Map a page (or several) of advisories. */
+export function mapAdvisories(advisories) {
+  const entries = [];
+  const skipped = [];
+  for (const advisory of advisories) {
+    const result = mapAdvisory(advisory);
+    entries.push(...result.entries);
+    skipped.push(...result.skipped);
+  }
+  return { entries, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+/** Split a feed package value into { prefix, name, version }. */
+export function splitPackageValue(value) {
+  const match = value.match(/^([a-z]+:)/);
+  const prefix = match ? match[1] : "";
+  const rest = value.slice(prefix.length);
+  const at = rest.lastIndexOf("@");
+  return {
+    prefix,
+    name: at > 0 ? rest.slice(0, at) : rest,
+    version: at > 0 ? rest.slice(at + 1) : undefined,
+  };
+}
+
+/**
+ * Drop entries the feed already covers.
+ *
+ * Two rules, both matching how the scanner reads the feed:
+ *   1. exact duplicate - same `type:value` (the key mergeFeeds uses)
+ *   2. already covered - a bare-name IOC for the same ecosystem+package
+ *      already fires on every version, so a version-pinned import adds nothing
+ *
+ * @returns {{added: Array<object>, duplicates: number, covered: number}}
+ */
+export function dedupe(existing, incoming) {
+  const seen = new Set();
+  const bareNames = new Set();
+  for (const entry of existing) {
+    seen.add(`${entry.type}:${entry.value}`);
+    if (entry.type !== "package") continue;
+    const { prefix, name, version } = splitPackageValue(entry.value);
+    if (version === undefined) bareNames.add(`${prefix}${name}`);
+  }
+
+  const added = [];
+  let duplicates = 0;
+  let covered = 0;
+
+  for (const entry of incoming) {
+    const key = `${entry.type}:${entry.value}`;
+    if (seen.has(key)) {
+      duplicates++;
+      continue;
+    }
+    const { prefix, name, version } = splitPackageValue(entry.value);
+    if (version !== undefined && bareNames.has(`${prefix}${name}`)) {
+      covered++;
+      continue;
+    }
+    seen.add(key);
+    if (version === undefined) bareNames.add(`${prefix}${name}`);
+    added.push(entry);
+  }
+
+  return { added, duplicates, covered };
+}
+
+// ---------------------------------------------------------------------------
+// Upstream fetch (bounded, explicit timeout, optional token)
+// ---------------------------------------------------------------------------
+
+/** ISO date (YYYY-MM-DD) `days` before `now`. */
+export function sinceDate(days, now = new Date()) {
+  const d = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Extract the rel="next" URL from a Link header, or null. */
+export function nextPageUrl(linkHeader) {
+  if (!linkHeader) return null;
+  const match = String(linkHeader).match(/<([^>]+)>;\s*rel="next"/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Fetch malware advisories published on or after `since`.
+ *
+ * Bounded three ways: an explicit per-request timeout, a hard page cap, and
+ * the fixed 100-item page size. Any non-200 or transport error rejects - the
+ * caller treats that as fatal and writes nothing.
+ */
+export async function fetchMalwareAdvisories({
+  since,
+  until,
+  maxPages = 10,
+  timeoutMs = 15000,
+  token,
+  fetchImpl = globalThis.fetch,
+  baseUrl = GITHUB_ADVISORIES_URL,
+} = {}) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "supply-chain-guard-feed-import",
+  };
+  // Strictly optional: raises the rate limit, never required for access.
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const params = new URLSearchParams({
+    type: "malware",
+    per_page: "100",
+    sort: "published",
+    direction: "desc",
+  });
+  if (since) params.set("published", until ? `${since}..${until}` : `>=${since}`);
+
+  let url = `${baseUrl}?${params.toString()}`;
+  const advisories = [];
+  let pages = 0;
+  let truncated = false;
+
+  while (url) {
+    if (pages >= maxPages) {
+      truncated = true;
+      break;
+    }
+    let response;
+    try {
+      response = await fetchImpl(url, { headers, signal: AbortSignal.timeout(timeoutMs) });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`GitHub Advisory Database request failed: ${message}`);
+    }
+    if (!response.ok) {
+      const remaining = response.headers?.get?.("x-ratelimit-remaining");
+      const hint =
+        remaining === "0"
+          ? " (rate limit exhausted; set GITHUB_TOKEN to raise it from 60 to 5000 requests/hour)"
+          : "";
+      throw new Error(
+        `GitHub Advisory Database returned HTTP ${response.status}${hint}`,
+      );
+    }
+    let page;
+    try {
+      page = await response.json();
+    } catch {
+      throw new Error("GitHub Advisory Database returned a body that is not JSON");
+    }
+    if (!Array.isArray(page)) {
+      throw new Error("GitHub Advisory Database returned an unexpected payload (not an array)");
+    }
+    advisories.push(...page);
+    pages++;
+    url = nextPageUrl(response.headers?.get?.("link"));
+  }
+
+  return { advisories, pages, truncated };
+}
+
+/**
+ * Ask OSV.dev which of these packages it also lists as malicious (MAL- ids).
+ *
+ * Corroboration only: OSV is never used to DISCOVER a package, so an OSV
+ * entry that applies to a single version of an otherwise legitimate package
+ * can never turn into a bare-name block here.
+ *
+ * @returns {Promise<{ids: Map<string, string>, ok: boolean, error?: string}>}
+ *          keyed by `${prefix}${name}`
+ */
+export async function crossReferenceOsv(
+  packages,
+  { timeoutMs = 15000, chunkSize = 250, fetchImpl = globalThis.fetch, url = OSV_QUERYBATCH_URL } = {},
+) {
+  const ids = new Map();
+  const unique = [...new Map(packages.map((p) => [`${p.prefix}${p.name}`, p])).values()];
+  if (unique.length === 0) return { ids, ok: true };
+
+  try {
+    for (let i = 0; i < unique.length; i += chunkSize) {
+      const chunk = unique.slice(i, i + chunkSize);
+      const body = JSON.stringify({
+        queries: chunk.map((p) => ({
+          package: { name: p.name, ecosystem: OSV_ECOSYSTEM[p.prefix] },
+        })),
+      });
+      const response = await fetchImpl(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": "supply-chain-guard-feed-import",
+        },
+        body,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const json = await response.json();
+      const results = Array.isArray(json?.results) ? json.results : [];
+      chunk.forEach((pkg, index) => {
+        const vulns = results[index]?.vulns;
+        if (!Array.isArray(vulns)) return;
+        const mal = vulns
+          .map((v) => v?.id)
+          .find((id) => typeof id === "string" && id.startsWith("MAL-") && SAFE_ADVISORY_ID.test(id));
+        if (mal) ids.set(`${pkg.prefix}${pkg.name}`, mal);
+      });
+    }
+    return { ids, ok: true };
+  } catch (err) {
+    // Non-fatal by design: corroboration is an enrichment, not a gate.
+    return { ids, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Serialization into src/threat-intel.ts
+// ---------------------------------------------------------------------------
+
+const FEED_MARKER = "const BUNDLED_FEED: FeedIOC[] = [";
+
+/** Render one entry as a source line in the file's existing one-line style. */
+export function formatEntry(entry) {
+  const parts = [
+    `type: ${JSON.stringify(entry.type)}`,
+    `value: ${JSON.stringify(entry.value)}`,
+    `severity: ${JSON.stringify(entry.severity)}`,
+    // Match the file's existing style: 1.0, not 1.
+    `confidence: ${Number.isInteger(entry.confidence) ? entry.confidence.toFixed(1) : entry.confidence}`,
+    `source: ${JSON.stringify(entry.source)}`,
+  ];
+  if (entry.firstSeen) parts.push(`firstSeen: ${JSON.stringify(entry.firstSeen)}`);
+  return `  { ${parts.join(", ")} },`;
+}
+
+/** Strip the transient bookkeeping fields before serialization. */
+export function publicEntry(entry) {
+  const { _ecosystemPrefix, _name, ...rest } = entry;
+  return rest;
+}
+
+/**
+ * Append entries to the BUNDLED_FEED array literal in a threat-intel.ts source
+ * string. Uses the same marker/terminator pair as generate-feed.mjs, so the
+ * two never disagree about where the array ends.
+ */
+export function applyEntries(source, entries, { date, sourceLabel = "GitHub Advisory Database" } = {}) {
+  const start = source.indexOf(FEED_MARKER);
+  if (start === -1) throw new Error("BUNDLED_FEED marker not found in src/threat-intel.ts");
+  const terminator = source.indexOf("\n];", start + FEED_MARKER.length);
+  if (terminator === -1) throw new Error("BUNDLED_FEED array terminator not found in src/threat-intel.ts");
+
+  // Insert BEFORE the terminator's own line break, carriage return included.
+  // Splitting a CRLF pair here would leave a stray "\r" behind, which turns a
+  // 25-line append into a whole-file diff on a CRLF checkout.
+  const eol = source.includes("\r\n") ? "\r\n" : "\n";
+  const insertAt = terminator > 0 && source[terminator - 1] === "\r" ? terminator - 1 : terminator;
+
+  const header = `  // Imported from ${sourceLabel} (${date}) - see docs/threat-feed-sources.md`;
+  // A leading empty line separates the imported block from the curated entries.
+  // Every line is prefixed (not suffixed) with the EOL, so the last imported
+  // line borrows the terminator's own line break from the untouched remainder.
+  const lines = ["", header, ...entries.map((e) => formatEntry(publicEntry(e)))];
+  const block = lines.map((line) => eol + line).join("");
+
+  return source.slice(0, insertAt) + block + source.slice(insertAt);
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a full import.
+ *
+ * Nothing is written until every step below has succeeded in memory, so a
+ * failure anywhere leaves src/threat-intel.ts and feed.json byte-identical.
+ */
+export async function importUpstreamFeed({
+  root = repoRoot,
+  days = 7,
+  since,
+  until,
+  limit = 250,
+  maxPages = 10,
+  timeoutMs = 15000,
+  token,
+  useOsv = true,
+  dryRun = false,
+  now = new Date(),
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const from = since ?? sinceDate(days, now);
+  const threatIntelPath = join(root, "src", "threat-intel.ts");
+  const feedPath = join(root, "feed.json");
+
+  // 1. Fetch (fatal on failure - nothing has been written yet).
+  const { advisories, pages, truncated } = await fetchMalwareAdvisories({
+    since: from,
+    until,
+    maxPages,
+    timeoutMs,
+    token,
+    fetchImpl,
+  });
+
+  // 2. Map (pure).
+  const { entries: mapped, skipped } = mapAdvisories(advisories);
+
+  // 3. Dedupe against the feed that is actually committed.
+  const existing = extractBundledEntries(root);
+  const { added, duplicates, covered } = dedupe(existing, mapped);
+  const capped = added.length > limit;
+  const selected = capped ? added.slice(0, limit) : added;
+
+  // 4. Corroborate with OSV (never fatal).
+  let osv = { ids: new Map(), ok: true };
+  if (useOsv && selected.length > 0) {
+    osv = await crossReferenceOsv(
+      selected.map((e) => ({ prefix: e._ecosystemPrefix, name: e._name })),
+      { timeoutMs, fetchImpl },
+    );
+    for (const entry of selected) {
+      const mal = osv.ids.get(`${entry._ecosystemPrefix}${entry._name}`);
+      if (mal) {
+        entry.source = `${entry.source}, ${mal}`;
+        entry.confidence = CONFIDENCE_CORROBORATED;
+      }
+    }
+  }
+
+  const report = {
+    since: from,
+    until: until ?? null,
+    advisoriesFetched: advisories.length,
+    pages,
+    truncated,
+    mapped: mapped.length,
+    duplicates,
+    covered,
+    skipped: summarize(skipped),
+    skippedTotal: skipped.length,
+    corroboratedByOsv: [...osv.ids.keys()].length,
+    osvAvailable: osv.ok,
+    osvError: osv.error ?? null,
+    added: selected.length,
+    capped,
+    entries: selected.map(publicEntry),
+    dryRun,
+    written: false,
+  };
+
+  if (selected.length === 0 || dryRun) return report;
+
+  // 5. Build the new source in memory and prove it re-parses to exactly the
+  //    entries we expect BEFORE anything touches the working tree.
+  const original = readFileSync(threatIntelPath, "utf8");
+  const updated = applyEntries(original, selected, { date: from });
+  writeFileSync(threatIntelPath, updated);
+  try {
+    const reparsed = extractBundledEntries(root);
+    if (reparsed.length !== existing.length + selected.length) {
+      throw new Error(
+        `re-parse mismatch: expected ${existing.length + selected.length} entries, got ${reparsed.length}`,
+      );
+    }
+    // 6. Regenerate feed.json from the (now updated) single source of truth.
+    writeFileSync(feedPath, serializeFeed(buildFeed(root)));
+  } catch (err) {
+    // Roll the source file back so a half-applied import can never ship.
+    writeFileSync(threatIntelPath, original);
+    throw new Error(
+      `import aborted and rolled back: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  report.written = true;
+  return report;
+}
+
+/** Count skip reasons for the report. */
+function summarize(skipped) {
+  const counts = {};
+  for (const item of skipped) counts[item.reason] = (counts[item.reason] ?? 0) + 1;
+  return counts;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export function parseArgs(argv) {
+  const opts = { dryRun: false, json: false, useOsv: true };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => argv[++i];
+    if (arg === "--dry-run") opts.dryRun = true;
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--no-osv") opts.useOsv = false;
+    else if (arg === "--days") opts.days = Number(next());
+    else if (arg === "--since") opts.since = next();
+    else if (arg === "--until") opts.until = next();
+    else if (arg === "--limit") opts.limit = Number(next());
+    else if (arg === "--max-pages") opts.maxPages = Number(next());
+    else if (arg === "--timeout") opts.timeoutMs = Number(next());
+    else if (arg === "--help" || arg === "-h") opts.help = true;
+    else throw new Error(`unknown option: ${arg}`);
+  }
+  return opts;
+}
+
+const USAGE = `
+  Import malicious-package IOCs from upstream advisory databases.
+
+    node scripts/import-threat-feed.mjs [options]
+
+    --days <n>        Look-back window in days (default 7)
+    --since <date>    Explicit start date (YYYY-MM-DD), overrides --days
+    --until <date>    Explicit end date (YYYY-MM-DD)
+    --limit <n>       Maximum new entries to add in one run (default 250)
+    --max-pages <n>   Maximum upstream pages to fetch (default 10)
+    --timeout <ms>    Per-request timeout (default 15000)
+    --no-osv          Skip the OSV.dev corroboration query
+    --dry-run         Report only; write nothing
+    --json            Machine-readable report on stdout
+
+  GITHUB_TOKEN / GH_TOKEN is optional and only raises the REST rate limit.
+`;
+
+const isMain =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  let report;
+  try {
+    const opts = parseArgs(process.argv.slice(2));
+    if (opts.help) {
+      console.log(USAGE);
+      process.exit(0);
+    }
+    report = await importUpstreamFeed({
+      ...opts,
+      token: process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`\n  Feed import failed: ${message}`);
+    console.error(`  Nothing was written; src/threat-intel.ts and feed.json are unchanged.\n`);
+    process.exit(1);
+  }
+
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(`\n  Upstream feed import (published >= ${report.since})\n`);
+    console.log(`  Advisories fetched:   ${report.advisoriesFetched} (${report.pages} page(s)${report.truncated ? ", page cap reached" : ""})`);
+    console.log(`  Mapped to IOCs:       ${report.mapped}`);
+    console.log(`  Already in the feed:  ${report.duplicates} duplicate, ${report.covered} covered by a bare-name IOC`);
+    console.log(`  Skipped:              ${report.skippedTotal} ${JSON.stringify(report.skipped)}`);
+    console.log(`  OSV corroboration:    ${report.osvAvailable ? `${report.corroboratedByOsv} confirmed` : `unavailable (${report.osvError})`}`);
+    console.log(`  New entries:          ${report.added}${report.capped ? " (limit reached)" : ""}`);
+    for (const entry of report.entries.slice(0, 20)) {
+      console.log(`    ${entry.value}  [${entry.source}]`);
+    }
+    if (report.entries.length > 20) console.log(`    ... and ${report.entries.length - 20} more`);
+    console.log(
+      report.written
+        ? `\n  Written: src/threat-intel.ts + feed.json. Review the diff before committing.\n`
+        : `\n  Nothing written${report.dryRun ? " (--dry-run)" : ""}.\n`,
+    );
+  }
+}

--- a/src/__tests__/feed-import.test.ts
+++ b/src/__tests__/feed-import.test.ts
@@ -1,0 +1,759 @@
+/**
+ * Upstream threat-feed import (scripts/import-threat-feed.mjs).
+ *
+ * Every test here is OFFLINE: the upstream responses are fixtures and the
+ * network layer is injected as `fetchImpl`. The three behaviours that matter
+ * are the mapping (upstream advisory -> FeedIOC), the deduplication against
+ * the feed that is already committed, and the failure mode (a network error
+ * must leave src/threat-intel.ts and feed.json byte-identical and surface as
+ * a rejected promise, which the CLI turns into a non-zero exit).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { isValidFeedIOC, type FeedIOC } from "../threat-intel.js";
+
+const IMPORT_SCRIPT_URL = new URL("../../scripts/import-threat-feed.mjs", import.meta.url).href;
+const load = () => import(/* @vite-ignore */ IMPORT_SCRIPT_URL);
+
+// ---------------------------------------------------------------------------
+// Fixtures - shaped exactly like GET /advisories?type=malware responses.
+// Package names are synthetic (never real packages) so a fixture can never
+// become a live indicator by accident.
+// ---------------------------------------------------------------------------
+
+interface AdvisoryFixture {
+  ghsa_id: string;
+  type?: string;
+  severity?: string;
+  published_at?: string;
+  withdrawn_at?: string | null;
+  vulnerabilities: Array<{
+    package: { ecosystem: string; name: string };
+    vulnerable_version_range: string | null;
+  }>;
+}
+
+function advisory(over: Partial<AdvisoryFixture> = {}): AdvisoryFixture {
+  return {
+    ghsa_id: "GHSA-aaaa-bbbb-cccc",
+    type: "malware",
+    severity: "critical",
+    published_at: "2026-07-24T17:20:25Z",
+    withdrawn_at: null,
+    vulnerabilities: [
+      {
+        package: { ecosystem: "npm", name: "scg-fixture-pkg" },
+        vulnerable_version_range: ">= 0",
+      },
+    ],
+    ...over,
+  };
+}
+
+/** A fetchImpl that answers one page and then stops. */
+function singlePage(body: unknown, status = 200) {
+  return async () => ({
+    ok: status === 200,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Version-range mapping
+// ---------------------------------------------------------------------------
+
+describe("parseVersionRange", () => {
+  it("maps an exact pin", async () => {
+    const { parseVersionRange } = await load();
+    expect(parseVersionRange("= 1.2.3")).toEqual({ kind: "exact", version: "1.2.3" });
+    expect(parseVersionRange("=1.2.3")).toEqual({ kind: "exact", version: "1.2.3" });
+  });
+
+  it("maps an all-versions range", async () => {
+    const { parseVersionRange } = await load();
+    expect(parseVersionRange(">= 0")).toEqual({ kind: "all" });
+    expect(parseVersionRange("> 0")).toEqual({ kind: "all" });
+    expect(parseVersionRange(">= 0.0.0")).toEqual({ kind: "all" });
+  });
+
+  it("refuses to collapse a bounded range into a bare-name block", async () => {
+    const { parseVersionRange } = await load();
+    // Collapsing this to a bare name would block versions upstream never
+    // called malicious - the over-blocking the curated feed avoids by hand.
+    expect(parseVersionRange(">= 1.0.0, <= 1.2.0")).toEqual({ kind: "unmappable" });
+    expect(parseVersionRange("< 2.0.0")).toEqual({ kind: "unmappable" });
+    expect(parseVersionRange("")).toEqual({ kind: "unmappable" });
+    expect(parseVersionRange(null)).toEqual({ kind: "unmappable" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Advisory -> FeedIOC mapping
+// ---------------------------------------------------------------------------
+
+describe("mapAdvisory", () => {
+  it("maps an all-versions npm advisory to a bare-name IOC", async () => {
+    const { mapAdvisory, publicEntry } = await load();
+    const { entries, skipped } = mapAdvisory(advisory());
+    expect(skipped).toEqual([]);
+    expect(publicEntry(entries[0])).toEqual({
+      type: "package",
+      value: "scg-fixture-pkg",
+      severity: "critical",
+      confidence: 0.9,
+      source: "GHSA-aaaa-bbbb-cccc",
+      firstSeen: "2026-07-24",
+    });
+  });
+
+  it("maps an exact pin to name@version", async () => {
+    const { mapAdvisory } = await load();
+    const { entries } = mapAdvisory(
+      advisory({
+        vulnerabilities: [
+          {
+            package: { ecosystem: "npm", name: "scg-fixture-pkg" },
+            vulnerable_version_range: "= 4.5.6",
+          },
+        ],
+      }),
+    );
+    expect(entries[0].value).toBe("scg-fixture-pkg@4.5.6");
+  });
+
+  it("prefixes every non-npm ecosystem the scanner can match", async () => {
+    const { mapAdvisory } = await load();
+    const cases: Array<[string, string]> = [
+      ["pip", "pypi:scg-fixture-pkg"],
+      ["composer", "composer:scg-fixture-pkg"],
+      ["go", "go:scg-fixture-pkg"],
+      ["rubygems", "ruby:scg-fixture-pkg"],
+      ["rust", "cargo:scg-fixture-pkg"],
+      ["nuget", "nuget:scg-fixture-pkg"],
+      ["npm", "scg-fixture-pkg"],
+    ];
+    for (const [ecosystem, expected] of cases) {
+      const { entries } = mapAdvisory(
+        advisory({
+          vulnerabilities: [
+            {
+              package: { ecosystem, name: "scg-fixture-pkg" },
+              vulnerable_version_range: ">= 0",
+            },
+          ],
+        }),
+      );
+      expect(entries[0].value).toBe(expected);
+    }
+  });
+
+  it("keeps a scoped npm name and a Go module path intact", async () => {
+    const { mapAdvisory } = await load();
+    const { entries } = mapAdvisory(
+      advisory({
+        vulnerabilities: [
+          {
+            package: { ecosystem: "npm", name: "@scg-fixture/scoped" },
+            vulnerable_version_range: "= 1.0.0",
+          },
+          {
+            package: { ecosystem: "go", name: "github.com/scg-fixture/mod" },
+            vulnerable_version_range: ">= 0",
+          },
+        ],
+      }),
+    );
+    expect(entries.map((e: FeedIOC) => e.value)).toEqual([
+      "@scg-fixture/scoped@1.0.0",
+      "go:github.com/scg-fixture/mod",
+    ]);
+  });
+
+  it("maps severity down to the three levels the feed schema has", async () => {
+    const { mapAdvisory } = await load();
+    const sev = (s: string) => mapAdvisory(advisory({ severity: s })).entries[0].severity;
+    expect(sev("critical")).toBe("critical");
+    expect(sev("high")).toBe("high");
+    expect(sev("moderate")).toBe("medium");
+    expect(sev("medium")).toBe("medium");
+    // Never promoted above what upstream claimed.
+    expect(sev("low")).toBe("medium");
+    expect(sev("unknown")).toBe("medium");
+  });
+
+  it("records provenance in the source field", async () => {
+    const { mapAdvisory } = await load();
+    const { entries } = mapAdvisory(advisory({ ghsa_id: "GHSA-1234-5678-9abc" }));
+    expect(entries[0].source).toBe("GHSA-1234-5678-9abc");
+  });
+
+  it("skips withdrawn advisories", async () => {
+    const { mapAdvisory } = await load();
+    const result = mapAdvisory(advisory({ withdrawn_at: "2026-07-25T00:00:00Z" }));
+    expect(result.entries).toEqual([]);
+    expect(result.skipped[0].reason).toBe("withdrawn");
+  });
+
+  it("skips ecosystems the scanner has no matcher for", async () => {
+    const { mapAdvisory } = await load();
+    const result = mapAdvisory(
+      advisory({
+        vulnerabilities: [
+          {
+            package: { ecosystem: "maven", name: "org.example:thing" },
+            vulnerable_version_range: ">= 0",
+          },
+        ],
+      }),
+    );
+    expect(result.entries).toEqual([]);
+    expect(result.skipped[0].reason).toBe("unsupported-ecosystem");
+  });
+
+  it("skips a package name that could break out of the TypeScript literal", async () => {
+    const { mapAdvisory } = await load();
+    const hostile = advisory({
+      vulnerabilities: [
+        {
+          package: { ecosystem: "npm", name: 'x", severity: "critical" }, { type: "domain", value: "evil' },
+          vulnerable_version_range: ">= 0",
+        },
+      ],
+    });
+    const result = mapAdvisory(hostile);
+    expect(result.entries).toEqual([]);
+    expect(result.skipped[0].reason).toBe("unsafe-package-name");
+  });
+
+  it("reports an unmappable range instead of guessing", async () => {
+    const { mapAdvisory } = await load();
+    const result = mapAdvisory(
+      advisory({
+        vulnerabilities: [
+          {
+            package: { ecosystem: "npm", name: "scg-fixture-pkg" },
+            vulnerable_version_range: ">= 1.0.0, <= 1.2.0",
+          },
+        ],
+      }),
+    );
+    expect(result.entries).toEqual([]);
+    expect(result.skipped[0].reason).toBe("unmappable-version-range");
+  });
+
+  it("emits entries that pass the feed's own validity gate", async () => {
+    const { mapAdvisory, publicEntry } = await load();
+    const { entries } = mapAdvisory(
+      advisory({
+        vulnerabilities: [
+          { package: { ecosystem: "npm", name: "scg-fixture-pkg" }, vulnerable_version_range: "= 1.0.0" },
+          { package: { ecosystem: "pip", name: "scg-fixture-py" }, vulnerable_version_range: ">= 0" },
+        ],
+      }),
+    );
+    expect(entries).toHaveLength(2);
+    for (const entry of entries) {
+      expect(isValidFeedIOC(publicEntry(entry))).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+describe("dedupe", () => {
+  const existing: FeedIOC[] = [
+    { type: "package", value: "already-there@1.0.0", severity: "critical", confidence: 1 },
+    { type: "package", value: "whole-package-bad", severity: "critical", confidence: 1 },
+    { type: "package", value: "ruby:gem-bad", severity: "critical", confidence: 1 },
+    { type: "domain", value: "c2.example", severity: "critical", confidence: 1 },
+  ];
+
+  it("drops an exact duplicate", async () => {
+    const { dedupe } = await load();
+    const result = dedupe(existing, [
+      { type: "package", value: "already-there@1.0.0", severity: "critical", confidence: 0.9 },
+    ]);
+    expect(result.added).toEqual([]);
+    expect(result.duplicates).toBe(1);
+  });
+
+  it("drops a version pin already covered by a bare-name IOC", async () => {
+    const { dedupe } = await load();
+    const result = dedupe(existing, [
+      { type: "package", value: "whole-package-bad@9.9.9", severity: "critical", confidence: 0.9 },
+      { type: "package", value: "ruby:gem-bad@2.0.0", severity: "critical", confidence: 0.9 },
+    ]);
+    expect(result.added).toEqual([]);
+    expect(result.covered).toBe(2);
+  });
+
+  it("does not confuse ecosystems that share a package name", async () => {
+    const { dedupe } = await load();
+    const result = dedupe(existing, [
+      { type: "package", value: "pypi:whole-package-bad@1.0.0", severity: "critical", confidence: 0.9 },
+    ]);
+    expect(result.added).toHaveLength(1);
+    expect(result.covered).toBe(0);
+  });
+
+  it("deduplicates within the incoming batch too", async () => {
+    const { dedupe } = await load();
+    const incoming = [
+      { type: "package", value: "brand-new@1.0.0", severity: "critical", confidence: 0.9 },
+      { type: "package", value: "brand-new@1.0.0", severity: "critical", confidence: 0.9 },
+    ];
+    const result = dedupe(existing, incoming);
+    expect(result.added).toHaveLength(1);
+    expect(result.duplicates).toBe(1);
+  });
+
+  it("adds genuinely new indicators", async () => {
+    const { dedupe } = await load();
+    const result = dedupe(existing, [
+      { type: "package", value: "brand-new", severity: "critical", confidence: 0.9 },
+    ]);
+    expect(result.added).toHaveLength(1);
+    expect(result.duplicates).toBe(0);
+    expect(result.covered).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fetch layer (bounded, optional token) - injected fetchImpl, no network
+// ---------------------------------------------------------------------------
+
+describe("fetchMalwareAdvisories", () => {
+  it("follows Link rel=next and stops at the page cap", async () => {
+    const { fetchMalwareAdvisories } = await load();
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: (h: string) => (h === "link" ? '<https://next.example/page>; rel="next"' : null) },
+        json: async () => [advisory({ ghsa_id: `GHSA-page-${calls}-cccc` })],
+      };
+    };
+    const result = await fetchMalwareAdvisories({ maxPages: 3, fetchImpl });
+    expect(calls).toBe(3);
+    expect(result.pages).toBe(3);
+    expect(result.truncated).toBe(true);
+    expect(result.advisories).toHaveLength(3);
+  });
+
+  it("sends no Authorization header when no token is configured", async () => {
+    const { fetchMalwareAdvisories } = await load();
+    let seen: Record<string, string> = {};
+    const fetchImpl = async (_url: string, init: { headers: Record<string, string> }) => {
+      seen = init.headers;
+      return { ok: true, status: 200, headers: { get: () => null }, json: async () => [] };
+    };
+    await fetchMalwareAdvisories({ fetchImpl });
+    expect(seen.Authorization).toBeUndefined();
+    expect(seen.Accept).toBe("application/vnd.github+json");
+  });
+
+  it("uses the token when one is supplied (rate limit only, never required)", async () => {
+    const { fetchMalwareAdvisories } = await load();
+    let seen: Record<string, string> = {};
+    const fetchImpl = async (_url: string, init: { headers: Record<string, string> }) => {
+      seen = init.headers;
+      return { ok: true, status: 200, headers: { get: () => null }, json: async () => [] };
+    };
+    await fetchMalwareAdvisories({ fetchImpl, token: "t0ken" });
+    expect(seen.Authorization).toBe("Bearer t0ken");
+  });
+
+  it("passes an abort signal so a hung upstream cannot stall the run", async () => {
+    const { fetchMalwareAdvisories } = await load();
+    let signal: unknown;
+    const fetchImpl = async (_url: string, init: { signal: unknown }) => {
+      signal = init.signal;
+      return { ok: true, status: 200, headers: { get: () => null }, json: async () => [] };
+    };
+    await fetchMalwareAdvisories({ fetchImpl, timeoutMs: 1234 });
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("rejects on a non-200 and names the rate limit when it is the cause", async () => {
+    const { fetchMalwareAdvisories } = await load();
+    const fetchImpl = async () => ({
+      ok: false,
+      status: 403,
+      headers: { get: (h: string) => (h === "x-ratelimit-remaining" ? "0" : null) },
+      json: async () => ({}),
+    });
+    await expect(fetchMalwareAdvisories({ fetchImpl })).rejects.toThrow(/HTTP 403.*GITHUB_TOKEN/s);
+  });
+
+  it("rejects on a transport error", async () => {
+    const { fetchMalwareAdvisories } = await load();
+    const fetchImpl = async () => {
+      throw new Error("getaddrinfo ENOTFOUND");
+    };
+    await expect(fetchMalwareAdvisories({ fetchImpl })).rejects.toThrow(/request failed/);
+  });
+
+  it("rejects a payload that is not an array of advisories", async () => {
+    const { fetchMalwareAdvisories } = await load();
+    await expect(
+      fetchMalwareAdvisories({ fetchImpl: singlePage({ message: "nope" }) }),
+    ).rejects.toThrow(/unexpected payload/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OSV corroboration - enrichment, never a gate
+// ---------------------------------------------------------------------------
+
+describe("crossReferenceOsv", () => {
+  it("records a MAL- id per package and lifts nothing else", async () => {
+    const { crossReferenceOsv } = await load();
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({
+        results: [
+          { vulns: [{ id: "MAL-2026-11054" }] },
+          { vulns: [{ id: "GHSA-not-a-mal-id" }] },
+          {},
+        ],
+      }),
+    });
+    const result = await crossReferenceOsv(
+      [
+        { prefix: "", name: "a" },
+        { prefix: "pypi:", name: "b" },
+        { prefix: "go:", name: "c" },
+      ],
+      { fetchImpl },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.ids.get("a")).toBe("MAL-2026-11054");
+    expect(result.ids.has("pypi:b")).toBe(false);
+    expect(result.ids.has("go:c")).toBe(false);
+  });
+
+  it("degrades gracefully when OSV is unavailable", async () => {
+    const { crossReferenceOsv } = await load();
+    const fetchImpl = async () => {
+      throw new Error("ECONNRESET");
+    };
+    const result = await crossReferenceOsv([{ prefix: "", name: "a" }], { fetchImpl });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("ECONNRESET");
+    expect(result.ids.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Serialization into the BUNDLED_FEED array literal
+// ---------------------------------------------------------------------------
+
+describe("applyEntries", () => {
+  const SOURCE = [
+    "const BUNDLED_FEED: FeedIOC[] = [",
+    '  { type: "domain", value: "existing.example", severity: "critical", confidence: 1.0 },',
+    "];",
+    "",
+    "export const CACHE_DIR = \".scg-cache\";",
+    "",
+  ].join("\n");
+
+  it("appends inside the array, before the terminator", async () => {
+    const { applyEntries } = await load();
+    const out = applyEntries(
+      SOURCE,
+      [
+        {
+          type: "package",
+          value: "scg-fixture-pkg@1.0.0",
+          severity: "critical",
+          confidence: 0.9,
+          source: "GHSA-aaaa-bbbb-cccc",
+          firstSeen: "2026-07-24",
+        },
+      ],
+      { date: "2026-07-24" },
+    );
+    const arrayBody = out.slice(0, out.indexOf("\n];"));
+    expect(arrayBody).toContain('value: "scg-fixture-pkg@1.0.0"');
+    expect(arrayBody).toContain('source: "GHSA-aaaa-bbbb-cccc"');
+    expect(arrayBody).toContain("// Imported from GitHub Advisory Database (2026-07-24)");
+    expect(out).toContain('export const CACHE_DIR = ".scg-cache";');
+  });
+
+  it("produces a literal that evaluates back to the same entry", async () => {
+    const { applyEntries } = await load();
+    const { runInNewContext } = await import("node:vm");
+    const entry = {
+      type: "package",
+      value: "pypi:scg-fixture-py",
+      severity: "high",
+      confidence: 1.0,
+      source: "GHSA-aaaa-bbbb-cccc, MAL-2026-11054",
+    };
+    const out = applyEntries(SOURCE, [entry], { date: "2026-07-24" });
+    const marker = "const BUNDLED_FEED: FeedIOC[] = [";
+    const body = out.slice(out.indexOf(marker) + marker.length, out.indexOf("\n];"));
+    const parsed = runInNewContext(`[${body}\n]`, {}) as FeedIOC[];
+    expect(parsed[parsed.length - 1]).toEqual(entry);
+  });
+
+  it("preserves CRLF working trees without splitting a CRLF pair", async () => {
+    const { applyEntries } = await load();
+    const crlf = SOURCE.replace(/\n/g, "\r\n");
+    const out = applyEntries(crlf, [
+      { type: "package", value: "x", severity: "critical", confidence: 0.9, source: "GHSA-aaaa-bbbb-cccc" },
+    ], { date: "2026-07-24" });
+    expect(out).toContain('value: "x"');
+    // A stray "\r" or a lone "\n" makes git treat the whole file as rewritten,
+    // turning a 25-line append into a several-thousand-line diff.
+    expect(out.match(/\r\r/g)).toBeNull();
+    expect(out.match(/[^\r]\n/g)).toBeNull();
+    // Every line ends CRLF and the array still terminates correctly.
+    expect(out.split("\r\n").length).toBe(crlf.split("\r\n").length + 3);
+    expect(out).toContain("\r\n];");
+  });
+
+  it("keeps LF working trees on LF", async () => {
+    const { applyEntries } = await load();
+    const out = applyEntries(SOURCE, [
+      { type: "package", value: "x", severity: "critical", confidence: 0.9, source: "GHSA-aaaa-bbbb-cccc" },
+    ], { date: "2026-07-24" });
+    expect(out.includes("\r")).toBe(false);
+    expect(out).toContain("\n];");
+  });
+
+  it("writes confidence in the file's existing 1.0 style", async () => {
+    const { formatEntry } = await load();
+    expect(formatEntry({ type: "package", value: "x", severity: "critical", confidence: 1.0, source: "GHSA-aaaa-bbbb-cccc" })).toContain(
+      "confidence: 1.0",
+    );
+    expect(formatEntry({ type: "package", value: "x", severity: "critical", confidence: 0.9, source: "GHSA-aaaa-bbbb-cccc" })).toContain(
+      "confidence: 0.9",
+    );
+  });
+
+  it("refuses a source file without the expected array", async () => {
+    const { applyEntries } = await load();
+    expect(() => applyEntries("const OTHER = [];", [], { date: "2026-07-24" })).toThrow(
+      /marker not found/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure mode - the feed must survive a broken upstream untouched
+// ---------------------------------------------------------------------------
+
+describe("importUpstreamFeed failure mode", () => {
+  let tmpRoot: string;
+  let threatIntelPath: string;
+  let feedPath: string;
+
+  const FAKE_THREAT_INTEL = [
+    "export interface FeedIOC { type: string }",
+    "const BUNDLED_FEED: FeedIOC[] = [",
+    '  { type: "domain", value: "existing.example", severity: "critical", confidence: 1.0 },',
+    "];",
+    "",
+  ].join("\n");
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "scg-import-"));
+    fs.mkdirSync(path.join(tmpRoot, "src"));
+    threatIntelPath = path.join(tmpRoot, "src", "threat-intel.ts");
+    feedPath = path.join(tmpRoot, "feed.json");
+    fs.writeFileSync(threatIntelPath, FAKE_THREAT_INTEL);
+    fs.writeFileSync(path.join(tmpRoot, "package.json"), JSON.stringify({ version: "9.9.9" }));
+    fs.writeFileSync(feedPath, '{"schema":1,"entries":[{"type":"domain","value":"existing.example"}]}\n');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("leaves both files byte-identical and rejects when the upstream fetch fails", async () => {
+    const { importUpstreamFeed } = await load();
+    const before = {
+      ts: fs.readFileSync(threatIntelPath),
+      feed: fs.readFileSync(feedPath),
+    };
+    const fetchImpl = async () => {
+      throw new Error("getaddrinfo ENOTFOUND api.github.com");
+    };
+
+    await expect(importUpstreamFeed({ root: tmpRoot, fetchImpl })).rejects.toThrow(
+      /GitHub Advisory Database request failed/,
+    );
+
+    expect(fs.readFileSync(threatIntelPath).equals(before.ts)).toBe(true);
+    expect(fs.readFileSync(feedPath).equals(before.feed)).toBe(true);
+  });
+
+  it("leaves both files untouched on an HTTP error", async () => {
+    const { importUpstreamFeed } = await load();
+    const before = fs.readFileSync(threatIntelPath);
+    const fetchImpl = async () => ({
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      json: async () => ({}),
+    });
+    await expect(importUpstreamFeed({ root: tmpRoot, fetchImpl })).rejects.toThrow(/HTTP 503/);
+    expect(fs.readFileSync(threatIntelPath).equals(before)).toBe(true);
+  });
+
+  it("writes nothing in --dry-run but still reports what it would add", async () => {
+    const { importUpstreamFeed } = await load();
+    const before = fs.readFileSync(threatIntelPath);
+    const report = await importUpstreamFeed({
+      root: tmpRoot,
+      dryRun: true,
+      useOsv: false,
+      fetchImpl: singlePage([advisory()]),
+    });
+    expect(report.added).toBe(1);
+    expect(report.written).toBe(false);
+    expect(report.entries[0].value).toBe("scg-fixture-pkg");
+    expect(fs.readFileSync(threatIntelPath).equals(before)).toBe(true);
+  });
+
+  it("writes nothing when everything upstream is already covered", async () => {
+    const { importUpstreamFeed } = await load();
+    fs.writeFileSync(
+      threatIntelPath,
+      FAKE_THREAT_INTEL.replace(
+        "];",
+        '  { type: "package", value: "scg-fixture-pkg", severity: "critical", confidence: 1.0 },\n];',
+      ),
+    );
+    const before = fs.readFileSync(threatIntelPath);
+    const report = await importUpstreamFeed({
+      root: tmpRoot,
+      useOsv: false,
+      fetchImpl: singlePage([advisory()]),
+    });
+    expect(report.added).toBe(0);
+    expect(report.duplicates).toBe(1);
+    expect(report.written).toBe(false);
+    expect(fs.readFileSync(threatIntelPath).equals(before)).toBe(true);
+  });
+
+  it("applies new entries and regenerates feed.json from the updated source", async () => {
+    const { importUpstreamFeed } = await load();
+    const report = await importUpstreamFeed({
+      root: tmpRoot,
+      useOsv: false,
+      fetchImpl: singlePage([
+        advisory({
+          ghsa_id: "GHSA-1111-2222-3333",
+          vulnerabilities: [
+            { package: { ecosystem: "pip", name: "scg-fixture-py" }, vulnerable_version_range: "= 2.0.0" },
+          ],
+        }),
+      ]),
+    });
+    expect(report.written).toBe(true);
+    expect(report.added).toBe(1);
+
+    const source = fs.readFileSync(threatIntelPath, "utf8");
+    expect(source).toContain('value: "pypi:scg-fixture-py@2.0.0"');
+    expect(source).toContain('source: "GHSA-1111-2222-3333"');
+
+    const feed = JSON.parse(fs.readFileSync(feedPath, "utf8"));
+    expect(feed.schema).toBe(1);
+    expect(feed.entryCount).toBe(2);
+    expect(feed.entries[1].value).toBe("pypi:scg-fixture-py@2.0.0");
+    // Provenance survives into the published artifact.
+    expect(feed.entries[1].source).toBe("GHSA-1111-2222-3333");
+  });
+
+  it("still imports (at single-source confidence) when OSV is down", async () => {
+    const { importUpstreamFeed, CONFIDENCE_SINGLE_SOURCE } = await load();
+    const fetchImpl = async (url: string) => {
+      if (String(url).includes("osv.dev")) throw new Error("ECONNRESET");
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => [advisory()],
+      };
+    };
+    const report = await importUpstreamFeed({ root: tmpRoot, fetchImpl });
+    expect(report.osvAvailable).toBe(false);
+    expect(report.written).toBe(true);
+    expect(report.entries[0].confidence).toBe(CONFIDENCE_SINGLE_SOURCE);
+  });
+
+  it("raises confidence to 1.0 when OSV corroborates the package", async () => {
+    const { importUpstreamFeed, CONFIDENCE_CORROBORATED } = await load();
+    const fetchImpl = async (url: string) => {
+      if (String(url).includes("osv.dev")) {
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          json: async () => ({ results: [{ vulns: [{ id: "MAL-2026-11054" }] }] }),
+        };
+      }
+      return { ok: true, status: 200, headers: { get: () => null }, json: async () => [advisory()] };
+    };
+    const report = await importUpstreamFeed({ root: tmpRoot, fetchImpl });
+    expect(report.entries[0].confidence).toBe(CONFIDENCE_CORROBORATED);
+    expect(report.entries[0].source).toBe("GHSA-aaaa-bbbb-cccc, MAL-2026-11054");
+    expect(report.corroboratedByOsv).toBe(1);
+  });
+
+  it("caps how many entries a single run may add", async () => {
+    const { importUpstreamFeed } = await load();
+    const many = Array.from({ length: 5 }, (_, i) =>
+      advisory({
+        ghsa_id: `GHSA-cap${i}-bbbb-cccc`,
+        vulnerabilities: [
+          { package: { ecosystem: "npm", name: `scg-fixture-cap-${i}` }, vulnerable_version_range: ">= 0" },
+        ],
+      }),
+    );
+    const report = await importUpstreamFeed({
+      root: tmpRoot,
+      limit: 2,
+      useOsv: false,
+      fetchImpl: singlePage(many),
+    });
+    expect(report.added).toBe(2);
+    expect(report.capped).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  it("parses the documented options", async () => {
+    const { parseArgs } = await load();
+    expect(parseArgs(["--days", "30", "--limit", "10", "--dry-run", "--no-osv", "--json"])).toEqual({
+      days: 30,
+      limit: 10,
+      dryRun: true,
+      useOsv: false,
+      json: true,
+    });
+  });
+
+  it("rejects an unknown option instead of ignoring it", async () => {
+    const { parseArgs } = await load();
+    expect(() => parseArgs(["--wat"])).toThrow(/unknown option/);
+  });
+});

--- a/src/osv-export.ts
+++ b/src/osv-export.ts
@@ -18,6 +18,7 @@ import type { FeedIOC } from "./threat-intel.js";
 /** Ecosystem-prefix (feed) -> OSV ecosystem name. Unlisted prefixes are skipped. */
 const OSV_ECOSYSTEMS: Record<string, string> = {
   npm: "npm", // bare (unprefixed) feed package entries are npm
+  pypi: "PyPI", // pypi: entries (python-lockfile-scanner resolves these)
   go: "Go",
   ruby: "RubyGems",
   composer: "Packagist",

--- a/src/threat-intel.ts
+++ b/src/threat-intel.ts
@@ -913,8 +913,15 @@ export async function updateThreatFeed(
 // must be scanned normally - an attacker cannot smuggle code past the check by
 // naming a file feed.json, because any extra key or non-scalar value fails it.
 const FEED_DOC_KEYS = new Set(["schema", "package", "version", "entryCount", "entries", "timestamp"]);
+// Mirrors the FeedIOC interface (plus the legacy "note"/"ecosystem" keys). It
+// MUST list every field the feed can carry: "source" and "lastSeen" are part of
+// FeedIOC, and entries imported from upstream advisory databases populate
+// "source" with their provenance (see scripts/import-threat-feed.mjs). Leaving
+// a real field out here would make the project's own feed.json fail this check
+// and get scanned as ordinary content - the v5.4.0 phantom-findings bug.
 const FEED_ENTRY_KEYS = new Set([
-  "type", "value", "severity", "confidence", "family", "campaign", "firstSeen", "note", "ecosystem",
+  "type", "value", "severity", "confidence", "family", "campaign", "source",
+  "firstSeen", "lastSeen", "note", "ecosystem",
 ]);
 
 /**


### PR DESCRIPTION
## Why

The daily threat-intel refresh pulled from an internal security-news aggregator that is **no longer maintained** (its repo was deleted during the Forgejo migration, it is 9 commits behind and cannot be redeployed).

Availability was never the real problem though; **value** was. That endpoint is a plain RSS aggregator over 17 general security feeds (BleepingComputer, Dark Reading, Talos, ZDI, Krebs, ...). Not one is package-malware or supply-chain specific, and none of the vendors the refresh actually ended up citing (Socket, Aikido, StepSecurity, safedep, OX) is even in the list. It publishes headlines and excerpts, never an atomic indicator, so every single run needed a human to go read the linked vendor write-ups by hand.

This PR cuts that dependency and wires two real upstream sources instead.

## Sources

Both public, **no account and no API key**:

| Source | Role | Licence |
| --- | --- | --- |
| [GitHub Advisory Database](https://github.com/advisories?query=type%3Amalware) malware advisories (CWE-506) via `GET /advisories?type=malware` | Primary (discovery) | CC BY 4.0 |
| [OSV.dev](https://osv.dev/) `POST /v1/querybatch` | Corroboration only | `MAL-` records from [ossf/malicious-packages](https://github.com/ossf/malicious-packages), Apache-2.0 |

- `GITHUB_TOKEN` / `GH_TOKEN` is **strictly optional**: it only raises the REST rate limit from 60 to 5000 requests/hour. Without it the import works; if the unauthenticated limit is exhausted, the error message says so.
- **OSV is never used for discovery.** It can only raise the confidence of a package GitHub already flagged (0.9 to 1.0), so a `MAL-` record covering one version of an otherwise legitimate package can never turn into a whole-package block. If OSV is unreachable the run continues at 0.9 and reports it.
- Symmetry worth noting: the tool already speaks OSV in the other direction (`supply-chain-guard feed osv`). Now it speaks it both ways.

## What is in here

```bash
npm run feed:import -- --dry-run    # report only
npm run feed:import                 # last 7 days, max 250 new entries, then regenerates feed.json
```

- `scripts/import-threat-feed.mjs` - fetch, map, dedupe, apply. Same `.mjs`-with-exported-pure-functions shape as `generate-feed.mjs`, so vitest can drive it offline.
- `src/__tests__/feed-import.test.ts` - **44 tests, all offline** (fixtures + injected `fetchImpl`, no test touches the network).
- `docs/threat-feed-sources.md` - sources, licences and attribution, the full field mapping, ecosystem prefix table, version-range rules, failure mode, dedup rules.
- `src/threat-intel.ts` - `source` and `lastSeen` added to `FEED_ENTRY_KEYS` (see below).
- `src/osv-export.ts` - `pypi:` is now a recognised OSV export ecosystem, so PyPI IOCs stop being silently dropped from `feed osv`.

**No IOCs are imported in this PR.** `feed.json` is byte-identical at 430 entries. This ships the mechanism; the first real refresh is a separate, reviewable change.

## Mapping, and what it refuses to do

Feed quality is the product, so the import is deliberately conservative and reports what it will not guess:

| Upstream range | Feed value |
| --- | --- |
| `= 1.2.3` | `name@1.2.3` |
| `>= 0`, `> 0` | `name` (whole package malicious) |
| `>= 1.0.0, <= 1.2.0`, `< 2.0.0`, empty | **skipped**, reported as `unmappable-version-range` |

A bounded range is not collapsed into a bare name; that would block versions upstream never called malicious, which is exactly the over-blocking the curated feed avoids by hand for hijacked-but-legitimate packages.

- Only ecosystems this scanner can actually resolve are imported: npm (bare), `pypi:`, `composer:`, `go:`, `ruby:`, `cargo:`, `nuget:`. Maven/Actions/Pub/Swift/Hex are counted in the report, not invented into the feed.
- `family` and `campaign` stay **unset** - neither database publishes them, and inventing a family name would put fiction in the feed.
- `confidence` is not published upstream either, so it is a documented project constant (0.9 single-source, 1.0 corroborated) rather than a per-entry guess.
- `severity` is mapped down, never up: `moderate`/`low`/`unknown` land on `medium`, the floor the FeedIOC type allows.

## Provenance and dedup

Every imported entry populates `FeedIOC.source` with its advisory ids (`GHSA-...`, plus `MAL-...` when corroborated), so each line can be checked against the public advisory page. 0 of the 430 existing entries used that field, so this establishes the convention; it is documented in the README and in `docs/threat-feed-sources.md`.

That change had a sharp edge worth calling out: `source` was **missing from `FEED_ENTRY_KEYS`** in `isInertThreatFeedFile()`. Without adding it, the project's own `feed.json` would stop being recognised as its own inert data and would be scanned as ordinary content - the v5.4.0 dogfooding bug that produced 169 phantom criticals. `lastSeen` was missing too; the allowlist now mirrors the `FeedIOC` interface.

Dedup runs against the committed feed and is ecosystem-aware (`pypi:foo` and npm `foo` are never conflated):

1. exact `type:value` duplicate (the key `mergeFeeds` uses at scan time), and
2. a version pin already covered by an existing bare-name IOC.

## Failure mode

The fetch is the only fatal step, and nothing is written until the whole batch has been fetched, mapped, deduped and **re-parsed in memory**. If the rewritten source does not re-parse to the expected entry count, the source file is rolled back and `feed.json` is never regenerated.

Proven end to end against the live API, not just in tests:

```
$ md5sum src/threat-intel.ts feed.json
2345f2b5108689d7c68092739dd93f54 *src/threat-intel.ts
4f9fbe03dbdbc5b3e9e1c69142a449a3 *feed.json

$ node scripts/import-threat-feed.mjs --timeout 1 --days 1
  Feed import failed: GitHub Advisory Database request failed: The operation was aborted due to timeout
  Nothing was written; src/threat-intel.ts and feed.json are unchanged.
EXIT=1

$ md5sum src/threat-intel.ts feed.json
2345f2b5108689d7c68092739dd93f54 *src/threat-intel.ts
4f9fbe03dbdbc5b3e9e1c69142a449a3 *feed.json
```

Network calls are bounded three ways: an explicit per-request `AbortSignal.timeout`, a page cap, and the fixed 100-item page size. A default daily run makes at most 11 requests.

## Hardening

Package names come from a database anyone can file into, and the importer writes them into a TypeScript source file. They are re-validated against a charset **narrower** than the feed's own package shape (no quotes, no backslashes, no whitespace) before serialization, values go through `JSON.stringify`, and there is a test that a name crafted to break out of the string literal is rejected rather than written.

## Real run against the live sources

`--dry-run --days 7 --max-pages 4` on 2026-07-25:

```
  Advisories fetched:   400 (4 page(s), page cap reached)
  Mapped to IOCs:       623
  Already in the feed:  0 duplicate, 33 covered by a bare-name IOC
  Skipped:              1 {"withdrawn":1}
  OSV corroboration:    194 confirmed
  New entries:          250 (limit reached)
    app-node-layer   [GHSA-4xc7-2jx9-rp5j, MAL-2026-11054]
    svgcraft-core@1.0.0 .. @1.0.7  [GHSA-j9vc-q728-qcx4, MAL-2026-6715]
    ...
```

A first real refresh with the defaults (`--days 7 --limit 250`) would add **250 entries**, taking the feed from 430 to 680, roughly 78% of them OSV-corroborated at confidence 1.0. A write run was also executed for real (`--days 2 --limit 25`), producing a clean 36-line diff in `src/threat-intel.ts` plus 202 lines in `feed.json`, passing every gate at 455 entries with `isInertThreatFeedFile()` still true, then reverted so this PR stays mechanism-only.

## Verification

- `npm run build` - green (`check:aahp` 7 gates, `check:feed` 430 entries fresh, `check:handoff` in sync, `tsc` clean)
- `npm test` - 1447 passed. The only failures are the 14 known `vscode-scanner` tests that shell out to a `zip` binary this Windows box does not have; they are green in CI and untouched by this change.
- All gates re-run **with** 25 real imported entries applied: still green.

## Follow-up (not in this PR)

The daily refresh itself still runs from a local scheduled task outside this repo that fetches the retired aggregator URL. It needs to be repointed at `npm run feed:import`, or replaced by a scheduled workflow in this repo, otherwise the dead source stays in the loop. Left out deliberately: a scheduled workflow is standing automation and a separate decision.
