### PR TITLE
docs(handoff): record v5.25.1 handoff state

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,28 +3,28 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1785822037",
-    "timestamp": "2026-08-04T05:40:38Z",
-    "commit": "6df7896",
+    "session_id": "cli-1785822835",
+    "timestamp": "2026-08-04T05:53:55Z",
+    "commit": "28bbd9f",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:da741f3cdbf1ec735858be2a2603482af894e8d6b1faf05d74119c3a051c89fb",
-      "updated": "2026-08-04T05:38:46Z",
-      "lines": 2114,
+      "checksum": "sha256:260f3416f13cfa0c8bdc425595e4fb5f03ef28a4ce5b24b78b3d1afcb6a88c3a",
+      "updated": "2026-08-04T05:53:48Z",
+      "lines": 2155,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:b76e8fdaa4e5557627b330286441ef230aac425c248925fe92c6caa85aa1f5da",
-      "updated": "2026-08-04T05:40:17Z",
+      "updated": "2026-08-04T05:43:23Z",
       "lines": 70,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:e5ff0a1aefc1ed3f4103774391b133c6e441b626366be3e612429843bedd1cdf",
-      "updated": "2026-08-04T05:40:37Z",
+      "updated": "2026-08-04T05:53:55Z",
       "lines": 132,
       "summary": "(no summary available)"
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:996aa26cecbae699857b22d34c540755d49109faed9da20c6d53e29c314c8541",
-      "updated": "2026-08-04T05:40:37Z",
+      "updated": "2026-08-04T05:53:55Z",
       "lines": 67,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:fb9917b18371e7687d1107953100889009552a5e2f2687e7b15fd04a7f52e532",
-      "updated": "2026-08-04T05:40:37Z",
+      "updated": "2026-08-04T05:53:55Z",
       "lines": 49,
       "summary": "(no summary available)"
     },
@@ -80,7 +80,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 37954,
-    "full_read": 46560
+    "manifest_plus_core": 38560,
+    "full_read": 47166
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,44 @@
+> HANDOFF (2026-08-04, claude-opus-5). Read this first; the note below has the reasoning
+> behind each decision.
+>
+> STATE: clean. `main` == tag `v5.25.1` == `v5` branch == npm `latest`. Zero open PRs, zero
+> open issues. Nothing is half-finished and nothing needs picking up.
+>
+> THE RELEASE WAS VERIFIED AGAINST npm, NOT AGAINST THE GREEN PIPELINE. A passing CI run
+> only proves the workflow ran. What was actually checked: the published tarball was
+> installed from the registry and pointed at real fixtures. `mrmustard@0.7.4` in a
+> `poetry.lock` is flagged CRITICAL through BOTH paths (`IOC_KNOWN_BAD_VERSION` from the
+> blocklist pin and `PYTHON_MALICIOUS_PACKAGE` from the bundled feed), and clean `0.7.3`
+> produces zero mentions. Worth repeating on future releases: it costs about a minute and it
+> is the only check that proves the shipped artifact detects what the changelog claims.
+>
+> ONE LIVE DECISION FOR EMRE, and it will come back on its own: `@babel/parser` 8 cannot be
+> merged while CI pins Node 20 (babel 8 wants `^22.18.0 || >=24.11.0`). Dependabot PR #109
+> was closed with that reasoning, and dependabot WILL reopen it. Do not merge it on sight.
+> Taking it means raising `node-version` in both `ci.yml` jobs AND `engines` in
+> `package.json` together, which is a support-matrix change and Emre's call. Details in the
+> note below and in the closing comment on #109.
+>
+> FOR THE NEXT DAILY RUN, one prediction worth checking rather than trusting: the 2026-07-21
+> bulk-publication spike should fall out of the default `--days 14` window on 2026-08-05, so
+> the 16,006-entry backlog and the drain-aware cap error should simply stop appearing and no
+> slicing should be needed. If a default `npm run feed:import -- --dry-run` still reports a
+> five-figure remainder after that date, it is a NEW spike and not this one, so re-verify
+> before reusing the standing exclusion. Either way: never pass `--allow-backlog` or
+> `--allow-truncated` to make the run exit clean, and never raise `--limit` to force a
+> machine-generated four-figure diff into a public repo.
+>
+> STANDING DECISIONS CARRIED FORWARD, do not re-litigate without new evidence: the PyPI and
+> NuGet halves of the 2026-07-20/21 spike (~20,800 rows) stay out, and known scanner-testbed
+> corpora (`@gocortexio/npmgremlinbox-*`, `vybscan-testbed-*`) are still ingested on purpose.
+> The second one is the only open question of substance and it is a judgement call for Emre,
+> not a release task: filtering testbeds means maintaining a list of "malware we choose not
+> to flag". None of v5.25.1's entries were testbed corpora.
+>
+> ALSO STILL OPEN, unchanged and not a release task: the vscode-scanner is purely
+> behavioural, so a known-bad extension ID has nowhere to live in the IOC model. That is a
+> data-model change.
+
 > Note (2026-08-04, claude-opus-5): Released v5.25.1. Patch, not a minor: the release is
 > IOC data plus two dev/build-time dependency bumps, with no new flag or user-facing
 > behaviour. Precedent checked rather than assumed - v5.23.5 shipped 250 package IOCs AND a


### PR DESCRIPTION
Docs only. No version change, no code change - `.ai/handoff/STATUS.md` plus the generated handoff files it invalidates.

Records the post-release state for the next agent:

- `main` == tag `v5.25.1` == `v5` branch == npm `latest`; zero open PRs and zero open issues.
- The release was verified by installing the published package from npm and scanning real fixtures, not by trusting the green pipeline. `mrmustard@0.7.4` is flagged CRITICAL through both detection paths; clean `0.7.3` produces zero mentions.
- Dependabot #109 (`@babel/parser` 8) will reopen on its own and must not be merged while CI pins Node 20. Taking it requires raising `node-version` in both jobs and `engines` together, which is Emre's call.
- A checkable prediction for the next daily run: the 2026-07-21 spike should leave the default `--days 14` window on 2026-08-05, so the 16,006-entry backlog should stop appearing without any slicing. If a five-figure remainder still shows up after that date it is a NEW spike, so the standing exclusion must be re-verified rather than reused.
- Standing decisions carried forward, with the testbed-corpora question flagged as the one open item of substance.
