### PR TITLE
feat(threat-intel): IOCs for 2026-08-04

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,28 +3,28 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1785745766",
-    "timestamp": "2026-08-03T08:29:27Z",
-    "commit": "016f79a",
+    "session_id": "cli-1785821127",
+    "timestamp": "2026-08-04T05:25:27Z",
+    "commit": "5b0df10",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:5bb32394e3dc523e4759764abe6270bca113da4c7e25c7ccc6ff95c572fcb0cf",
-      "updated": "2026-08-03T08:28:06Z",
-      "lines": 2042,
+      "checksum": "sha256:3cc8c331d864c7f4a5706841128dee61bb07eac5ca4a028b2e849ae6ea371cd9",
+      "updated": "2026-08-04T05:25:21Z",
+      "lines": 2092,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:5bb72551b8400d126ca551409cf62d1a141ff75681ed24ed61c6aca25d429a4f",
-      "updated": "2026-08-03T08:29:24Z",
+      "updated": "2026-08-03T08:35:07Z",
       "lines": 70,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:07965b6c546c96537b0556357f2d1c1998b32d6e8fe09b6f048444dd1a465fd4",
-      "updated": "2026-08-03T08:29:26Z",
+      "updated": "2026-08-04T05:25:27Z",
       "lines": 131,
       "summary": "(no summary available)"
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:8eedd300a98961d8f8e86dcdf57c681885aabc9ccae2e94e8361356fb4f27421",
-      "updated": "2026-08-03T08:29:26Z",
+      "updated": "2026-08-04T05:25:27Z",
       "lines": 67,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:86de506336d2e3560ae06bf742fe62a55a7d7ab1b9ffb7480fbc408edc866ce2",
-      "updated": "2026-08-03T08:29:26Z",
+      "updated": "2026-08-04T05:25:27Z",
       "lines": 49,
       "summary": "(no summary available)"
     },
@@ -80,7 +80,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 36833,
-    "full_read": 45429
+    "manifest_plus_core": 37618,
+    "full_read": 46214
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,53 @@
+> Note (2026-08-04, claude-opus-5, unreleased): Daily threat-intel run. 16 package IOCs
+> imported (15 npm, 1 PyPI) plus 6 non-package IOCs added by hand. No version bump; Emre
+> cuts the release.
+>
+> THE IMPORT NEEDED A SLICE, and the reason matters more than the number. A default run
+> reports 250 new entries and a 16,006-entry remainder, with the drain-aware cap correctly
+> calling that remainder unreachable before it ages out. It is not a new flood: all 16,006
+> are the PyPI and NuGet halves of the 2026-07-21 spike, which the standing decision (v5.24.0,
+> re-verified 2026-08-03 on a 25-package liveness sample) already excludes. Verified rather
+> than assumed, two ways: `--ecosystem npm` over the full window yields exactly the same 15
+> npm entries, and `--since 2026-07-22` over ALL ecosystems yields those 15 plus one genuine
+> PyPI entry. So the slice is strictly better than the ecosystem filter here - it keeps the
+> one real non-npm entry (`pypi:instalogin1234@0.0.1`) that `--ecosystem npm` would have
+> dropped. Nothing was left waiting behind `--limit`, and `--allow-backlog` was not used.
+>
+> THE SUBSTANCE OF THE RUN was the manual enrichment, not the import. The mrmustard PyPI
+> compromise is the kind of campaign the advisory databases reduce to a version string:
+> GHSA/OSV had `pypi:mrmustard@0.7.4` (already in the feed since the 2026-08-03 run), and
+> nothing else. The atomic indicators - exfil host, the CI-secret dead drop, the two poisoned
+> artifact hashes - exist only in the vendor write-ups. Both StepSecurity and safedep were
+> read, they agree, hence confidence 1.0.
+>
+> TWO DISCIPLINE CALLS, both deliberate and both worth not re-litigating:
+> - The breached maintainer's GitHub account is NOT blocked. The account was taken over; the
+>   human is a victim. A first pass over a Hacker News roundup surfaced a different handle
+>   for the same role, which is a second reason to keep maintainer handles out of this: the
+>   secondary sources do not even agree on which victim to name.
+> - `webhook[.]site` is listed only as the attacker's specific bin id, never the apex. It is
+>   a routine development tool; blocking the host would fire on ordinary debugging code.
+>   Same reasoning already applied to `oss-cn-beijing[.]aliyuncs[.]com` and `github[.]com`.
+>
+> HASH VERIFICATION, because WebFetch mangles long hex and a bad hash is unfalsifiable once
+> shipped. A web search summary asserted that one of the two hashes was the CLEAN 0.7.3
+> sdist, which would have been a false positive on every clean install. That claim was wrong,
+> and it was settled against PyPI's own JSON API rather than by re-reading the vendor page:
+> 0.7.4 is gone from PyPI (expected for malware), 0.7.3's real digests are different, and
+> neither vendor hash collides with any of the 24 artifacts across the 13 surviving releases.
+> Both hashes are also well-formed 64-char hex. Recorded because the search summary was
+> confident and wrong, and the registry is the authority here.
+>
+> ALSO CLOSED a one-line gap found while cross-referencing: the Alibaba dev-toolchain RAT
+> shipped 8 of its 9 OSS bucket paths in v5.24.0. The missing one is the native second-stage
+> binary (`.../aone-kit-update/aone-kit-update`), now added. Everything else in that campaign
+> - all 8 hashes, both C2 subdomains, the attacker GitHub account, all 18 packages - was
+> already covered.
+>
+> Five tests added to `campaigns.test.ts`, all through `scan()` rather than against pattern
+> constants: the 0.7.4 lockfile hit, the clean-0.7.3 negative, the C2 domain, the artifact
+> hash, and an unrelated-webhook.site-bin negative. Full-suite verdict comes from CI.
+
 > Note (2026-08-03, claude-opus-5): Released v5.25.0. Minor, not a patch: `--ecosystem` is
 > a new user-facing CLI flag on the importer. Ships that flag plus the 133 package IOCs from
 > PR #105; feed at 6,294 entries. PR #106 was merged first so the release met the zero-open-PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Added
