### PR TITLE
fix(action): explain a recovered clean scan instead of posting a blank line

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,28 +3,28 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1785918704",
-    "timestamp": "2026-08-05T08:31:44Z",
-    "commit": "74830f2",
+    "session_id": "cli-1785919908",
+    "timestamp": "2026-08-05T08:51:48Z",
+    "commit": "e7effc4",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:cb92ba8469ed258958196b0133706d9b95e2a48225611c344fbf7032dba14bc6",
-      "updated": "2026-08-05T08:31:30Z",
-      "lines": 196,
+      "checksum": "sha256:cd280117150cc66bf3837d375c27dac20d0ad60bce6af3286a9c33ba51f39937",
+      "updated": "2026-08-05T08:51:34Z",
+      "lines": 211,
       "summary": "v5.25.3 was published and the 2026-08-05 threat-intel run has since landed on"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:3709f6c26a406d7db4bdd36349b4f6abab1d97167b867ec90087f2696f61ca7c",
-      "updated": "2026-08-05T08:30:27Z",
+      "updated": "2026-08-05T08:35:30Z",
       "lines": 164,
       "summary": "Five tasks are ready, one owner decision is blocked, and T-008/T-015 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:4c7c05f75679c8ba2641519b0cf8a7ffb4ccbd2f11b9ac22e197b5410acaefe9",
-      "updated": "2026-08-05T08:31:44Z",
+      "updated": "2026-08-05T08:51:47Z",
       "lines": 137,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:5dfa918495471b0ffee209970cb897731446793ece4dd2dd99141cd620192b2b",
-      "updated": "2026-08-05T08:31:44Z",
+      "updated": "2026-08-05T08:51:47Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:561b706dd7252b5bd815a6619e4360fcecf309833defcbd75b095df85debd6db",
-      "updated": "2026-08-05T08:31:44Z",
+      "updated": "2026-08-05T08:51:47Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
@@ -80,8 +80,8 @@
   "quick_context": "v5.25.3 was published and the 2026-08-05 threat-intel run has since landed on Five tasks are ready, one owner decision is blocked, and T-008/T-015 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3346,
-    "full_read": 13200
+    "manifest_plus_core": 3553,
+    "full_read": 13407
   }
   ,"next_task_id": 16
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -16,7 +16,7 @@ ChainDrop indicators, and three Windows-only handoff-gate fixes.
 |-------|---------------|
 | Released package | v5.25.3 on npm |
 | Release commit | 56137d4 |
-| Release target | v5.25.4 |
+| Release target | v5.25.4 released; next is unreleased Action comment fix |
 | Merged implementation | 74830f2, PR #117 |
 | Working branch base | 74830f2 |
 | Threat feed | 6,588 entries, feed.json current |
@@ -170,6 +170,21 @@ the tool and owns the full-suite result.
 ---
 
 ## Live Decisions and Remaining Work
+
+### Action PR-comment fallback (fixed, unreleased)
+
+`action.yml` guarded `reportForComment` on its own indented value. Indenting an empty
+report produces four spaces, which is truthy, so the clean-scan fallback at the end of
+the detail chain was unreachable and the three `if (reportForComment)` guards always
+fired. Verified by execution, not by reading: an empty report is reachable through a
+failed report read or an empty file, and the visible effect is a blank indented line
+where the clean explanation belongs. The verdict line is separate, so no comment ever
+claimed clean when it was not - degraded, never falsely reassuring.
+
+Reachability is narrower than it first looked: a first clean scan posts no comment at
+all, so this only appeared when a stale findings or partial comment was replaced on the
+return to clean. Two scanner-level tests now drive the real comment script through the
+update path; both fail against the previous guard.
 
 - T-009: implement cryptographic offline DSSE, Fulcio-chain, and Rekor inclusion
   verification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Fixed
+
+- The Action's PR comment now explains a recovered clean scan instead of posting a
+  blank line. `reportForComment` was guarded on its own indented value, and indenting
+  an empty report yields four spaces, which is truthy - so the clean-scan fallback was
+  unreachable and every `if (reportForComment)` guard always fired. It surfaced only
+  when a stale findings or partial comment was replaced on the return to clean, which
+  is exactly when the reader needs to be told the run came back clean. An empty report
+  is reachable through a failed report read or an empty report file. The verdict line
+  was never affected, so no comment ever claimed clean when it was not.
+
 ## [5.25.4] - 2026-08-05
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -417,10 +417,17 @@ runs:
           // Treat every scanner-rendered line as inert code. Even the Markdown
           // formatter contains package-controlled text, which must not create
           // links, images, headings, mentions, or other active PR content.
