### PR TITLE
feat(feed-import): add --ecosystem filter for mixed spikes

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,17 +3,17 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1785743854",
-    "timestamp": "2026-08-03T07:57:34Z",
-    "commit": "cc017bf",
+    "session_id": "cli-1785744724",
+    "timestamp": "2026-08-03T08:12:04Z",
+    "commit": "db6a5e2",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:57dd0655b470ece953190251e41b3cf7809aae6c9c5fb252a21911be0994b4c2",
-      "updated": "2026-08-03T07:57:25Z",
-      "lines": 1991,
+      "checksum": "sha256:f18ff92ee977033d67485431bfb3984bd5b461fe480f44b96381c0cbfee934df",
+      "updated": "2026-08-03T08:11:56Z",
+      "lines": 2010,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:e23ab22310eccaa63662fbb895fb94d79e1a7df32feb4bc91d7c94d3af2223f3",
-      "updated": "2026-08-03T07:57:33Z",
+      "updated": "2026-08-03T08:12:03Z",
       "lines": 130,
       "summary": "(no summary available)"
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:e9adb131f387fe42631359304db4c43023771b2d6c46698a351157526c187994",
-      "updated": "2026-08-03T07:57:33Z",
+      "updated": "2026-08-03T08:12:03Z",
       "lines": 67,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:94099e0779c291ba05fdfa586160c4171ca7774d3686e30b7e6334d566cc8a5c",
-      "updated": "2026-08-03T07:57:33Z",
+      "updated": "2026-08-03T08:12:03Z",
       "lines": 49,
       "summary": "(no summary available)"
     },
@@ -80,7 +80,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 36086,
-    "full_read": 44671
+    "manifest_plus_core": 36370,
+    "full_read": 44955
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,22 @@
+> Note (2026-08-03, claude-opus-5, unreleased): Added `--ecosystem` to the feed importer,
+> which is the follow-up the note below flagged for a decision. Emre approved building it
+> as its own PR after #105 merged.
+>
+> Scope was deliberately narrow. The flag filters by ecosystem and nothing else; it does
+> NOT automate the liveness check that motivated it. A package removed from its registry
+> can still sit in a lockfile, a vendored directory or a mirror, so "dead on the registry"
+> is not "safe to skip" - it trades a little coverage for feed size, which is a judgement
+> call about a specific spike and should stay with the operator. Automating it would bury
+> that trade behind a flag. Recorded because the tempting next step is a `--skip-dead`
+> flag, and it should not be built without arguing past this.
+>
+> Nine tests written failing first (mapAdvisory filtering, the ecosystem-filtered skip
+> reason, multi-select, the no-filter regression guard, end-to-end import, comma-separated
+> and repeated parsing, and two on rejecting an unknown name). Verified against the real
+> spike, not just fixtures: `--since 2026-07-20 --until 2026-07-21 --ecosystem npm` maps
+> exactly 153 rows, the same number the hand-rolled fetch proxy produced, and reports
+> 21,014 as ecosystem-filtered. Suite 373 -> 382.
+>
 > Note (2026-08-03, claude-opus-5, unreleased): Daily threat-intel run. 133 package IOCs
 > imported (131 npm, 2 PyPI), feed 6,161 -> 6,294. 132 of 133 are corroborated by both
 > GHSA and OSV. No version bump; Emre cuts the release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ### Added
 
+- **`--ecosystem <list>` for `scripts/import-threat-feed.mjs`**, to import only
+  part of a mixed bulk-publication spike. Comma-separated and repeatable, valid
+  values are the ecosystems the scanner can resolve (`npm`, `pip`, `composer`,
+  `go`, `rubygems`, `rust`, `nuget`). Everything outside the selection is counted
+  under `ecosystem-filtered` in the skip report rather than quietly omitted, and
+  the selection is recorded as `ecosystems` in the JSON report. An unknown name
+  is rejected rather than ignored: a silently ignored typo would filter every
+  advisory out and import zero IOCs while exiting 0, the same silent false
+  negative the page cap is fatal about. Closes the gap that forced the
+  2026-08-03 run to hand-roll a fetch proxy to take the npm half of the
+  2026-07-20/21 spike.
+
 - **133 malicious package IOCs** imported from the GitHub Advisory Database
   (CWE-506) and corroborated against OSV.dev: 131 npm and 2 PyPI, covering the
   14-day window to 2026-08-03. 132 of the 133 are confirmed by both databases