+
+- **16 malicious package IOCs** imported from the GitHub Advisory Database
+  (CWE-506) and corroborated against OSV.dev: 15 npm and 1 PyPI, covering
+  2026-07-22 to 2026-08-04. 15 of the 16 are confirmed by both databases
+  (confidence 1.0). The window was sliced to start at 2026-07-22 on purpose: the
+  default 14-day window reaches back into the 2026-07-21 bulk-publication spike
+  and the importer reported a 16,006-entry remainder that cannot be drained
+  before it ages out. All 16,006 are the PyPI and NuGet halves of that spike,
+  which are already excluded by a standing, re-verified decision, and the slice
+  loses no npm coverage: an `--ecosystem npm` run over the full window returns
+  the same 15 npm entries.
+
+- **5 non-package IOCs for the mrmustard PyPI compromise** (StepSecurity +
+  safedep, July 2026), a campaign the advisory databases only describe as a
+  package version. An attacker took over a maintainer's GitHub account, probed
+  the project's self-hosted CI runners to steal its PyPI publishing token, and
+  published a poisoned `0.7.4` of XanaduAI's photonic quantum library. The
+  payload runs on every `import mrmustard`, harvests SSH private keys, AWS
+  credentials, Kubernetes configs, SLURM job queues and GPU inventories, and
+  installs three persistence mechanisms that survive `pip uninstall`. Added: the
+  exfiltration host `metrics[.]femboy[.]energy`, the `webhook[.]site` bin that
+  received the stolen CI secrets, the two poisoned 0.7.4 artifact hashes, and a
+  `0.7.4` version pin. The malicious code was injected into the published
+  artifacts only - the GitHub source was left clean - so the artifact hash is the
+  indicator the repository cannot provide. The breached maintainer account is
+  deliberately **not** blocked: that account is a victim of the takeover, not an
+  indicator. The `webhook[.]site` apex is not listed either - it is an ordinary
+  development tool, so only the attacker's specific bin id is an indicator. Both
+  artifact hashes were checked against every artifact of every mrmustard release
+  still on PyPI (24 files across 13 versions) and collide with none, so a clean
+  install cannot trip them, and only `0.7.4` is pinned: `0.7.3` and earlier and
+  the `1.0.0a` pre-releases stay clean.
+
+- **1 non-package IOC for the Alibaba developer toolchain RAT** (Socket, July
+  2026): the native second-stage binary staged in the attacker's OSS bucket
+  alongside the eight paths already shipped in v5.24.0. Scoped to the full bucket
+  path, never the shared `oss-cn-beijing[.]aliyuncs[.]com` gateway.
+
 ## [5.25.0] - 2026-08-03
 
 ### Added