+          // Guard on the SOURCE, not the indented result. Indenting an empty
+          // report yields '    ', which is truthy, so every `if (reportForComment)`
+          // below would fire and the clean-scan fallback would be unreachable -
+          // a run that recovered to clean would replace a stale warning comment
+          // with a blank indented line instead of saying so.
           let reportForComment = escapedReport
-            .split(/\r?\n/)
-            .map((line) => `    ${line}`)
-            .join('\n');
+            ? escapedReport
+                .split(/\r?\n/)
+                .map((line) => `    ${line}`)
+                .join('\n')
+            : '';
           if (reportReadTruncated && reportForComment) {
             reportForComment += '\n\n> Report excerpt truncated before comment construction.';
           }

--- a/src/__tests__/action-partial-scan.test.ts
+++ b/src/__tests__/action-partial-scan.test.ts
@@ -313,6 +313,35 @@ describe("Marketplace Action fail-closed contract", () => {
     expect(calls.created?.body).not.toContain("no reportable malicious indicators detected");
   });
 
+  // An empty report indents to "    " (four spaces), which is truthy. Guarding on
+  // the indented string instead of the source made the clean-scan fallback
+  // unreachable and every `if (reportForComment)` guard always true. A first clean
+  // scan posts nothing at all, so this only surfaces when a stale finding or
+  // partial comment is replaced on the return to clean - which is exactly when the
+  // reader most needs to be told the run came back clean.
+  it("explains the clean result when replacing a stale comment and the report cannot be read", async () => {
+    const calls = await runCommentScenario({
+      reportValid: true,
+      findingsCount: 0,
+      outcome: "success",
+      existingBody: "## supply-chain-guard Scan Report\n\n> WARNING: Findings were detected.",
+      // report omitted: the file is never written, so the read throws and the
+      // script falls back to an empty report string.
+    });
+    expect(calls.updated?.body).toContain("no reportable malicious indicators detected");
+  });
+
+  it("explains the clean result when replacing a stale comment and the report is empty", async () => {
+    const calls = await runCommentScenario({
+      report: "   \n  ",
+      reportValid: true,
+      findingsCount: 0,
+      outcome: "success",
+      existingBody: "## supply-chain-guard Scan Report\n\n> WARNING: Scan incomplete.",
+    });
+    expect(calls.updated?.body).toContain("no reportable malicious indicators detected");
+  });
+
   it("lets canonical partial metadata override a contradictory formatted report", async () => {
     const calls = await runCommentScenario({
       report: "Formatter claimed clean",


### PR DESCRIPTION
## The defect

`action.yml` built the PR-comment body with:

```js
let reportForComment = escapedReport.split(/\r?\n/).map((line) => `    ${line}`).join('\n');
```

Indenting an **empty** report yields `'    '` - four spaces, which is truthy. So the clean-scan fallback

```js
`${canonicalLine}\n\n${reportForComment || '> Complete scan: no reportable malicious indicators detected.'}`
```

was unreachable, and all three `if (reportForComment)` guards always fired.

Verified by execution, not by reading:

```
''.split(/\r?\n/).map(l => '    '+l).join('\n')  ->  "    "   truthy=true  len=4
```

An empty report is reachable two ways: the bounded read throws and leaves the empty default (`action.yml:393-407`), or the file is empty after `.trim()`.

## Impact, stated precisely

**Degraded, never falsely reassuring.** The canonical verdict line is built separately and was unaffected, so no comment ever claimed clean when it was not. The visible effect is a blank indented line where the explanation belongs.

Reachability is also narrower than it first looks, and this is worth recording: a **first** clean scan posts no comment at all (`if (clean && !botComment) return`). The bug only surfaces when a stale findings or partial comment is **replaced on the return to clean** - which is precisely the moment the reader needs to be told the run came back clean.

## The fix

Guard on the source string rather than the indented result.

## Tests

Two cases added to `action-partial-scan.test.ts`, driving the **real** comment script through the update path (unreadable report, and empty report file). Both fail against the previous guard and pass with it; the suite is 15 passed / 3 skipped.

`npm run build` green (7 governance gates), `aahp verify --level ci` green, targeted suites 131 passed.