### PR TITLE
fix(release): gate package-lock.json in version-sync and correct the v5.20.2 feed claim

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,28 +3,28 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1785224709",
-    "timestamp": "2026-07-28T07:45:09Z",
-    "commit": "de0a93a",
+    "session_id": "cli-1785226685",
+    "timestamp": "2026-07-28T08:18:05Z",
+    "commit": "2f25469",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:4a01365bf6a15dcef5b5683f3f3bc566c5ff8e2dc5ae8088820f04ae70bf302a",
-      "updated": "2026-07-28T07:35:32Z",
-      "lines": 1319,
+      "checksum": "sha256:e9ad8222a9db9341b67453c61b40a3678304aceeb92eb8fc72a6427d0d0219cc",
+      "updated": "2026-07-28T08:17:55Z",
+      "lines": 1345,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:80d684aa02f31bfe7fb0ef80a6042ff7a0d6e2fe2db24c71016b94801a0a16e6",
-      "updated": "2026-07-28T07:30:30Z",
+      "updated": "2026-07-28T07:46:32Z",
       "lines": 63,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:64d5006aa66c1edae78279aee5bfe4c714bdfd45b77961e35bb011ba25a922bd",
-      "updated": "2026-07-28T07:45:09Z",
+      "updated": "2026-07-28T08:18:05Z",
       "lines": 121,
       "summary": "(no summary available)"
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:6efc940c2d828b5ff51e2eaa21a2a61fa736250e18fd756eb96e3337c66b1c15",
-      "updated": "2026-07-28T07:45:09Z",
+      "updated": "2026-07-28T08:18:05Z",
       "lines": 66,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:5a58294ec445c53f7192610929d5f8a60c578e596aeb636513857872069729c7",
-      "updated": "2026-07-28T07:45:09Z",
+      "updated": "2026-07-28T08:18:05Z",
       "lines": 49,
       "summary": "(no summary available)"
     },
@@ -80,7 +80,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 25818,
-    "full_read": 34232
+    "manifest_plus_core": 26220,
+    "full_read": 34634
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,29 @@
+> Note (2026-07-28, claude-opus-4-8): Post-release review of v5.20.2 (external, GPT-5.6-Sol)
+> found two real defects. Both confirmed by measurement, both fixed here. No republish: the
+> published package is correct.
+>
+> 1. LOCKFILE NEVER BUMPED, TWO RELEASES RUNNING. package-lock.json carries the project
+> version twice (root `.version` and `.packages[""].version`) and npm only rewrites them at
+> install time, so an in-place (sed) release bump leaves them behind. Measured at the tags:
+> v5.20.0 lock=5.20.0 (correct), v5.20.1 lock=5.20.0 (stale), v5.20.2 lock=5.20.1 (stale) -
+> it trails by exactly one release. Nothing caught it because package-lock.json was not in
+> aahp.config.json versionSites. It never affected the published package (the lockfile is not
+> in `files`). Fixed: lockfile resynced, ADDED to versionSites (minOccurrences 2, now 7 sites),
+> and CLAUDE.md release step 4 now says to run `npm install --package-lock-only` after the
+> bump. Mutation-proved: reverting the lock to 5.20.1 turns version-sync red.
+>
+> 2. "feed.json is byte-identical" WAS FALSE AS SHIPPED - my error, in the CHANGELOG and the
+> release notes. Byte-identity was verified at the chunking step, before the version bump; the
+> bump then changed feed.json's embedded version string (the ONLY line that differs between
+> v5.20.1 and v5.20.2). The accurate claim, now in the CHANGELOG: all 1,197 entries are
+> identical, only the embedded version differs. Worth naming the pattern - a claim verified at
+> one point in the work was carried forward after a later step invalidated it, which is exactly
+> the staleness class the gates in this repo exist to prevent. Re-verify claims at the point
+> you publish them, not at the point you first prove them.
+>
+> The full local suite is 1,589 pass / 14 fail, all vscode-scanner, all from the missing Windows
+> `zip` binary - the documented environment gap, green on CI. Not a regression.
+
 > Note (2026-07-28, claude-opus-4-8): Released v5.20.2 - removed the TS2590 build ceiling
 > and bumped the AAHP gate toolchain to 3.9.0 (supersedes PR #83).
 >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Fixed
+
+- `package-lock.json` is now covered by the version-sync gate. The release bump edits
+  version strings in place, but npm writes the lockfile's own `version` fields at install
+  time, so the lockfile trailed a release behind (5.20.0 at the v5.20.1 tag, 5.20.1 at the
+  v5.20.2 tag) and nothing caught it because the file was not a configured version site.
+  It never affected the published package, which does not ship the lockfile. Resync with
+  `npm install --package-lock-only` when bumping.
+
 ## [5.20.2] - 2026-07-28
 
 ### Fixed
@@ -21,7 +30,8 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
   `FEED_CHUNK_n` consts spread back into `BUNDLED_FEED`, which typechecks 100,000 entries
   across 100 chunks in about 9 seconds. Every entry is still validated against `FeedIOC`
   (bad severity, wrong field type, missing required field and unknown property are all
-  still compile errors), and no IOC data changed: `feed.json` is byte-identical.
+  still compile errors), and no IOC data changed: all 1,197 entries in `feed.json` are
+  identical, with only its embedded version string differing.
 ### Changed
 
 - **The daily import now rolls over to a new chunk instead of growing one array.**