--- a/feed.json
+++ b/feed.json
@@ -2,7 +2,7 @@
   "schema": 1,
   "package": "supply-chain-guard",
   "version": "5.25.0",
-  "entryCount": 6294,
+  "entryCount": 6315,
   "entries": [
     {
       "type": "domain",
@@ -51046,6 +51046,180 @@
       "confidence": 1,
       "source": "GHSA-6wp2-7xxw-m8c6, MAL-2026-11428",
       "firstSeen": "2026-08-02"
+    },
+    {
+      "type": "package",
+      "value": "internallib_v688",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-jvmj-rg3h-c654",
+      "firstSeen": "2026-08-04"
+    },
+    {
+      "type": "package",
+      "value": "pypi:instalogin1234@0.0.1",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-7929-ff6q-qmmh, MAL-2026-11503",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "internallib_v524",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-2wgh-22xm-wp5f, MAL-2026-11512",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "simple-date-formatter-new-1@1.0.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-83gm-93p7-wh7r, MAL-2026-11502",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "internallib_v568",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-f4rq-x75f-gx73, MAL-2026-11513",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "beaver-ui-header",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-qm7r-x5cp-5wc2, MAL-2026-11508",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "beaver-ui-items-with-more",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-qq8g-w3r7-rqp8, MAL-2026-11509",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "bigops-chat-messages",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-7fcf-754p-pfhv, MAL-2026-11511",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "beaver-ui-date-range-picker",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-x5q8-8mg7-8jvg, MAL-2026-11506",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "accounts-final-form",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-2rrw-8g3r-w44h, MAL-2026-11504",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "fluid-type-ui",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-4w4v-pw3v-q85q, MAL-2026-11136",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "accounts-loading-state",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-9pwq-f6rq-8q69, MAL-2026-11505",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "beaver-ui-layout",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-w259-8g6c-8ppr, MAL-2026-11510",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "lifestyle-test-utils",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-5f9f-jfwr-xxvp, MAL-2026-11514",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "beaver-ui-grid",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-xjhx-6v3c-9cqp, MAL-2026-11507",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "simple-date-formatter-util-5@1.0.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-rhm2-fwx3-922c, MAL-2026-11501",
+      "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "domain",
+      "value": "metrics.femboy.energy",
+      "severity": "critical",
+      "confidence": 1,
+      "campaign": "mrmustard PyPI Compromise",
+      "source": "StepSecurity, safedep",
+      "firstSeen": "2026-07-24"
+    },
+    {
+      "type": "url",
+      "value": "webhook.site/710babde-6ace-47fe-83f4-9688e6548df9",
+      "severity": "critical",
+      "confidence": 1,
+      "campaign": "mrmustard PyPI Compromise",
+      "source": "StepSecurity, safedep",
+      "firstSeen": "2026-07-24"
+    },
+    {
+      "type": "hash",
+      "value": "0404f8590fdaef95280c1d908068f31bf2321fe887faabf0c2329ba67c7203cb",
+      "severity": "critical",
+      "confidence": 1,
+      "campaign": "mrmustard PyPI Compromise",
+      "source": "safedep",
+      "firstSeen": "2026-07-24"
+    },
+    {
+      "type": "hash",
+      "value": "81f0d1291a975d012d1b892cf9967557fdbb1ad4e1ac0545702ad235ace1cac5",
+      "severity": "critical",
+      "confidence": 1,
+      "campaign": "mrmustard PyPI Compromise",
+      "source": "safedep",
+      "firstSeen": "2026-07-24"
+    },
+    {
+      "type": "url",
+      "value": "aone-kit.oss-cn-beijing.aliyuncs.com/aone-kit-update/aone-kit-update",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "AlibabaDevRAT",
+      "campaign": "Alibaba Dev Toolchain RAT",
+      "source": "Socket",
+      "firstSeen": "2026-07-29"
     }
   ]
 }

--- a/src/__tests__/campaigns.test.ts
+++ b/src/__tests__/campaigns.test.ts
@@ -3584,4 +3584,72 @@ describe("Campaign Signatures", () => {
       expect(finding, "a PyPI IOC must not fire on an npm dependency").toBeUndefined();
     });
   });