--- a/docs/threat-feed-sources.md
+++ b/docs/threat-feed-sources.md
@@ -127,6 +127,7 @@ npm run feed:import -- --dry-run          # report only, writes nothing
 npm run feed:import                       # last 14 days, max 250 new entries
 npm run feed:import -- --days 30 --limit 500
 npm run feed:import -- --json             # machine-readable report
+npm run feed:import -- --since 2026-07-20 --until 2026-07-21 --ecosystem npm --limit 100000
 ```
 
 | Option | Default | Purpose |
@@ -134,6 +135,7 @@ npm run feed:import -- --json             # machine-readable report
 | `--days <n>` | 14 | Look-back window |
 | `--since <YYYY-MM-DD>` | - | Explicit start date, overrides `--days` |
 | `--until <YYYY-MM-DD>` | - | Explicit end date |
+| `--ecosystem <list>` | all | Import only these ecosystems (comma-separated, repeatable) |
 | `--limit <n>` | 250 | Maximum new entries added in one run |
 | `--max-pages <n>` | 750 | Hard cap on upstream pages fetched; hitting it is fatal |
 | `--allow-truncated` | off | Import anyway when the page cap was hit |
@@ -170,6 +172,36 @@ scanner means a silent false negative. Truncation consequently **aborts the impo
 and exits non-zero** rather than writing a knowingly partial window. Recover by
 raising `--max-pages`, or by slicing the window with `--since`/`--until`. Only
 pass `--allow-truncated` when a partial import is genuinely what you want.
+
+### Why a spike may be worth taking only in part
+
+A bulk-publication spike is routinely mixed, and the halves are not equally
+useful. On 2026-07-20/21 the window carried 104 npm advisories alongside roughly
+11,800 PyPI and NuGet ones. Sampling 25 distinct packages per ecosystem against
+the registries: npm was 25/25 still installable, PyPI 0/25, NuGet 2/25. The npm
+half was live threat data; the rest was historical record that would have taken
+the bundled feed from 6,294 to about 27,000 entries to cover packages nobody can
+install.
+
+`--ecosystem` is how that split is taken. Everything outside the selection is
+counted under `ecosystem-filtered` in the skip report rather than quietly
+omitted, so the decision stays visible in the run output:
+
+```
+Ecosystem filter:     npm only
+Mapped to IOCs:       153
+Skipped:              21014 {"ecosystem-filtered":21014}
+```
+
+An unknown ecosystem name is rejected instead of ignored. A silently ignored
+typo would filter every advisory out and import zero IOCs while exiting 0, which
+is the same silent false negative the page cap is fatal about.
+
+Liveness itself is deliberately **not** automated. A package removed from its
+registry can still sit in a lockfile, a vendored directory or a mirror, so
+skipping dead packages trades a small amount of coverage for feed size. That is
+a judgement call about a specific spike, and it belongs with the operator rather
+than buried behind a flag.
 
 Because a busy window can need hundreds of requests, `GITHUB_TOKEN` is optional
 for a small window but effectively required for a large one: the anonymous REST

--- a/scripts/import-threat-feed.mjs
+++ b/scripts/import-threat-feed.mjs
@@ -188,10 +188,11 @@ export function feedValue(prefix, name, version) {
  *
  * @returns {{entries: Array<object>, skipped: Array<{reason: string, detail: string}>}}
  */
-export function mapAdvisory(advisory) {
+export function mapAdvisory(advisory, { ecosystems } = {}) {
   const entries = [];
   const skipped = [];
   const id = advisory?.ghsa_id;
+  const selected = ecosystems?.length ? new Set(ecosystems) : null;
 
   if (!id || !SAFE_ADVISORY_ID.test(id)) {
     return { entries, skipped: [{ reason: "unusable-advisory-id", detail: String(id) }] };
@@ -219,6 +220,13 @@ export function mapAdvisory(advisory) {
     const name = vuln?.package?.name;
     const prefix = ECOSYSTEM_PREFIX[ecosystem];
 
+    // Deliberate exclusion, checked before support: --ecosystem npm on a mixed
+    // window should report "you asked for npm" for every other row, rather than
+    // splitting the same rows across "filtered" and "unsupported".
+    if (selected && !selected.has(ecosystem)) {
+      skipped.push({ reason: "ecosystem-filtered", detail: `${id} (${ecosystem || "none"})` });
+      continue;
+    }
     if (prefix === undefined) {
       skipped.push({ reason: "unsupported-ecosystem", detail: `${id} (${ecosystem || "none"})` });
       continue;
@@ -260,11 +268,11 @@ export function mapAdvisory(advisory) {
 }
 
 /** Map a page (or several) of advisories. */
-export function mapAdvisories(advisories) {
+export function mapAdvisories(advisories, { ecosystems } = {}) {
   const entries = [];
   const skipped = [];
   for (const advisory of advisories) {
-    const result = mapAdvisory(advisory);
+    const result = mapAdvisory(advisory, { ecosystems });
     entries.push(...result.entries);
     skipped.push(...result.skipped);
   }
@@ -679,6 +687,7 @@ export async function importUpstreamFeed({
   useOsv = true,
   dryRun = false,
   allowTruncated = false,
+  ecosystems,
   now = new Date(),
   fetchImpl = globalThis.fetch,
 } = {}) {
@@ -730,7 +739,7 @@ export async function importUpstreamFeed({
   }
 
   // 2. Map (pure).
-  const { entries: mapped, skipped } = mapAdvisories(advisories);
+  const { entries: mapped, skipped } = mapAdvisories(advisories, { ecosystems });
 
   // 3. Dedupe against the feed that is actually committed.
   const existing = extractBundledEntries(root);
@@ -772,6 +781,9 @@ export async function importUpstreamFeed({
     capped,
     limitApplied: limit,
     daysApplied: days,
+    // Which ecosystems this run was restricted to, or null for "all supported".
+    // Recorded so a slice import is self-describing in the JSON report.
+    ecosystems: ecosystems?.length ? [...ecosystems] : null,
     // How many mappable, non-duplicate IOCs were left behind by --limit. Most
     // of these are picked up by later runs, because the fetch is newest-first
     // and dedupe removes what has already been taken, so each run advances into
@@ -850,6 +862,30 @@ function positiveInt(flag, raw) {
   return value;
 }
 
+/**
+ * Parse a comma-separated `--ecosystem` value into validated upstream names.
+ *
+ * Unknown names are rejected rather than ignored. An ignored typo would filter
+ * every advisory out and import ZERO IOCs while exiting 0, which in a threat-feed
+ * importer is the same silent false negative the page-cap guard is fatal about.
+ */
+function ecosystemList(raw) {
+  const valid = Object.keys(ECOSYSTEM_PREFIX);
+  const names = String(raw ?? "")
+    .split(",")
+    .map((n) => n.trim().toLowerCase())
+    .filter(Boolean);
+  if (names.length === 0) {
+    throw new Error(`--ecosystem expects at least one name; valid values are ${valid.join(", ")}.`);
+  }
+  for (const name of names) {
+    if (!valid.includes(name)) {
+      throw new Error(`unknown ecosystem ${JSON.stringify(name)}; valid values are ${valid.join(", ")}.`);
+    }
+  }
+  return names;
+}
+
 export function parseArgs(argv) {
   const opts = { dryRun: false, json: false, useOsv: true };
   for (let i = 0; i < argv.length; i++) {
@@ -863,6 +899,7 @@ export function parseArgs(argv) {
     else if (arg === "--until") opts.until = next();
     else if (arg === "--limit") opts.limit = positiveInt(arg, next());
     else if (arg === "--max-pages") opts.maxPages = positiveInt(arg, next());
+    else if (arg === "--ecosystem") opts.ecosystems = [...(opts.ecosystems ?? []), ...ecosystemList(next())];
     else if (arg === "--allow-truncated") opts.allowTruncated = true;
     else if (arg === "--allow-backlog") opts.allowBacklog = true;
     else if (arg === "--timeout") opts.timeoutMs = positiveInt(arg, next());
@@ -899,6 +936,13 @@ const USAGE = `
                         of the window and no later run can reach it - it ages out
                         for good. Only pass this when a knowingly partial import
                         is what you want.