--- a/aahp.config.json
+++ b/aahp.config.json
@@ -6,7 +6,8 @@
     { "file": "src/scanner.ts", "minOccurrences": 1, "note": "TOOL_VERSION const (ScanReport.tool + risk-history)" },
     { "file": "README.md", "minOccurrences": 1, "note": "pre-commit snippet rev: tag" },
     { "file": ".pre-commit-hooks.yaml", "minOccurrences": 1, "note": "example rev: tag in header comment" },
-    { "file": "server.json", "minOccurrences": 2, "note": "MCP registry version + npm package version" }
+    { "file": "server.json", "minOccurrences": 2, "note": "MCP registry version + npm package version" },
+    { "file": "package-lock.json", "minOccurrences": 2, "note": "lockfile root version + packages[\"\"].version; npm writes these at install time, so a sed-based bump leaves them a release behind (was stale in v5.20.1 and v5.20.2). Resync with `npm install --package-lock-only`" }
   ],
   "claims": [
     {

--- a/docs/threat-feed-sources.md
+++ b/docs/threat-feed-sources.md
@@ -10,9 +10,17 @@ The feed has two kinds of entries:
 | Curated | A maintainer reads a vendor write-up and hand-adds the atomic indicators (package, domain, IP, hash, URL) | Recorded in the `CHANGELOG.md` entry for the release that shipped it |
 | Imported | `npm run feed:import` pulls malicious-package records from upstream advisory databases | Recorded per entry in the `source` field |
 
-Both land in the same place: the `BUNDLED_FEED` array in `src/threat-intel.ts`,
-which is the single source of truth. `npm run feed:generate` republishes it as
-`feed.json`, and `npm run check:feed` fails the build if the two ever drift.
+Both land in the same place: the bundled feed in `src/threat-intel.ts`, which is
+the single source of truth. `npm run feed:generate` republishes it as `feed.json`,
+and `npm run check:feed` fails the build if the two ever drift.
+
+The feed is stored as capacity-bounded `FEED_CHUNK_n` consts spread back together
+into `BUNDLED_FEED`. That is not cosmetic: one array literal of this size trips
+`TS2590` in `tsc`, and the limit is content-dependent (uniformly-shaped imported
+entries hit it far sooner than hand-curated ones). Entries are appended to the last
+chunk; when it reaches `FEED_CHUNK_CAPACITY` the importer opens a new chunk and
+registers it in the spread, so no single literal can grow into that ceiling. Nothing
+about this changes how you run an import - the rollover is automatic.
 
 ## Upstream sources
 
@@ -200,6 +208,7 @@ batch are collapsed too.
 ## Reviewing an import
 
 An import is a proposal, not a release. Read the diff before committing: the
-entries are appended to `BUNDLED_FEED` under a dated comment, and every one of
-them names the advisory it came from, so each line can be checked against
+entries are appended to the last feed chunk under a dated comment (or to a new
+chunk, if that one was full), and every one of them names the advisory it came
+from, so each line can be checked against
 `https://github.com/advisories/<GHSA-id>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "supply-chain-guard",
-  "version": "5.20.1",
+  "version": "5.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "supply-chain-guard",
-      "version": "5.20.1",
+      "version": "5.20.2",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.3"


### PR DESCRIPTION
Post-release review of v5.20.2 (external) found two real defects. Both confirmed by measurement. Neither affects the published package, so this fixes forward rather than republishing.

## 1. The lockfile was never bumped, for two releases running

`package-lock.json` carries the project version twice (root `.version` and `.packages[""].version`), and npm only rewrites them at install time - so an in-place release bump leaves them behind. Measured at the tags:

| Tag | package.json | package-lock.json |
|---|---|---|
| v5.20.0 | 5.20.0 | 5.20.0 |
| v5.20.1 | 5.20.1 | **5.20.0** |
| v5.20.2 | 5.20.2 | **5.20.1** |

It trails by exactly one release. Nothing caught it because `package-lock.json` was not in `aahp.config.json` `versionSites`. It never affected the published package, which does not ship the lockfile.

**Fix:** lockfile resynced (`npm install --package-lock-only`, 2 lines, no dependency churn) and added to `versionSites` with `minOccurrences: 2`, so version-sync now covers 7 sites. Mutation-proved: reverting the lock to 5.20.1 turns the gate red.

## 2. "feed.json is byte-identical" was false as shipped

Byte-identity was verified at the chunking step, before the version bump. The bump then changed `feed.json`'s embedded version string, which is the only line differing between v5.20.1 and v5.20.2. Corrected to the accurate claim: all 1,197 entries are identical, only the embedded version differs.

## 3. Doc drift from the chunking change

`docs/threat-feed-sources.md` still described entries as appended to a single `BUNDLED_FEED` array. Updated for the chunked layout and automatic rollover, and to make explicit that running an import is unchanged.

## Verification

`npm run build` green (7/7 gates, version-sync now 7 sites), `aahp verify --level ci` green, gate mutation-proved in both directions.