+
+  // =================================================================
+  // mrmustard PyPI compromise (July 2026)
+  // =================================================================
+
+  describe("mrmustard PyPI compromise (July 2026)", () => {
+    // mrmustard is a REAL XanaduAI library with a long clean history, so this is a
+    // version pin, not a name block. The negative test below is the one that matters:
+    // blocking the name would fire on every clean install of a legitimate project.
+    it("flags the poisoned 0.7.4 through a real scan of a Python lockfile", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "poetry.lock"),
+        '[[package]]\nname = "mrmustard"\nversion = "0.7.4"\ndescription = "quantum"\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => /mrmustard/.test(JSON.stringify(f)));
+      expect(finding, "PyPI lockfile must flag the poisoned mrmustard release").toBeDefined();
+      expect(finding?.severity).toBe("critical");
+    });
+
+    it("does NOT flag the clean 0.7.3 release", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "poetry.lock"),
+        '[[package]]\nname = "mrmustard"\nversion = "0.7.3"\ndescription = "quantum"\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => /mrmustard/.test(JSON.stringify(f)));
+      expect(finding, "only 0.7.4 is malicious - 0.7.3 must stay clean").toBeUndefined();
+    });
+
+    it("flags the credential exfiltration C2 domain", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "probe.js"),
+        'const endpoint = "https://metrics.femboy.energy/v1/collect";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_C2_DOMAIN");
+      expect(finding, "the mrmustard exfil host must be flagged").toBeDefined();
+      expect(finding?.severity).toBe("critical");
+    });
+
+    it("flags the poisoned 0.7.4 artifact hash", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "lock.js"),
+        'const sha = "0404f8590fdaef95280c1d908068f31bf2321fe887faabf0c2329ba67c7203cb";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_MALWARE_HASH");
+      expect(finding, "the poisoned sdist hash must be flagged").toBeDefined();
+    });
+
+    // webhook.site is an ordinary development tool. Only the attacker's bin id is an
+    // indicator, so an unrelated bin must not trip the scanner.
+    it("does NOT flag an unrelated webhook.site bin", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "debug.js"),
+        'const hook = "https://webhook.site/00000000-1111-2222-3333-444444444444";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => /webhook\.site/.test(JSON.stringify(f)));
+      expect(finding, "the webhook.site apex must not be blocked").toBeUndefined();
+    });
+  });
 });

--- a/src/ioc-blocklist.ts
+++ b/src/ioc-blocklist.ts
@@ -214,6 +214,15 @@ export const KNOWN_C2_DOMAINS: string[] = [
   // a whole, so neither parent host is listed.
   "openshield.canatrace.com",
   "nostop.go2cloud.org",
+
+  // mrmustard PyPI compromise (StepSecurity + safedep, July 2026). An attacker took over
+  // a maintainer's GitHub account, used the project's own self-hosted CI runners to steal
+  // its PyPI publishing token, and pushed a poisoned 0.7.4 whose payload runs on every
+  // `import mrmustard`. It collects SSH private keys, AWS credentials and Kubernetes
+  // configs - plus SLURM job queues and GPU inventories, so the target is research and HPC
+  // estates - and POSTs them here. Attacker subdomain only: femboy[.]energy is not listed
+  // on its own, and the exfil path /v1/collect is covered by the host entry.
+  "metrics.femboy.energy",
 ];
 
 // ---------------------------------------------------------------------------