+    --ecosystem <list>  Import only these ecosystems (comma-separated, repeatable).
+                        One of ${Object.keys(ECOSYSTEM_PREFIX).join(", ")}. Everything
+                        else in the window is reported as ecosystem-filtered rather
+                        than imported. Use this when a bulk-publication spike is
+                        mixed and only part of it is worth taking - see the
+                        2026-07-20/21 spike, where the npm half sampled 25/25 still
+                        installable and the PyPI/NuGet halves 0/25 and 2/25.
     --timeout <ms>      Per-request timeout (default 15000)
     --no-osv            Skip the OSV.dev corroboration query
     --dry-run           Report only; write nothing
@@ -935,6 +979,9 @@ if (isMain) {
     console.log(JSON.stringify(report, null, 2));
   } else {
     console.log(`\n  Upstream feed import (published >= ${report.since})\n`);
+    if (report.ecosystems) {
+      console.log(`  Ecosystem filter:     ${report.ecosystems.join(", ")} only`);
+    }
     console.log(`  Advisories fetched:   ${report.advisoriesFetched} (${report.pages} page(s)${report.truncated ? ", page cap reached" : ""})`);
     console.log(`  Mapped to IOCs:       ${report.mapped}`);
     console.log(`  Already in the feed:  ${report.duplicates} duplicate, ${report.covered} covered by a bare-name IOC`);

--- a/src/__tests__/feed-import.test.ts
+++ b/src/__tests__/feed-import.test.ts
@@ -988,6 +988,125 @@ describe("importUpstreamFeed failure mode", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Ecosystem filter
+//
+// A bulk-publication spike is routinely mixed: 2026-07-20/21 carried 104 live
+// npm advisories alongside ~11,800 PyPI/NuGet ones that no longer resolve on
+// their registries. Taking only the live half was a real need twice, and with
+// no flag for it the only way through was a hand-rolled fetch proxy that
+// stripped vulnerabilities before mapping - an unreviewed script standing in
+// for a tool. These tests pin the supported way to do it.
+// ---------------------------------------------------------------------------
+
+describe("ecosystem filter", () => {
+  const mixed = {
+    ghsa_id: "GHSA-eeee-ffff-0000",
+    type: "malware",
+    severity: "critical",
+    published_at: "2026-07-21T09:00:00Z",
+    withdrawn_at: null,
+    vulnerabilities: [
+      { package: { ecosystem: "npm", name: "scg-fixture-live" }, vulnerable_version_range: ">= 0" },
+      { package: { ecosystem: "pip", name: "scg-fixture-dead" }, vulnerable_version_range: ">= 0" },
+      { package: { ecosystem: "nuget", name: "Scg.Fixture.Dead" }, vulnerable_version_range: ">= 0" },
+    ],
+  };
+
+  it("maps only the selected ecosystem", async () => {
+    const { mapAdvisory } = await load();
+    const { entries } = mapAdvisory(mixed, { ecosystems: ["npm"] });
+    expect(entries.map((e: FeedIOC) => e.value)).toEqual(["scg-fixture-live"]);
+  });
+
+  it("records what the filter excluded rather than dropping it silently", async () => {
+    const { mapAdvisory } = await load();
+    const { skipped } = mapAdvisory(mixed, { ecosystems: ["npm"] });
+    expect(skipped.map((s: { reason: string }) => s.reason)).toEqual([
+      "ecosystem-filtered",
+      "ecosystem-filtered",
+    ]);
+  });
+
+  it("selects several ecosystems at once", async () => {
+    const { mapAdvisory } = await load();
+    const { entries } = mapAdvisory(mixed, { ecosystems: ["npm", "nuget"] });
+    expect(entries.map((e: FeedIOC) => e.value)).toEqual([
+      "scg-fixture-live",
+      "nuget:Scg.Fixture.Dead",
+    ]);
+  });
+
+  it("maps every supported ecosystem when no filter is given", async () => {
+    const { mapAdvisory } = await load();
+    const { entries } = mapAdvisory(mixed);
+    expect(entries).toHaveLength(3);
+  });
+
+  it("imports only the selected ecosystem end to end", async () => {
+    const { importUpstreamFeed } = await load();
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "scg-eco-"));
+    try {
+      fs.mkdirSync(path.join(tmpRoot, "src"));
+      fs.writeFileSync(
+        path.join(tmpRoot, "src", "threat-intel.ts"),
+        [
+          "export interface FeedIOC { type: string }",
+          "const BUNDLED_FEED: FeedIOC[] = [",
+          '  { type: "domain", value: "existing.example", severity: "critical", confidence: 1.0 },',
+          "];",
+          "",
+        ].join("\n"),
+      );
+      fs.writeFileSync(path.join(tmpRoot, "package.json"), JSON.stringify({ version: "9.9.9" }));
+      fs.writeFileSync(
+        path.join(tmpRoot, "feed.json"),
+        '{"schema":1,"entries":[{"type":"domain","value":"existing.example"}]}\n',
+      );
+
+      const report = await importUpstreamFeed({
+        root: tmpRoot,
+        useOsv: false,
+        ecosystems: ["npm"],
+        fetchImpl: singlePage([mixed]),
+      });
+
+      expect(report.added).toBe(1);
+      expect(report.entries[0].value).toBe("scg-fixture-live");
+      expect(report.ecosystems).toEqual(["npm"]);
+      const source = fs.readFileSync(path.join(tmpRoot, "src", "threat-intel.ts"), "utf8");
+      expect(source).not.toContain("scg-fixture-dead");
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("parses --ecosystem as a comma-separated list", async () => {
+    const { parseArgs } = await load();
+    expect(parseArgs(["--ecosystem", "npm,pip"]).ecosystems).toEqual(["npm", "pip"]);
+  });
+
+  it("accumulates a repeated --ecosystem flag", async () => {
+    const { parseArgs } = await load();
+    expect(parseArgs(["--ecosystem", "npm", "--ecosystem", "nuget"]).ecosystems).toEqual([
+      "npm",
+      "nuget",
+    ]);
+  });
+
+  // A typo here would silently import nothing, which in a threat-feed importer
+  // is the same silent false negative the page-cap guard is fatal about.
+  it("rejects an unknown ecosystem instead of importing nothing", async () => {
+    const { parseArgs } = await load();
+    expect(() => parseArgs(["--ecosystem", "npmm"])).toThrow(/unknown ecosystem/);
+  });
+
+  it("names the valid ecosystems in the rejection", async () => {
+    const { parseArgs } = await load();
+    expect(() => parseArgs(["--ecosystem", "maven"])).toThrow(/nuget/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #105, which flagged this for a decision. No version bump.

## Why

A bulk-publication spike is routinely mixed, and the halves are not equally useful. On
2026-07-20/21 the window carried 104 npm advisories alongside roughly 11,800 PyPI and
NuGet ones. Sampling 25 distinct packages per ecosystem against the registries:

| Ecosystem | Still installable |
|---|---|
| npm | 25/25 |
| PyPI | 0/25 |
| NuGet | 2/25 |

The npm half was live threat data. The rest would have taken the bundled feed from 6,294
to about 27,000 entries to cover packages nobody can install. There was no supported way
to take only the live half, so the 2026-08-03 run drove `importUpstreamFeed()` through a
hand-rolled `fetchImpl` proxy that stripped non-npm vulnerabilities before mapping. It
worked, but an unreviewed scratchpad script was standing in for a tool, and mixed spikes
have now come up twice.

## What

`--ecosystem <list>`, comma-separated and repeatable, validated against the ecosystems the
scanner can actually resolve (`npm`, `pip`, `composer`, `go`, `rubygems`, `rust`, `nuget`).

Filtered rows are counted under `ecosystem-filtered` in the skip report, and the selection
is recorded as `ecosystems` in the JSON report. That matters: a filtered window and an
empty window otherwise look identical in the output.

```
Ecosystem filter:     npm only
Mapped to IOCs:       153
Skipped:              21014 {"ecosystem-filtered":21014}
```

An unknown name is rejected rather than ignored, because a silently ignored typo would
filter every advisory out and import zero IOCs while exiting 0 - the same silent false
negative the page cap is fatal about.

## What this deliberately does not do

It does not automate the liveness check that motivated it, and I'd push back on adding one
later without a real argument. A package removed from its registry can still sit in a
lockfile, a vendored directory or a mirror, so "dead on the registry" is not "safe to
skip" - it trades a little coverage for feed size. That is a judgement call about a
specific spike and belongs with the operator, not buried behind a flag. The reasoning is
recorded in `docs/threat-feed-sources.md` and STATUS.md so the next agent has to argue
past it rather than rediscover it.

## Verification

Nine tests, each written failing first and watched fail for the right reason before any
implementation existed:

- `mapAdvisory` maps only the selected ecosystem
- the excluded rows are recorded, not dropped silently
- multi-select (`npm,nuget`)
- no filter still maps every supported ecosystem (regression guard)
- end-to-end import writes only the selected ecosystem and reports `ecosystems`
- `--ecosystem npm,pip` parses as a list
- a repeated `--ecosystem` flag accumulates
- an unknown ecosystem is rejected
- the rejection names the valid values

Verified against the real spike rather than only fixtures:
`--since 2026-07-20 --until 2026-07-21 --ecosystem npm` maps exactly **153** rows, the same
number the hand-rolled proxy produced, reports 21,014 as `ecosystem-filtered`, and finds 0
new because #105 already imported all 153.

- Targeted suites: **382 passed** (373 before, +9).
- `npm run build` green: 7 AAHP gates, check:feed, check:handoff, tsc.
- No pattern table touched, so the regex validators are not implicated.
- CI runs the full suite on this PR and that is the authoritative verdict.