@@ -381,6 +390,7 @@ export const KNOWN_DEAD_DROPS: string[] = [
   "aone-kit.oss-cn-beijing.aliyuncs.com/plugins/crypto.js",
   "aone-kit.oss-cn-beijing.aliyuncs.com/aone-kit-update/aone-kit.js",
   "aone-kit.oss-cn-beijing.aliyuncs.com/aone-kit-update/app.asar",
+  "aone-kit.oss-cn-beijing.aliyuncs.com/aone-kit-update/aone-kit-update",
   // Config dead-drops under the attacker GitHub account, saved locally as
   // .cloud-preferences.json and then evaluated by local-config-parser. Specific
   // account/repo paths only - never the github.com apex.
@@ -392,6 +402,13 @@ export const KNOWN_DEAD_DROPS: string[] = [
   // vpnsetup_d9gfqvs3dsic73fcvi90.exe. Path-scoped on purpose: the campaign path is
   // listed, never the freevpn[.]win host on its own.
   "freevpn.win/lps/gbox-lp/index.html",
+
+  // mrmustard PyPI compromise (StepSecurity + safedep, July 2026). The CI workflow the
+  // attacker pushed from the breached maintainer account dumped the repository secrets,
+  // including the PyPI publishing token, to this collector. Scoped to the single attacker
+  // bin: webhook[.]site is a legitimate request-inspection service used constantly in
+  // ordinary development, so the apex is deliberately NOT listed - only this bin id.
+  "webhook.site/710babde-6ace-47fe-83f4-9688e6548df9",
 ];
 
 // ---------------------------------------------------------------------------
@@ -665,6 +682,14 @@ export const KNOWN_MALICIOUS_HASHES: Record<string, string> = {
   "ae7565109fd01b88d82acf7f73ab20709cbc2c9f26fdea13e429ccc87a55d4fb": "Joyfill compromise: DEV#POPPER decoded detached bootstrap (SHA256)",
   "26e679eaf1e9baeb7c55eb48db482301171d4d26e1728544b23734a90dc70e1b": "Joyfill compromise: DEV#POPPER campaign artifact (SHA256)",
   "2cfede38fb121a71a2f3607474aa8cd588a99f51b37e5e6f0d8cb789fa275032": "Joyfill compromise: DEV#POPPER campaign artifact (SHA256)",
+
+  // mrmustard PyPI compromise (safedep, July 2026). The two poisoned 0.7.4 artifacts. The
+  // malicious code was injected into the published artifacts only - the GitHub source was
+  // left clean - so the release hash is the indicator that the repository cannot give you.
+  // Both were checked against every artifact of every mrmustard release still on PyPI (24
+  // files, 13 versions) and collide with none, so a clean install cannot trip these.
+  "0404f8590fdaef95280c1d908068f31bf2321fe887faabf0c2329ba67c7203cb": "mrmustard 0.7.4 poisoned sdist (SHA256)",
+  "81f0d1291a975d012d1b892cf9967557fdbb1ad4e1ac0545702ad235ace1cac5": "mrmustard 0.7.4 poisoned wheel (SHA256)",
 };
 
 // ---------------------------------------------------------------------------
@@ -1449,6 +1474,10 @@ export const KNOWN_BAD_PYPI_VERSIONS: Record<string, { versions: string[]; descr
   "litellm": {
     versions: ["1.82.7", "1.82.8"],
     description: "LiteLLM PyPI compromise (TeamPCP): litellm_init.pth auto-runs on Python startup; RSA-4096+AES-256 credential exfil to models.litellm.cloud; persistent backdoor polling checkmarx.zone every 50min (March 24, 2026; Trail of Bits write-up May 22, 2026)",
+  },
+  "mrmustard": {
+    versions: ["0.7.4"],
+    description: "mrmustard PyPI compromise: XanaduAI photonic quantum library; a breached maintainer GitHub account was used to steal the PyPI token via the project's self-hosted CI runners and publish a poisoned 0.7.4. A 258-line _check_tf_compatibility() in __init__.py runs on every import, steals SSH keys, AWS credentials, Kubernetes configs, SLURM queues and GPU inventories to metrics.femboy.energy, and installs three persistence mechanisms (a mmcompat.pth site-packages hook, a 15-minute cron entry and a shell rc hook) that survive pip uninstall. Legitimate package - only 0.7.4 is malicious; 0.7.3 and earlier and the 1.0.0a pre-releases are clean (StepSecurity + safedep, July 2026)",
   },
 };
 

--- a/src/threat-intel.ts
+++ b/src/threat-intel.ts
@@ -6812,6 +6812,36 @@ const FEED_CHUNK_6: FeedIOC[] = [
   { type: "package", value: "houzidawang806", severity: "critical", confidence: 1.0, source: "GHSA-7gf8-h22p-4qr4, MAL-2026-5729", firstSeen: "2026-08-02" },
   { type: "package", value: "pypi:trongriden@0.0.1", severity: "critical", confidence: 1.0, source: "GHSA-fgg6-xq4r-cp2h, MAL-2026-11429", firstSeen: "2026-08-02" },
   { type: "package", value: "pypi:wacve-utils@1.0.7", severity: "critical", confidence: 1.0, source: "GHSA-6wp2-7xxw-m8c6, MAL-2026-11428", firstSeen: "2026-08-02" },
+
+  // Imported from GitHub Advisory Database (2026-07-22) - see docs/threat-feed-sources.md
+  { type: "package", value: "internallib_v688", severity: "critical", confidence: 0.9, source: "GHSA-jvmj-rg3h-c654", firstSeen: "2026-08-04" },
+  { type: "package", value: "pypi:instalogin1234@0.0.1", severity: "critical", confidence: 1.0, source: "GHSA-7929-ff6q-qmmh, MAL-2026-11503", firstSeen: "2026-08-03" },
+  { type: "package", value: "internallib_v524", severity: "critical", confidence: 1.0, source: "GHSA-2wgh-22xm-wp5f, MAL-2026-11512", firstSeen: "2026-08-03" },
+  { type: "package", value: "simple-date-formatter-new-1@1.0.0", severity: "critical", confidence: 1.0, source: "GHSA-83gm-93p7-wh7r, MAL-2026-11502", firstSeen: "2026-08-03" },
+  { type: "package", value: "internallib_v568", severity: "critical", confidence: 1.0, source: "GHSA-f4rq-x75f-gx73, MAL-2026-11513", firstSeen: "2026-08-03" },
+  { type: "package", value: "beaver-ui-header", severity: "critical", confidence: 1.0, source: "GHSA-qm7r-x5cp-5wc2, MAL-2026-11508", firstSeen: "2026-08-03" },
+  { type: "package", value: "beaver-ui-items-with-more", severity: "critical", confidence: 1.0, source: "GHSA-qq8g-w3r7-rqp8, MAL-2026-11509", firstSeen: "2026-08-03" },
+  { type: "package", value: "bigops-chat-messages", severity: "critical", confidence: 1.0, source: "GHSA-7fcf-754p-pfhv, MAL-2026-11511", firstSeen: "2026-08-03" },
+  { type: "package", value: "beaver-ui-date-range-picker", severity: "critical", confidence: 1.0, source: "GHSA-x5q8-8mg7-8jvg, MAL-2026-11506", firstSeen: "2026-08-03" },
+  { type: "package", value: "accounts-final-form", severity: "critical", confidence: 1.0, source: "GHSA-2rrw-8g3r-w44h, MAL-2026-11504", firstSeen: "2026-08-03" },
+  { type: "package", value: "fluid-type-ui", severity: "critical", confidence: 1.0, source: "GHSA-4w4v-pw3v-q85q, MAL-2026-11136", firstSeen: "2026-08-03" },
+  { type: "package", value: "accounts-loading-state", severity: "critical", confidence: 1.0, source: "GHSA-9pwq-f6rq-8q69, MAL-2026-11505", firstSeen: "2026-08-03" },
+  { type: "package", value: "beaver-ui-layout", severity: "critical", confidence: 1.0, source: "GHSA-w259-8g6c-8ppr, MAL-2026-11510", firstSeen: "2026-08-03" },
+  { type: "package", value: "lifestyle-test-utils", severity: "critical", confidence: 1.0, source: "GHSA-5f9f-jfwr-xxvp, MAL-2026-11514", firstSeen: "2026-08-03" },
+  { type: "package", value: "beaver-ui-grid", severity: "critical", confidence: 1.0, source: "GHSA-xjhx-6v3c-9cqp, MAL-2026-11507", firstSeen: "2026-08-03" },
+  { type: "package", value: "simple-date-formatter-util-5@1.0.0", severity: "critical", confidence: 1.0, source: "GHSA-rhm2-fwx3-922c, MAL-2026-11501", firstSeen: "2026-08-03" },
+
+  // mrmustard PyPI compromise (StepSecurity + safedep, July 2026). Two independent
+  // vendors, so full confidence. The breached maintainer account is deliberately absent:
+  // that account is a victim, not an indicator.
+  { type: "domain", value: "metrics.femboy.energy", severity: "critical", confidence: 1.0, campaign: "mrmustard PyPI Compromise", source: "StepSecurity, safedep", firstSeen: "2026-07-24" },
+  { type: "url", value: "webhook.site/710babde-6ace-47fe-83f4-9688e6548df9", severity: "critical", confidence: 1.0, campaign: "mrmustard PyPI Compromise", source: "StepSecurity, safedep", firstSeen: "2026-07-24" },
+  { type: "hash", value: "0404f8590fdaef95280c1d908068f31bf2321fe887faabf0c2329ba67c7203cb", severity: "critical", confidence: 1.0, campaign: "mrmustard PyPI Compromise", source: "safedep", firstSeen: "2026-07-24" },
+  { type: "hash", value: "81f0d1291a975d012d1b892cf9967557fdbb1ad4e1ac0545702ad235ace1cac5", severity: "critical", confidence: 1.0, campaign: "mrmustard PyPI Compromise", source: "safedep", firstSeen: "2026-07-24" },
+
+  // Alibaba developer toolchain RAT (Socket, July 2026). The native second-stage binary
+  // staged next to aone-kit.js and app.asar; the other eight bucket paths shipped earlier.
+  { type: "url", value: "aone-kit.oss-cn-beijing.aliyuncs.com/aone-kit-update/aone-kit-update", severity: "critical", confidence: 0.85, family: "AlibabaDevRAT", campaign: "Alibaba Dev Toolchain RAT", source: "Socket", firstSeen: "2026-07-29" },
 ];
 
 // Composed from the chunks above. A single array literal of this size trips


### PR DESCRIPTION
Daily threat-intel run. 16 package IOCs imported, 6 non-package IOCs added by hand. No version bump - the version belongs to the release.

Feed: 6,294 -> 6,315 entries.

## Package IOCs (importer, 16)

GitHub Advisory Database (CWE-506), corroborated against OSV.dev. 15 npm, 1 PyPI; 15 of 16 confirmed by both databases (confidence 1.0).

`internallib_v524`, `internallib_v568`, `internallib_v688`, `simple-date-formatter-new-1@1.0.0`, `simple-date-formatter-util-5@1.0.0`, `beaver-ui-header`, `beaver-ui-items-with-more`, `beaver-ui-date-range-picker`, `beaver-ui-layout`, `beaver-ui-grid`, `bigops-chat-messages`, `accounts-final-form`, `accounts-loading-state`, `fluid-type-ui`, `lifestyle-test-utils`, `pypi:instalogin1234@0.0.1`

## Non-package IOCs (manual, 6)

### mrmustard PyPI compromise (5)

Sources: [StepSecurity](https://www.stepsecurity.io/blog/compromised-pypi-mrmustard-0-7-4-credential-stealer) and [safedep](https://safedep.io/mrmustard-malicious-pypi-package/), two independent vendors, hence confidence 1.0.

An attacker took over a maintainer's GitHub account, probed the project's self-hosted CI runners to steal the PyPI publishing token, and published a poisoned `0.7.4` of XanaduAI's photonic quantum library. The payload is a 258-line `_check_tf_compatibility()` in `__init__.py` that runs on every `import mrmustard`, harvests SSH private keys, AWS credentials, Kubernetes configs, SLURM job queues and GPU inventories, and installs three persistence mechanisms (a `mmcompat.pth` site-packages hook, a 15-minute cron entry, a shell rc hook) that survive `pip uninstall`. The rest of the release is byte-identical to clean 0.7.3.

| Indicator | Type |
| --- | --- |
| `metrics[.]femboy[.]energy` | C2 domain (`KNOWN_C2_DOMAINS`) |
| `webhook[.]site/710babde-6ace-47fe-83f4-9688e6548df9` | dead drop for the stolen CI secrets (`KNOWN_DEAD_DROPS`) |
| `0404f8590fdaef95280c1d908068f31bf2321fe887faabf0c2329ba67c7203cb` | poisoned 0.7.4 sdist (SHA-256) |
| `81f0d1291a975d012d1b892cf9967557fdbb1ad4e1ac0545702ad235ace1cac5` | poisoned 0.7.4 wheel (SHA-256) |
| `mrmustard` `0.7.4` | `KNOWN_BAD_PYPI_VERSIONS` pin |

The malicious code was injected into the published artifacts only - the GitHub source was left clean - so the artifact hash is the indicator the repository cannot provide.

### Alibaba developer toolchain RAT (1)

`aone-kit[.]oss-cn-beijing[.]aliyuncs[.]com/aone-kit-update/aone-kit-update` - the native second-stage binary. Eight of this campaign's nine bucket paths shipped in v5.24.0; this one was missing. Everything else in the campaign (all 8 hashes, both C2 subdomains, the attacker GitHub account, all 18 packages) was already covered.

## Why the window was sliced

A default run reports 250 new entries and a **16,006-entry remainder**, with the drain-aware cap correctly refusing to exit clean because that remainder cannot be drained before it ages out.

It is not a new flood. All 16,006 are the PyPI and NuGet halves of the 2026-07-21 bulk-publication spike, already excluded by the standing decision recorded in v5.24.0 and re-verified on 2026-08-03 (PyPI 0/25 and NuGet 2/25 still installable, npm 25/25).

Verified two ways rather than assumed:

- `--ecosystem npm` over the full 14-day window returns exactly the same 15 npm entries.
- `--since 2026-07-22` over **all** ecosystems returns those 15 plus one genuine PyPI entry.

So the slice is strictly better than the ecosystem filter here: it keeps `pypi:instalogin1234@0.0.1`, which `--ecosystem npm` would have dropped. Nothing was left waiting behind `--limit`, `--allow-backlog` was not used, and the page cap was not hit.

**Nothing was reported as unmappable in the imported slice.** The skip counts across the window were 7 `unmappable-version-range` (bounded ranges the scanner cannot resolve), 22 `unsafe-package-name` and 2 `withdrawn`.

## False-positive discipline

- **The breached maintainer account is not blocked.** The account was taken over; the human is a victim. A Hacker News roundup surfaced a *different* handle for the same role than the two primary vendors did, which is a second reason to keep maintainer handles out of the blocklist entirely - the secondary sources do not agree on which victim to name.
- **`webhook[.]site` apex is not listed**, only the attacker's specific bin id. It is an ordinary development tool and blocking the host would fire on routine debugging code. A negative test covers this.
- **`oss-cn-beijing[.]aliyuncs[.]com` apex is not listed**, only full bucket paths. Same reasoning as the existing entries.
- **`ifconfig[.]me`**, used by the payload for public-IP lookup, is not listed: legitimate shared service.
- **Only `0.7.4` is pinned.** `mrmustard` is a real library with a long clean history; `0.7.3` and earlier and the `1.0.0a` pre-releases stay clean. A negative test covers this.

## Hash verification

WebFetch mangles long hex strings, so the two hashes were not taken on trust. A web search summary asserted that `0404f859...` was the **clean 0.7.3 sdist** - which, if true, would have meant a false positive on every clean install. That claim is wrong, and it was settled against PyPI's own JSON API rather than by re-reading the vendor page:

- `0.7.4` is gone from PyPI (expected for malware), so it cannot be hashed directly.
- `0.7.3`'s real digests are `972faa06...` (sdist) and `09781b24...` (wheel) - neither vendor hash.
- Neither vendor hash collides with **any** of the 24 artifacts across the 13 surviving `mrmustard` releases.
- Both are well-formed 64-character hex.

## Verification

- `npm run build` green: all 7 `aahp check` gates, `check:feed`, `check:handoff`, `tsc`.
- Targeted suites green locally: `feed`, `threat-intel`, `campaigns`, `ioc-blocklist`, `feed-import`, `python-lockfile-scanner` - 401 tests. The full suite is not run locally on Windows by policy; **CI on this PR is the authoritative full-suite verdict.**
- Five tests added to `campaigns.test.ts`, all driven through `scan()` rather than asserted against pattern constants: the 0.7.4 lockfile hit, the clean-0.7.3 negative, the C2 domain, the artifact hash, and an unrelated-`webhook.site`-bin negative.
- Mutation-proved rather than assumed green: removing the C2 domain and the hash turns their tests red. The 0.7.4 detection was checked on both paths independently - it survives removal of the `KNOWN_BAD_PYPI_VERSIONS` pin (the feed entry catches it) and survives removal of the feed entry (the pin catches it), so both are live and neither is dead weight.

## Needs a decision

Nothing blocking in this PR. One item carried forward from the previous run, unchanged and still not a release task:

- Whether known scanner-testbed corpora (`@gocortexio/npmgremlinbox-*`, `vybscan-testbed-*`) should be ingested at all. Current answer is yes, because filtering them means maintaining a list of "malware we choose not to flag". None of this run's 16 entries are testbed corpora, so this does not affect the numbers above.
