### PR TITLE
feat(threat-intel): IOCs for 2026-08-09

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,28 +3,28 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1786181104",
-    "timestamp": "2026-08-08T09:25:04Z",
-    "commit": "3ce421d",
+    "session_id": "cli-1786252612",
+    "timestamp": "2026-08-09T05:16:53Z",
+    "commit": "7afaedc",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:b56cebc51203f817d139a89d445bd33dd9eecc3531d1df8e8497fe5a9a52e708",
-      "updated": "2026-08-08T09:24:57Z",
-      "lines": 609,
-      "summary": "Model: claude-opus-5. Scheduled daily advisory sweep, merged as #126. The sweep"
+      "checksum": "sha256:fd43504b6f338b7917341abd427047ad4f0e7ee4113209ba09ec322126dc689e",
+      "updated": "2026-08-09T05:16:26Z",
+      "lines": 656,
+      "summary": "Model: claude-opus-5. Scheduled daily advisory sweep. Base: 7afaedc (main,"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:a65304ce758e960231c7d80f7712d928dbd27e43d62750aeef2a2c4a489d77fe",
-      "updated": "2026-08-08T09:23:58Z",
+      "updated": "2026-08-08T09:28:06Z",
       "lines": 242,
       "summary": "Six tasks are ready, two owner decisions are blocked, and T-008/T-015 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:b2b8e1469492b57b4adb3c469c22af41d4a685fb48ccf6056bbb8e346f149814",
-      "updated": "2026-08-08T09:25:03Z",
+      "updated": "2026-08-09T05:16:52Z",
       "lines": 141,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:ec4df4ec28bee63d60fd7b8604d70c7ce2de9767c1891e511cf0177bc398d5e7",
-      "updated": "2026-08-08T09:25:03Z",
+      "updated": "2026-08-09T05:16:52Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:8f4aa23f0408ad5fad8c668d248baefb7baf1c1a8cb13cb4d9ae164064d3f3e5",
-      "updated": "2026-08-08T09:25:03Z",
+      "updated": "2026-08-09T05:16:52Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Scheduled daily advisory sweep, merged as #126. The sweep Six tasks are ready, two owner decisions are blocked, and T-008/T-015 are complete. ",
+  "quick_context": "Model: claude-opus-5. Scheduled daily advisory sweep. Base: 7afaedc (main, Six tasks are ready, two owner decisions are blocked, and T-008/T-015 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 8842,
-    "full_read": 18791
+    "manifest_plus_core": 9365,
+    "full_read": 19314
   }
   ,"next_task_id": 18
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,17 +3,17 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1786252612",
-    "timestamp": "2026-08-09T05:16:53Z",
-    "commit": "7afaedc",
+    "session_id": "cli-1786267280",
+    "timestamp": "2026-08-09T09:21:21Z",
+    "commit": "ae83655",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:fd43504b6f338b7917341abd427047ad4f0e7ee4113209ba09ec322126dc689e",
-      "updated": "2026-08-09T05:16:26Z",
-      "lines": 656,
+      "checksum": "sha256:c533ad977412ae544125e132334d9e585532583ced086ade552a54e3b667476c",
+      "updated": "2026-08-09T09:20:45Z",
+      "lines": 677,
       "summary": "Model: claude-opus-5. Scheduled daily advisory sweep. Base: 7afaedc (main,"
     },
     "NEXT_ACTIONS.md": {
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:b2b8e1469492b57b4adb3c469c22af41d4a685fb48ccf6056bbb8e346f149814",
-      "updated": "2026-08-09T05:16:52Z",
+      "updated": "2026-08-09T09:21:20Z",
       "lines": 141,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:ec4df4ec28bee63d60fd7b8604d70c7ce2de9767c1891e511cf0177bc398d5e7",
-      "updated": "2026-08-09T05:16:52Z",
+      "updated": "2026-08-09T09:21:20Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:8f4aa23f0408ad5fad8c668d248baefb7baf1c1a8cb13cb4d9ae164064d3f3e5",
-      "updated": "2026-08-09T05:16:52Z",
+      "updated": "2026-08-09T09:21:20Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
@@ -80,8 +80,8 @@
   "quick_context": "Model: claude-opus-5. Scheduled daily advisory sweep. Base: 7afaedc (main, Six tasks are ready, two owner decisions are blocked, and T-008/T-015 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 9365,
-    "full_read": 19314
+    "manifest_plus_core": 9630,
+    "full_read": 19579
   }
   ,"next_task_id": 18
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -45,11 +45,32 @@ axios maintainer account, who is a victim. `dl[.]wel1[.]ru` is listed once rathe
 than as five rows because domain matching is an unanchored substring test, so one
 entry covers the published platform subdomains without each double-reporting.
 
-**Open question for Emre.** Aikido lists a second attacker-controlled account,
-`nrwise` (`nrwise[@]proton[.]me`), alongside the hijacked axios maintainer. It is
-not clear from the write-up whether that is a GitHub handle or an npm publisher
-account, and `KNOWN_MALICIOUS_GITHUB_ACCOUNTS` is GitHub-only, so it was left out
-rather than filed in the wrong namespace. See the PR body.
+**`nrwise` resolved - do NOT add it, and do not re-open this next run.** Aikido
+lists a second attacker-controlled account, `nrwise` (`nrwise[@]proton[.]me`),
+alongside the hijacked axios maintainer. It was initially left out as an open
+question; it is now settled as a deliberate non-addition, on three independent
+grounds:
+
+- *The matcher makes it worthless.* `KNOWN_MALICIOUS_GITHUB_ACCOUNTS` is matched
+  as `github\.com/<account>\b`, so it only ever fires on a github.com URL in
+  scanned content. `github[.]com/nrwise` has ZERO public repositories, so no such
+  URL exists to be referenced. Detection value is exactly zero, not merely small.
+- *The account points away from the attacker.* It has been dormant since 2013
+  with no public repos and 2 followers. npm and GitHub are separate namespaces, so
+  an identical handle implies no connection; an abandoned 13-year-old account fits
+  an unrelated person who grabbed a short name far better than infrastructure
+  stood up for a March 2026 npm publish. Aikido's context (a proton[.]me address,
+  an npm-publishing attack) indicates their `nrwise` is the npm publisher account.
+  The aged-account-takeover reading cannot be excluded, but it changes nothing:
+  with no public repos there is still nothing to detect.
+- *There is nowhere correct to file an npm handle anyway.* No npm-account
+  collection exists in this codebase - `KNOWN_MALICIOUS_GITHUB_ACCOUNTS` is the
+  only account list. And the three packages involved (`axios@1.14.1`,
+  `axios@0.30.4`, `plain-crypto-js@4.2.1`) are already version-pinned, so the
+  handle would add no coverage. Same reasoning as `ch4ce` in the 2026-08-08 run.
+
+The asymmetry is one-sided: no detection gained, against a real risk of flagging a
+live account belonging to an actual person.
 
 ---
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,8 +1,55 @@
 # supply-chain-guard: Current State
 
-> Updated 2026-08-08 (threat-intel sweep). This is one current snapshot, not a session log.
+> Updated 2026-08-09 (threat-intel sweep). This is one current snapshot, not a session log.
 > Historical detail belongs in CHANGELOG.md, generated LOG.md,
 > LOG-ARCHIVE.md, and git history.
+
+---
+
+## Threat-intel run (2026-08-09, PR open, no version bump)
+
+Model: claude-opus-5. Scheduled daily advisory sweep. Base: 7afaedc (main,
+post-v5.25.8). Repo was clean with zero open PRs, so no concurrent-writer
+conflict. No version bump on this branch by design: Emre cuts the release.
+
+**Importer.** 64 new package IOCs (62 npm, 2 PyPI) in one standard pass over the
+rolling 14-day window. 4,492 advisories fetched over 45 pages, 16 corroborated by
+OSV. The page cap was NOT hit, so no window slicing and no `--allow-truncated`.
+The `--limit 250` cap was NOT reached either (`remaining: 0`, `undrainable: 0`),
+so unlike the last two runs nothing is left waiting. 158 advisories were skipped
+by design (149 withdrawn, 7 unmappable version range, 2 unsafe package name); the
+JSON report carries only counts for those, not per-advisory detail.
+
+**Manual enrichment (STEP 1b).** The headline campaign of the week, the
+keyv/cacheable ChainDrop worm, needed nothing: the 2026-08-07 and 2026-08-08 runs
+had already ingested its hashes, C2, wallet and package pins, including the
+judgement calls (cloud metadata IPs excluded, the `file-entry-cache@11.1.7`
+vendor discrepancy resolved against the registry). Three genuine gaps were filled
+instead:
+
+- **Flooding Dropper / WEL1DROPPER** (2026-08-07, ~850 packages). The feed already
+  held 78 `bigops` and 134 `dolyame` package entries from the advisory databases,
+  but none of the delivery infrastructure. Added 8 Cloudflare Worker sub-hosts, the
+  DNS-fallback host `dl[.]wel1[.]ru`, and 2 payload hashes.
+- **axios / UNC1069** (2026-03-31). Versions were already pinned; the C2, its
+  resolver IP and the 3 implant hashes were not.
+- **spellcheckpy / spellcheckerpy** (2026-01-20). Never ingested at all. Backfilled
+  as bare-name PyPI blocks plus host and IP. Single-source, confidence 0.85.
+
+**Deliberate non-additions.** The `workers[.]dev` apex; `nexus[.]tcsbank[.]ru`,
+`repo-linux[.]tcsbank[.]ru` and `alertmanager[.]cloudpayments[.]ru` (real Russian
+financial-services hosts that OpenSourceMalware embeds with an explicitly UNCLEAR
+role - health check, decoy, or compromised third party); the Cloudflare anycast
+address `104[.]21[.]35[.]216` published for the ChainDrop router; and the hijacked
+axios maintainer account, who is a victim. `dl[.]wel1[.]ru` is listed once rather
+than as five rows because domain matching is an unanchored substring test, so one
+entry covers the published platform subdomains without each double-reporting.
+
+**Open question for Emre.** Aikido lists a second attacker-controlled account,
+`nrwise` (`nrwise[@]proton[.]me`), alongside the hijacked axios maintainer. It is
+not clear from the write-up whether that is a GitHub handle or an npm publisher
+account, and `KNOWN_MALICIOUS_GITHUB_ACCOUNTS` is GitHub-only, so it was left out
+rather than filed in the wrong namespace. See the PR body.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Added
+
+- Threat feed: 64 malicious-package IOCs imported from the GitHub Advisory Database with
+  OSV.dev corroboration (2026-08-09 sweep, 62 npm and 2 PyPI). 4,492 advisories were fetched
+  over 45 pages; the page cap was not hit, no `--allow-truncated` or `--allow-backlog`
+  override was used, and the `--limit 250` cap was not reached, so nothing is left waiting
+  for the next run. The batch continues the `bnpl-*` / `statist-browser-typed-client-*`
+  dependency-confusion waves, adds a `@yancyyu/agentcli` version sweep (25 releases), a
+  `sextant-cli-*` per-platform binary cluster, a `svelte`/`streak` map-kit typosquat set,
+  and PyPI `riakcs`.
+- IOC blocklist: network infrastructure for the Flooding Dropper / WEL1DROPPER npm
+  slopsquatting campaign (OpenSourceMalware and Sonatype, 2026-08-07). The ~850 packages
+  arrive through the advisory databases, but the delivery hosts do not: added eight
+  attacker-controlled Cloudflare Worker sub-hosts (`oob-worker.*` and
+  `package-proxy.*oobworker`), the DNS-fallback download host `dl[.]wel1[.]ru`, and two
+  SHA-256 stage-2 payload hashes. The shared `workers[.]dev` apex and the three Russian
+  financial-services hosts the write-up embeds with an explicitly unresolved role
+  (`nexus[.]tcsbank[.]ru`, `repo-linux[.]tcsbank[.]ru`, `alertmanager[.]cloudpayments[.]ru`)
+  are deliberately not listed.
+- IOC blocklist: C2 and payload indicators for the axios maintainer account takeover
+  (UNC1069 / "Sapphire Sleet", 2026-03-31). The hijacked releases were already version
+  pinned; this adds the RAT C2 `sfrclak[.]com`, its resolver `142[.]11[.]206[.]73`, and the
+  three per-platform implant hashes. The hijacked maintainer account is a victim and is not
+  listed.
+- IOC blocklist: backfill for the `spellcheckpy` / `spellcheckerpy` PyPI RAT (Aikido,
+  2026-01-20), a campaign that had never been ingested. Both names are blocked bare, since
+  every published version is malicious and neither name has legitimate history, together
+  with the stage-2 host `updatenet[.]work` and `172[.]86[.]73[.]139`. Single-source, so the
+  feed entries carry confidence 0.85.
+- Tests: `campaigns.test.ts` gains scan-level coverage for all three campaigns, including a
+  negative test that the `workers[.]dev` apex and the unattributed third-party hosts stay
+  clean, a clean-version negative for axios, and an ecosystem-inversion guard that
+  `spellcheckpy` fires on a Python lockfile but not on an npm dependency of the same name.
+
 ## [5.25.8] - 2026-08-08
 
 ### Added

--- a/feed.json
+++ b/feed.json
@@ -2,7 +2,7 @@
   "schema": 1,
   "package": "supply-chain-guard",
   "version": "5.25.8",
-  "entryCount": 10680,
+  "entryCount": 10764,
   "entries": [
     {
       "type": "domain",
@@ -86183,6 +86183,718 @@
       "campaign": "Alibaba Dev Toolchain RAT",
       "source": "Corgea",
       "firstSeen": "2026-08-03"
+    },
+    {
+      "type": "package",
+      "value": "pypi:riakcs@0.0.1",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-3849-8v46-m7qx, MAL-2026-13665",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "pypi:riakcs@0.5.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-3849-8v46-m7qx, MAL-2026-13665",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "statist-browser-typed-client-eventea.projects.pwakasko",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-4fvg-gp6j-v2qm",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "statist-browser-typed-client-eventea.projects.tdevice",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-rrvf-xjx8-gmjh",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "statist-browser-typed-client-eventea.projects.pwahelp",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-wvc6-wpjx-jgx8",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "statist-browser-typed-client-eventea.projects.tdeal",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-966c-8786-6cx7",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "statist-browser-typed-client-eventea.projects.pwainsurance",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-hm23-rg8r-xhmg",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "statist-browser-typed-client-eventea.projects.pwafamily",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-qmv3-2w4r-rwwq",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "bnpl-blocks-desktop-bnpl-anchor-title",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-55g4-q5c3-783j, MAL-2026-12912",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "test-noexist-xyz-99",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-682j-6frp-w6rq",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "specials-resources-server",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-9wh2-7j4m-r43r",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "svelte-kit-cache",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-9fg7-rqp2-7hpg",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "streak-map-kit",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-w8wc-wm2m-27hv, MAL-2026-13628",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "map-streak-kit",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-m55q-8hc5-f46f, MAL-2026-13632",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "svelte-streak-kit",
+      "severity": "critical",
+      "confidence": 0.9,
+      "source": "GHSA-2w6v-q693-8jjm",
+      "firstSeen": "2026-08-08"
+    },
+    {
+      "type": "package",
+      "value": "@xiaohhhh1/canvas-agent@0.4.11",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-29wq-c378-jw6v, MAL-2026-13398",
+      "firstSeen": "2026-08-06"
+    },
+    {
+      "type": "package",
+      "value": "@xiaohhhh1/canvas-agent@0.4.10",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-29wq-c378-jw6v, MAL-2026-13398",
+      "firstSeen": "2026-08-06"
+    },
+    {
+      "type": "package",
+      "value": "@xiaohhhh1/canvas-agent@0.4.9",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-29wq-c378-jw6v, MAL-2026-13398",
+      "firstSeen": "2026-08-06"
+    },
+    {
+      "type": "package",
+      "value": "@xiaohhhh1/canvas-agent@0.4.8",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-29wq-c378-jw6v, MAL-2026-13398",
+      "firstSeen": "2026-08-06"
+    },
+    {
+      "type": "package",
+      "value": "@apicity/meta@0.8.8",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-rw5c-r24c-f9c7, MAL-2026-13412",
+      "firstSeen": "2026-08-06"
+    },
+    {
+      "type": "package",
+      "value": "sextant-cli-darwin-arm64@0.0.1-rc39",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-2qg7-5p3x-vr75, MAL-2026-11997",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "sextant-cli-darwin-arm64@0.0.1-rc38",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-2qg7-5p3x-vr75, MAL-2026-11997",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "tt-help-cli-ycl@1.4.78",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-jh6x-h6j2-xw9v, MAL-2026-12488",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "tt-help-cli-ycl@1.4.75",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-jh6x-h6j2-xw9v, MAL-2026-12488",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "tt-help-cli-ycl@1.4.76",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-jh6x-h6j2-xw9v, MAL-2026-12488",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "sextant-cli-darwin-amd64@0.0.1-rc39",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-7x22-xp2x-5r35, MAL-2026-12028",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "sextant-cli-darwin-amd64@0.0.1-rc38",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-7x22-xp2x-5r35, MAL-2026-12028",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "sextant-cli-linux-arm64@0.0.1-rc38",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-3w3q-fqgj-f36f, MAL-2026-12043",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "sextant-cli-linux-arm64@0.0.1-rc39",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-3w3q-fqgj-f36f, MAL-2026-12043",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "sextant-cli-linux-amd64@0.0.1-rc38",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-g6xw-m38g-gq9x, MAL-2026-12029",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "sextant-cli-linux-amd64@0.0.1-rc39",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-g6xw-m38g-gq9x, MAL-2026-12029",
+      "firstSeen": "2026-08-05"
+    },
+    {
+      "type": "package",
+      "value": "@ornikar/react-native-svg-transformer@1.0.13",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-rqjm-92gf-5c24, MAL-2026-11769",
+      "firstSeen": "2026-08-04"
+    },
+    {
+      "type": "package",
+      "value": "@ornikar/intl-config@10.0.10",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-g4r2-833j-2226, MAL-2026-11757",
+      "firstSeen": "2026-08-04"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.42",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.35",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.27",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.52",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.43",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.61",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.66",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.67",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.48",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.26",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.77",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.44",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.53",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.29",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.40",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.33",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.36",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.50",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.71",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.58",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.79",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.30",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.78",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.28",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.80",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@yancyyu/agentcli@1.9.25",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-wqc4-72w7-qr9g, MAL-2026-11123",
+      "firstSeen": "2026-07-28"
+    },
+    {
+      "type": "package",
+      "value": "@onescience/onecode@1.14.50-202608071618",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-v8hc-7wp4-4qj3, MAL-2026-10717",
+      "firstSeen": "2026-07-27"
+    },
+    {
+      "type": "package",
+      "value": "@onescience/onecode@1.14.50-202608071143",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-v8hc-7wp4-4qj3, MAL-2026-10717",
+      "firstSeen": "2026-07-27"
+    },
+    {
+      "type": "package",
+      "value": "@onescience/onecode@1.14.50-202608070922",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-v8hc-7wp4-4qj3, MAL-2026-10717",
+      "firstSeen": "2026-07-27"
+    },
+    {
+      "type": "package",
+      "value": "@heartlandone-private/fontawesome-pro@6.3.6",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-76cg-jp79-588m, MAL-2026-11093",
+      "firstSeen": "2026-07-27"
+    },
+    {
+      "type": "package",
+      "value": "@heartlandone-private/fontawesome-pro@6.3.2",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-76cg-jp79-588m, MAL-2026-11093",
+      "firstSeen": "2026-07-27"
+    },
+    {
+      "type": "domain",
+      "value": "oob-worker.cf103-070.workers.dev",
+      "severity": "critical",
+      "confidence": 1,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware, The Hacker News",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "oob-worker.cf102-baf.workers.dev",
+      "severity": "critical",
+      "confidence": 1,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware, The Hacker News",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "oob-worker.cf99-9b3.workers.dev",
+      "severity": "critical",
+      "confidence": 1,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware, The Hacker News",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "package-proxy.cf5oobworker.workers.dev",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "package-proxy.cf6oobworker.workers.dev",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "package-proxy.cf7oobworker.workers.dev",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "package-proxy.cf8oobworker.workers.dev",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "package-proxy.cf11oobworker.workers.dev",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "dl.wel1.ru",
+      "severity": "critical",
+      "confidence": 1,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware, The Hacker News",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "hash",
+      "value": "7e486657f30594afda379b97030252a09a19fe8055e25c9e371544f59bd8e9e3",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "hash",
+      "value": "c214746c74cae8ece8bdaf69aa05da4db6ce013f9e77452d1eed1a002fd9ba00",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "WEL1DROPPER",
+      "campaign": "Flooding Dropper",
+      "source": "OpenSourceMalware",
+      "firstSeen": "2026-08-07"
+    },
+    {
+      "type": "domain",
+      "value": "sfrclak.com",
+      "severity": "critical",
+      "confidence": 0.95,
+      "family": "UNC1069 RAT",
+      "campaign": "axios hijack",
+      "source": "Aikido, LevelBlue",
+      "firstSeen": "2026-03-31"
+    },
+    {
+      "type": "ip",
+      "value": "142.11.206.73",
+      "severity": "critical",
+      "confidence": 0.95,
+      "family": "UNC1069 RAT",
+      "campaign": "axios hijack",
+      "source": "Aikido, LevelBlue",
+      "firstSeen": "2026-03-31"
+    },
+    {
+      "type": "hash",
+      "value": "92ff08773995ebc8d55ec4b8e1a225d0d1e51efa4ef88b8849d0071230c9645a",
+      "severity": "critical",
+      "confidence": 0.95,
+      "family": "UNC1069 RAT",
+      "campaign": "axios hijack",
+      "source": "Aikido, LevelBlue",
+      "firstSeen": "2026-03-31"
+    },
+    {
+      "type": "hash",
+      "value": "617b67a8e1210e4fc87c92d1d1da45a2f311c08d26e89b12307cf583c900d101",
+      "severity": "critical",
+      "confidence": 0.95,
+      "family": "UNC1069 RAT",
+      "campaign": "axios hijack",
+      "source": "Aikido, LevelBlue",
+      "firstSeen": "2026-03-31"
+    },
+    {
+      "type": "hash",
+      "value": "fcb81618bb15edfdedfb638b4c08a2af9cac9ecfa551af135a8402bf980375cf",
+      "severity": "critical",
+      "confidence": 0.95,
+      "family": "UNC1069 RAT",
+      "campaign": "axios hijack",
+      "source": "Aikido, LevelBlue",
+      "firstSeen": "2026-03-31"
+    },
+    {
+      "type": "package",
+      "value": "pypi:spellcheckpy",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "Python RAT",
+      "campaign": "updatenet",
+      "source": "Aikido",
+      "firstSeen": "2026-01-20"
+    },
+    {
+      "type": "package",
+      "value": "pypi:spellcheckerpy",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "Python RAT",
+      "campaign": "updatenet",
+      "source": "Aikido",
+      "firstSeen": "2026-01-20"
+    },
+    {
+      "type": "domain",
+      "value": "updatenet.work",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "Python RAT",
+      "campaign": "updatenet",
+      "source": "Aikido",
+      "firstSeen": "2026-01-20"
+    },
+    {
+      "type": "ip",
+      "value": "172.86.73.139",
+      "severity": "critical",
+      "confidence": 0.85,
+      "family": "Python RAT",
+      "campaign": "updatenet",
+      "source": "Aikido",
+      "firstSeen": "2026-01-20"
     }
   ]
 }

--- a/src/__tests__/campaigns.test.ts
+++ b/src/__tests__/campaigns.test.ts
@@ -3992,4 +3992,199 @@ describe("Campaign Signatures", () => {
       ).toBeUndefined();
     });
   });
+
+  // =================================================================
+  // Flooding Dropper / WEL1DROPPER (August 2026)
+  // =================================================================
+
+  describe("Flooding Dropper npm slopsquatting campaign (August 2026)", () => {
+    it("flags a Cloudflare Worker payload host", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "install.js"),
+        'const url = "https://oob-worker.cf99-9b3.workers.dev/pkg/update_win.exe";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_C2_DOMAIN");
+      expect(finding, "the WEL1DROPPER payload host must be flagged").toBeDefined();
+      expect(finding?.severity).toBe("critical");
+    });
+
+    it("flags the package-proxy Worker host", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "fetch.js"),
+        'const mirror = "https://package-proxy.cf11oobworker.workers.dev/";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_C2_DOMAIN");
+      expect(finding, "the package-proxy Worker host must be flagged").toBeDefined();
+    });
+
+    // The DNS fallback host is listed once at the dl[.] label. Matching is an
+    // unanchored substring test, so the published platform subdomains must all
+    // resolve to that single entry rather than needing a row each.
+    it("flags every published DNS-fallback subdomain through the single dl.wel1.ru entry", async () => {
+      for (const host of [
+        "sdk.dl.wel1.ru",
+        "ext.dl.wel1.ru",
+        "pkg.dl.wel1.ru",
+        "net.dl.wel1.ru",
+        "dl.wel1.ru",
+      ]) {
+        const dir = fs.mkdtempSync(path.join(tempDir, "dns-"));
+        fs.writeFileSync(path.join(dir, "resolve.js"), `const c2 = "${host}";\n`);
+
+        const report = await scan({ target: dir, format: "text" });
+        const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_C2_DOMAIN");
+        expect(finding, `${host} must be flagged`).toBeDefined();
+      }
+    });
+
+    it("flags the stage-2 payload hash", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "notes.js"),
+        'const sha = "7e486657f30594afda379b97030252a09a19fe8055e25c9e371544f59bd8e9e3";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_MALWARE_HASH");
+      expect(finding, "the WEL1DROPPER payload hash must be flagged").toBeDefined();
+      expect(finding?.severity).toBe("critical");
+    });
+
+    // The write-up embeds three Russian financial-services hosts whose role it
+    // explicitly calls unclear (health check, decoy, or compromised third party),
+    // and the payload rides the shared Cloudflare Workers platform. Blocking either
+    // would flag legitimate infrastructure, so neither is ingested.
+    it("does NOT flag the workers.dev apex or the unattributed third-party hosts", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "clean.js"),
+        'const platform = "https://my-app.workers.dev/";\n' +
+          'const nexus = "https://nexus.tcsbank.ru/repository/npm-group/";\n' +
+          'const alerts = "https://alertmanager.cloudpayments.ru/api/v2/alerts";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_C2_DOMAIN");
+      expect(
+        finding,
+        "shared Cloudflare Workers and unattributed third-party hosts must not be blocked",
+      ).toBeUndefined();
+    });
+  });
+
+  // =================================================================
+  // axios maintainer takeover / UNC1069 (March 2026)
+  // =================================================================
+
+  describe("axios hijack - UNC1069 RAT infrastructure (March 2026)", () => {
+    it("flags the RAT C2 domain", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "stage.js"),
+        'const c2 = "http://sfrclak.com:8000/6202033";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_C2_DOMAIN");
+      expect(finding, "the axios RAT C2 domain must be flagged").toBeDefined();
+      expect(finding?.severity).toBe("critical");
+    });
+
+    it("flags the RAT C2 IP", async () => {
+      fs.writeFileSync(path.join(tempDir, "ip.js"), 'const host = "142.11.206.73";\n');
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_C2_IP");
+      expect(finding, "the axios RAT C2 IP must be flagged").toBeDefined();
+    });
+
+    it("flags the macOS implant hash", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "hash.js"),
+        'const sha = "92ff08773995ebc8d55ec4b8e1a225d0d1e51efa4ef88b8849d0071230c9645a";\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_MALWARE_HASH");
+      expect(finding, "the axios macOS implant hash must be flagged").toBeDefined();
+    });
+
+    it("flags the pinned malicious axios version", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({ name: "t", version: "1.0.0", dependencies: { axios: "1.14.1" } }),
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_BAD_VERSION");
+      expect(finding, "axios@1.14.1 must be flagged").toBeDefined();
+    });
+
+    // axios is a legitimate package with 83M+ weekly downloads. Only the two
+    // hijacked releases are malicious; every other version must stay clean.
+    it("does NOT flag a clean axios version", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({ name: "t", version: "1.0.0", dependencies: { axios: "1.7.9" } }),
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_BAD_VERSION");
+      expect(finding, "a clean axios release must not be flagged").toBeUndefined();
+    });
+  });
+
+  // =================================================================
+  // spellcheckpy / spellcheckerpy PyPI RAT (January 2026 backfill)
+  // =================================================================
+
+  describe("spellcheckpy PyPI RAT (January 2026)", () => {
+    it("flags spellcheckpy through a real scan of a Python lockfile", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "poetry.lock"),
+        '[[package]]\nname = "spellcheckpy"\nversion = "1.0.0"\ndescription = "rat"\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => /spellcheckpy/.test(JSON.stringify(f)));
+      expect(finding, "PyPI lockfile must flag the spellcheck RAT").toBeDefined();
+      expect(finding?.severity).toBe("critical");
+    });
+
+    // Same inversion guard as gcli-control: a bare feed value means the npm
+    // namespace, so a missing "pypi:" prefix would silently move detection to
+    // the wrong ecosystem instead of weakening it.
+    it("does NOT flag an npm dependency named spellcheckpy (wrong ecosystem)", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({ name: "t", version: "1.0.0", dependencies: { spellcheckpy: "1.0.0" } }),
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => /spellcheckpy/.test(JSON.stringify(f)));
+      expect(finding, "a PyPI IOC must not fire on an npm dependency").toBeUndefined();
+    });
+
+    it("flags the updatenet stage-2 delivery host", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "loader.py"),
+        'URL = "https://updatenet.work/settings/history.php"\n',
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "IOC_KNOWN_C2_DOMAIN");
+      expect(finding, "the spellcheck stage-2 host must be flagged").toBeDefined();
+      expect(finding?.severity).toBe("critical");
+    });
+
+    // The block is anchored, so the legitimate packages these names typosquat
+    // must stay clean.
+    it("does NOT flag the legitimate packages the names typosquat", () => {
+      for (const name of ["pyspellchecker", "spellchecker", "spellcheck"]) {
+        const hit = PYPI_TYPOSQUAT_PATTERNS.some((p) => new RegExp(p).test(name));
+        expect(hit, name).toBe(false);
+      }
+    });
+  });
 });

--- a/src/ioc-blocklist.ts
+++ b/src/ioc-blocklist.ts
@@ -253,6 +253,45 @@ export const KNOWN_C2_DOMAINS: string[] = [
   // every Ethereum repository on sight - the contract address in
   // KNOWN_C2_WALLETS is the indicator that actually distinguishes this campaign.
 
+  // Flooding Dropper / WEL1DROPPER npm slopsquatting campaign (OpenSourceMalware +
+  // Sonatype + Unit 42, August 7 2026). ~850 AI-generated typosquat packages published
+  // from disposable npm accounts (the "bigops" / "bnpl" / "dolyame" name families, 35.x.y
+  // versions) whose README talks the developer into running them. Stage 1 pulls a
+  // platform-specific RAT over HTTPS from these Cloudflare Worker hosts, and falls back to
+  // reassembling the binary from base64 chunks in DNS TXT records under dl[.]wel1[.]ru.
+  // Specific attacker sub-hosts only - never the shared workers[.]dev apex.
+  "oob-worker.cf103-070.workers.dev",
+  "oob-worker.cf102-baf.workers.dev",
+  "oob-worker.cf99-9b3.workers.dev",
+  "package-proxy.cf5oobworker.workers.dev",
+  "package-proxy.cf6oobworker.workers.dev",
+  "package-proxy.cf7oobworker.workers.dev",
+  "package-proxy.cf8oobworker.workers.dev",
+  "package-proxy.cf11oobworker.workers.dev",
+  // Attacker-registered download host, no legitimate service behind it. Listed at the
+  // dl[.] label rather than as four separate rows: matching here is an unanchored
+  // substring test, so this one entry already covers the published platform subdomains
+  // (sdk[.] / ext[.] / pkg[.] / net[.]) without each of them double-reporting.
+  "dl.wel1.ru",
+  // The write-up also lists nexus[.]tcsbank[.]ru, repo-linux[.]tcsbank[.]ru and
+  // alertmanager[.]cloudpayments[.]ru, embedded in the sample with an explicitly
+  // UNCLEAR role (health check, decoy, or compromised third party). Those are real
+  // Russian financial-services hosts, not confirmed attacker infrastructure, so they
+  // are deliberately NOT listed - blocking a possible victim on an unresolved
+  // attribution is exactly the false positive that gets a scanner switched off.
+
+  // axios maintainer account takeover - UNC1069 / "Sapphire Sleet" cross-platform RAT
+  // (Aikido + LevelBlue, March 31 2026). Extends coverage that previously only pinned
+  // axios@1.14.1 / @0.30.4 and plain-crypto-js@4.2.1: this is the dropper's C2, reached
+  // at hxxp://sfrclak[.]com:8000/6202033. Attacker-registered, no legitimate use.
+  "sfrclak.com",
+
+  // spellcheckpy / spellcheckerpy PyPI RAT (Aikido, January 2026). Backfill of a campaign
+  // that was never ingested. Stage 2 is pulled from hxxps://updatenet[.]work/settings/
+  // history.php and the implant beacons to hxxps://updatenet[.]work/update1.php.
+  // Attacker-registered lookalike of a software-update host. Single-source.
+  "updatenet.work",
+
   // GlassWASM / GlassWorm successor - trojanized Open VSX extensions (Socket + Corgea,
   // June 2026). Two impersonation clones of verified VS Code Marketplace extensions were
   // republished on Open VSX carrying a TinyGo-compiled WebAssembly stager. The WASM blob
@@ -378,6 +417,16 @@ export const KNOWN_C2_IPS: string[] = [
   "23.27.13.43",
   "198.105.127.210",
   "23.27.202.27",
+
+  // axios maintainer account takeover - UNC1069 / "Sapphire Sleet" (Aikido + LevelBlue,
+  // March 31 2026). Resolver for sfrclak[.]com, which serves the RAT stage on :8000.
+  "142.11.206.73",
+
+  // spellcheckpy / spellcheckerpy PyPI RAT (Aikido, January 2026). Host behind
+  // updatenet[.]work. Single-source. The Cloudflare edge address published for the
+  // ChainDrop router (104[.]21[.]35[.]216) is deliberately NOT listed anywhere here -
+  // it is a shared anycast address fronting millions of sites.
+  "172.86.73.139",
 ];
 
 // ---------------------------------------------------------------------------
@@ -794,6 +843,22 @@ export const KNOWN_MALICIOUS_HASHES: Record<string, string> = {
   "558b4f1d9a263c13756ab0126c09dd080c85ba405b29488e1c4e6aa68b554f1f": "GlassWASM TinyGo WebAssembly stager, snqpkebiwrxmoivl.wasm / orybbbdsuqmaapel.wasm (SHA256)",
   "3aa31999398e7f80231c03d7137ffdb554a84b83dbcffc59ce16c9a65f9e5d58": "GlassWASM trojanized noellee-doc.flint-debug 0.1.1 VSIX (SHA256)",
   "1e283327ad048bea39f4a8501770858a20f3555e87fe3e202274f2e87f8a3c25": "GlassWASM trojanized ExarGD.vsblack 0.0.1 VSIX (SHA256)",
+
+  // Flooding Dropper / WEL1DROPPER stage-2 RAT binaries (OpenSourceMalware, August 7 2026).
+  // Single-source for the hashes themselves; the campaign's package families and Worker
+  // hosts are corroborated by Sonatype and Unit 42. Both round-tripped as well-formed
+  // 64-char digests and the Linux one was re-confirmed by exact-string search.
+  "7e486657f30594afda379b97030252a09a19fe8055e25c9e371544f59bd8e9e3": "Flooding Dropper WEL1DROPPER stage-2 payload, Linux x86-64 (SHA256)",
+  "c214746c74cae8ece8bdaf69aa05da4db6ce013f9e77452d1eed1a002fd9ba00": "Flooding Dropper WEL1DROPPER stage-2 payload, macOS universal (SHA256)",
+
+  // axios maintainer account takeover - UNC1069 / "Sapphire Sleet" cross-platform RAT
+  // (Aikido + LevelBlue, March 31 2026). The axios and plain-crypto-js versions were
+  // already pinned; these are the dropped per-platform implants, which the advisory
+  // databases never publish. Each round-tripped as a well-formed 64-char digest and the
+  // macOS one was re-confirmed by exact-string search.
+  "92ff08773995ebc8d55ec4b8e1a225d0d1e51efa4ef88b8849d0071230c9645a": "axios/UNC1069 RAT, macOS /Library/Caches/com.apple.act.mond (SHA256)",
+  "617b67a8e1210e4fc87c92d1d1da45a2f311c08d26e89b12307cf583c900d101": "axios/UNC1069 RAT, Windows %PROGRAMDATA%\\wt.exe (SHA256)",
+  "fcb81618bb15edfdedfb638b4c08a2af9cac9ecfa551af135a8402bf980375cf": "axios/UNC1069 RAT, Linux /tmp/ld.py (SHA256)",
 };
 
 // ---------------------------------------------------------------------------

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -2908,6 +2908,14 @@ export const PYPI_TYPOSQUAT_PATTERNS: string[] = [
   // Single-source (Xygeni).
   "^gcli-control$",
 
+  // spellcheckpy / spellcheckerpy Python RAT (Aikido, January 20-21 2026). Backfill of a
+  // campaign that was never ingested. Typosquats of pyspellchecker/spellchecker that hide
+  // a gzipped stage-1 inside resources/eu.json.gz under a "spellchecker" dictionary key,
+  // then pull stage 2 from updatenet[.]work (in ioc-blocklist). Every published version is
+  // malicious and neither name has a legitimate history, so bare names rather than version
+  // pins. Single-source (Aikido).
+  "^(spellcheckpy|spellcheckerpy)$",
+
   // Very long single-word lowercase names
   "^[a-z]{20,}$",
 ];

--- a/src/threat-intel.ts
+++ b/src/threat-intel.ts
@@ -11304,6 +11304,107 @@ const FEED_CHUNK_10: FeedIOC[] = [
   // attacker-created by Socket. Version-pinned, see ioc-blocklist.ts.
   { type: "url", value: "raw.githubusercontent.com/smi1e2u/smart-config-manager/main/defaults/preferences.json", severity: "critical", confidence: 0.85, family: "AlibabaDevRAT", campaign: "Alibaba Dev Toolchain RAT", source: "Corgea", firstSeen: "2026-08-03" },
   { type: "package", value: "node-data-utils@1.0.1", severity: "critical", confidence: 0.85, family: "AlibabaDevRAT", campaign: "Alibaba Dev Toolchain RAT", source: "Corgea", firstSeen: "2026-08-03" },
+
+  // Imported from GitHub Advisory Database (2026-07-26) - see docs/threat-feed-sources.md
+  { type: "package", value: "pypi:riakcs@0.0.1", severity: "critical", confidence: 1.0, source: "GHSA-3849-8v46-m7qx, MAL-2026-13665", firstSeen: "2026-08-08" },
+  { type: "package", value: "pypi:riakcs@0.5.0", severity: "critical", confidence: 1.0, source: "GHSA-3849-8v46-m7qx, MAL-2026-13665", firstSeen: "2026-08-08" },
+  { type: "package", value: "statist-browser-typed-client-eventea.projects.pwakasko", severity: "critical", confidence: 0.9, source: "GHSA-4fvg-gp6j-v2qm", firstSeen: "2026-08-08" },
+  { type: "package", value: "statist-browser-typed-client-eventea.projects.tdevice", severity: "critical", confidence: 0.9, source: "GHSA-rrvf-xjx8-gmjh", firstSeen: "2026-08-08" },
+  { type: "package", value: "statist-browser-typed-client-eventea.projects.pwahelp", severity: "critical", confidence: 0.9, source: "GHSA-wvc6-wpjx-jgx8", firstSeen: "2026-08-08" },
+  { type: "package", value: "statist-browser-typed-client-eventea.projects.tdeal", severity: "critical", confidence: 0.9, source: "GHSA-966c-8786-6cx7", firstSeen: "2026-08-08" },
+  { type: "package", value: "statist-browser-typed-client-eventea.projects.pwainsurance", severity: "critical", confidence: 0.9, source: "GHSA-hm23-rg8r-xhmg", firstSeen: "2026-08-08" },
+  { type: "package", value: "statist-browser-typed-client-eventea.projects.pwafamily", severity: "critical", confidence: 0.9, source: "GHSA-qmv3-2w4r-rwwq", firstSeen: "2026-08-08" },
+  { type: "package", value: "bnpl-blocks-desktop-bnpl-anchor-title", severity: "critical", confidence: 1.0, source: "GHSA-55g4-q5c3-783j, MAL-2026-12912", firstSeen: "2026-08-08" },
+  { type: "package", value: "test-noexist-xyz-99", severity: "critical", confidence: 0.9, source: "GHSA-682j-6frp-w6rq", firstSeen: "2026-08-08" },
+  { type: "package", value: "specials-resources-server", severity: "critical", confidence: 0.9, source: "GHSA-9wh2-7j4m-r43r", firstSeen: "2026-08-08" },
+  { type: "package", value: "svelte-kit-cache", severity: "critical", confidence: 0.9, source: "GHSA-9fg7-rqp2-7hpg", firstSeen: "2026-08-08" },
+  { type: "package", value: "streak-map-kit", severity: "critical", confidence: 1.0, source: "GHSA-w8wc-wm2m-27hv, MAL-2026-13628", firstSeen: "2026-08-08" },
+  { type: "package", value: "map-streak-kit", severity: "critical", confidence: 1.0, source: "GHSA-m55q-8hc5-f46f, MAL-2026-13632", firstSeen: "2026-08-08" },
+  { type: "package", value: "svelte-streak-kit", severity: "critical", confidence: 0.9, source: "GHSA-2w6v-q693-8jjm", firstSeen: "2026-08-08" },
+  { type: "package", value: "@xiaohhhh1/canvas-agent@0.4.11", severity: "critical", confidence: 1.0, source: "GHSA-29wq-c378-jw6v, MAL-2026-13398", firstSeen: "2026-08-06" },
+  { type: "package", value: "@xiaohhhh1/canvas-agent@0.4.10", severity: "critical", confidence: 1.0, source: "GHSA-29wq-c378-jw6v, MAL-2026-13398", firstSeen: "2026-08-06" },
+  { type: "package", value: "@xiaohhhh1/canvas-agent@0.4.9", severity: "critical", confidence: 1.0, source: "GHSA-29wq-c378-jw6v, MAL-2026-13398", firstSeen: "2026-08-06" },
+  { type: "package", value: "@xiaohhhh1/canvas-agent@0.4.8", severity: "critical", confidence: 1.0, source: "GHSA-29wq-c378-jw6v, MAL-2026-13398", firstSeen: "2026-08-06" },
+  { type: "package", value: "@apicity/meta@0.8.8", severity: "critical", confidence: 1.0, source: "GHSA-rw5c-r24c-f9c7, MAL-2026-13412", firstSeen: "2026-08-06" },
+  { type: "package", value: "sextant-cli-darwin-arm64@0.0.1-rc39", severity: "critical", confidence: 1.0, source: "GHSA-2qg7-5p3x-vr75, MAL-2026-11997", firstSeen: "2026-08-05" },
+  { type: "package", value: "sextant-cli-darwin-arm64@0.0.1-rc38", severity: "critical", confidence: 1.0, source: "GHSA-2qg7-5p3x-vr75, MAL-2026-11997", firstSeen: "2026-08-05" },
+  { type: "package", value: "tt-help-cli-ycl@1.4.78", severity: "critical", confidence: 1.0, source: "GHSA-jh6x-h6j2-xw9v, MAL-2026-12488", firstSeen: "2026-08-05" },
+  { type: "package", value: "tt-help-cli-ycl@1.4.75", severity: "critical", confidence: 1.0, source: "GHSA-jh6x-h6j2-xw9v, MAL-2026-12488", firstSeen: "2026-08-05" },
+  { type: "package", value: "tt-help-cli-ycl@1.4.76", severity: "critical", confidence: 1.0, source: "GHSA-jh6x-h6j2-xw9v, MAL-2026-12488", firstSeen: "2026-08-05" },
+  { type: "package", value: "sextant-cli-darwin-amd64@0.0.1-rc39", severity: "critical", confidence: 1.0, source: "GHSA-7x22-xp2x-5r35, MAL-2026-12028", firstSeen: "2026-08-05" },
+  { type: "package", value: "sextant-cli-darwin-amd64@0.0.1-rc38", severity: "critical", confidence: 1.0, source: "GHSA-7x22-xp2x-5r35, MAL-2026-12028", firstSeen: "2026-08-05" },
+  { type: "package", value: "sextant-cli-linux-arm64@0.0.1-rc38", severity: "critical", confidence: 1.0, source: "GHSA-3w3q-fqgj-f36f, MAL-2026-12043", firstSeen: "2026-08-05" },
+  { type: "package", value: "sextant-cli-linux-arm64@0.0.1-rc39", severity: "critical", confidence: 1.0, source: "GHSA-3w3q-fqgj-f36f, MAL-2026-12043", firstSeen: "2026-08-05" },
+  { type: "package", value: "sextant-cli-linux-amd64@0.0.1-rc38", severity: "critical", confidence: 1.0, source: "GHSA-g6xw-m38g-gq9x, MAL-2026-12029", firstSeen: "2026-08-05" },
+  { type: "package", value: "sextant-cli-linux-amd64@0.0.1-rc39", severity: "critical", confidence: 1.0, source: "GHSA-g6xw-m38g-gq9x, MAL-2026-12029", firstSeen: "2026-08-05" },
+  { type: "package", value: "@ornikar/react-native-svg-transformer@1.0.13", severity: "critical", confidence: 1.0, source: "GHSA-rqjm-92gf-5c24, MAL-2026-11769", firstSeen: "2026-08-04" },
+  { type: "package", value: "@ornikar/intl-config@10.0.10", severity: "critical", confidence: 1.0, source: "GHSA-g4r2-833j-2226, MAL-2026-11757", firstSeen: "2026-08-04" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.42", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.35", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.27", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.52", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.43", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.61", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.66", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.67", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.48", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.26", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.77", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.44", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.53", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.29", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.40", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.33", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.36", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.50", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.71", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.58", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.79", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.30", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.78", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.28", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.80", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@yancyyu/agentcli@1.9.25", severity: "critical", confidence: 1.0, source: "GHSA-wqc4-72w7-qr9g, MAL-2026-11123", firstSeen: "2026-07-28" },
+  { type: "package", value: "@onescience/onecode@1.14.50-202608071618", severity: "critical", confidence: 1.0, source: "GHSA-v8hc-7wp4-4qj3, MAL-2026-10717", firstSeen: "2026-07-27" },
+  { type: "package", value: "@onescience/onecode@1.14.50-202608071143", severity: "critical", confidence: 1.0, source: "GHSA-v8hc-7wp4-4qj3, MAL-2026-10717", firstSeen: "2026-07-27" },
+  { type: "package", value: "@onescience/onecode@1.14.50-202608070922", severity: "critical", confidence: 1.0, source: "GHSA-v8hc-7wp4-4qj3, MAL-2026-10717", firstSeen: "2026-07-27" },
+  { type: "package", value: "@heartlandone-private/fontawesome-pro@6.3.6", severity: "critical", confidence: 1.0, source: "GHSA-76cg-jp79-588m, MAL-2026-11093", firstSeen: "2026-07-27" },
+  { type: "package", value: "@heartlandone-private/fontawesome-pro@6.3.2", severity: "critical", confidence: 1.0, source: "GHSA-76cg-jp79-588m, MAL-2026-11093", firstSeen: "2026-07-27" },
+
+  // Flooding Dropper / WEL1DROPPER npm slopsquatting campaign (August 7 2026). The package
+  // names arrive through the advisory databases; these are the delivery hosts and payload
+  // hashes, which they never publish. The three oob-worker hosts are reported by both
+  // OpenSourceMalware and The Hacker News; the package-proxy hosts and the two binary
+  // hashes are single-source (OpenSourceMalware), hence 0.85.
+  { type: "domain", value: "oob-worker.cf103-070.workers.dev", severity: "critical", confidence: 1.0, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware, The Hacker News", firstSeen: "2026-08-07" },
+  { type: "domain", value: "oob-worker.cf102-baf.workers.dev", severity: "critical", confidence: 1.0, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware, The Hacker News", firstSeen: "2026-08-07" },
+  { type: "domain", value: "oob-worker.cf99-9b3.workers.dev", severity: "critical", confidence: 1.0, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware, The Hacker News", firstSeen: "2026-08-07" },
+  { type: "domain", value: "package-proxy.cf5oobworker.workers.dev", severity: "critical", confidence: 0.85, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware", firstSeen: "2026-08-07" },
+  { type: "domain", value: "package-proxy.cf6oobworker.workers.dev", severity: "critical", confidence: 0.85, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware", firstSeen: "2026-08-07" },
+  { type: "domain", value: "package-proxy.cf7oobworker.workers.dev", severity: "critical", confidence: 0.85, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware", firstSeen: "2026-08-07" },
+  { type: "domain", value: "package-proxy.cf8oobworker.workers.dev", severity: "critical", confidence: 0.85, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware", firstSeen: "2026-08-07" },
+  { type: "domain", value: "package-proxy.cf11oobworker.workers.dev", severity: "critical", confidence: 0.85, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware", firstSeen: "2026-08-07" },
+  { type: "domain", value: "dl.wel1.ru", severity: "critical", confidence: 1.0, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware, The Hacker News", firstSeen: "2026-08-07" },
+  { type: "hash", value: "7e486657f30594afda379b97030252a09a19fe8055e25c9e371544f59bd8e9e3", severity: "critical", confidence: 0.85, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware", firstSeen: "2026-08-07" },
+  { type: "hash", value: "c214746c74cae8ece8bdaf69aa05da4db6ce013f9e77452d1eed1a002fd9ba00", severity: "critical", confidence: 0.85, family: "WEL1DROPPER", campaign: "Flooding Dropper", source: "OpenSourceMalware", firstSeen: "2026-08-07" },
+
+  // axios maintainer account takeover - UNC1069 / "Sapphire Sleet" (March 31 2026).
+  // The axios and plain-crypto-js versions were already pinned in v5.x; this is the
+  // C2 and the per-platform implants the advisory databases never published.
+  { type: "domain", value: "sfrclak.com", severity: "critical", confidence: 0.95, family: "UNC1069 RAT", campaign: "axios hijack", source: "Aikido, LevelBlue", firstSeen: "2026-03-31" },
+  { type: "ip", value: "142.11.206.73", severity: "critical", confidence: 0.95, family: "UNC1069 RAT", campaign: "axios hijack", source: "Aikido, LevelBlue", firstSeen: "2026-03-31" },
+  { type: "hash", value: "92ff08773995ebc8d55ec4b8e1a225d0d1e51efa4ef88b8849d0071230c9645a", severity: "critical", confidence: 0.95, family: "UNC1069 RAT", campaign: "axios hijack", source: "Aikido, LevelBlue", firstSeen: "2026-03-31" },
+  { type: "hash", value: "617b67a8e1210e4fc87c92d1d1da45a2f311c08d26e89b12307cf583c900d101", severity: "critical", confidence: 0.95, family: "UNC1069 RAT", campaign: "axios hijack", source: "Aikido, LevelBlue", firstSeen: "2026-03-31" },
+  { type: "hash", value: "fcb81618bb15edfdedfb638b4c08a2af9cac9ecfa551af135a8402bf980375cf", severity: "critical", confidence: 0.95, family: "UNC1069 RAT", campaign: "axios hijack", source: "Aikido, LevelBlue", firstSeen: "2026-03-31" },
+
+  // spellcheckpy / spellcheckerpy PyPI RAT (January 20-21 2026). Backfill of a campaign
+  // that was never ingested. Every published version is malicious, so the packages are
+  // listed by bare name. Single-source (Aikido), hence 0.85. The "pypi:" prefix is
+  // load-bearing - without it these would be read as npm names.
+  { type: "package", value: "pypi:spellcheckpy", severity: "critical", confidence: 0.85, family: "Python RAT", campaign: "updatenet", source: "Aikido", firstSeen: "2026-01-20" },
+  { type: "package", value: "pypi:spellcheckerpy", severity: "critical", confidence: 0.85, family: "Python RAT", campaign: "updatenet", source: "Aikido", firstSeen: "2026-01-20" },
+  { type: "domain", value: "updatenet.work", severity: "critical", confidence: 0.85, family: "Python RAT", campaign: "updatenet", source: "Aikido", firstSeen: "2026-01-20" },
+  { type: "ip", value: "172.86.73.139", severity: "critical", confidence: 0.85, family: "Python RAT", campaign: "updatenet", source: "Aikido", firstSeen: "2026-01-20" },
 ];
 
 // Composed from the chunks above. A single array literal of this size trips


### PR DESCRIPTION
Scheduled daily advisory sweep for 2026-08-09. No version bump - the release is a separate commit.

Base: `7afaedc` (main, post-v5.25.8). Repo was clean with zero open PRs at branch time and `main` had not moved at push time.

## Importer (STEP 1)

64 new package IOCs: **62 npm, 2 PyPI**.

| Metric | Value |
|---|---|
| Advisories fetched | 4,492 over 45 pages |
| Page cap hit | No (no `--allow-truncated`, no window slicing) |
| `--limit 250` reached | **No** - `remaining: 0`, `undrainable: 0` |
| OSV corroboration | 16 confirmed |
| Already covered | 9,430 duplicate, 483 by a bare-name IOC |
| Skipped by design | 158 (149 withdrawn, 7 unmappable version range, 2 unsafe package name) |

Nothing is left waiting for the next run - unlike the previous two sweeps, this window drained completely.

Notable clusters: continuation of the `bnpl-*` and `statist-browser-typed-client-*` dependency-confusion waves, a `@yancyyu/agentcli` version sweep (25 releases), a `sextant-cli-*` per-platform binary cluster, a `svelte`/`streak` map-kit typosquat set, and PyPI `riakcs`.

**Unmappable / skipped.** The importer reports only counts for skips, not per-advisory detail, so the 7 unmappable version ranges (bounded ranges the scanner cannot resolve to discrete versions) and 2 unsafe package names cannot be enumerated from a completed run. None were forced in by hand.

## Manual enrichment (STEP 1b)

The headline campaign of the week - the keyv/cacheable **ChainDrop** worm - needed nothing. The 2026-08-07 and 2026-08-08 runs had already ingested its hashes, C2, wallet and package pins, including the judgement calls (cloud metadata IPs excluded, the `file-entry-cache@11.1.7` vendor discrepancy resolved against the registry). Three genuine gaps were filled instead.

### 1. Flooding Dropper / WEL1DROPPER (2026-08-07)

~850 AI-generated typosquat packages published from disposable npm accounts (`bigops` / `bnpl` / `dolyame` families, 35.x.y versions) whose README talks the developer into running them. Stage 1 pulls a platform-specific RAT over HTTPS, falling back to reassembling the binary from base64 chunks in DNS TXT records.

The feed already held 78 `bigops` and 134 `dolyame` package entries from the advisory databases - but none of the delivery infrastructure, which is exactly what a database never publishes.

| Indicator | Type | Sources |
|---|---|---|
| `oob-worker.cf103-070.workers[.]dev` | domain | OpenSourceMalware, The Hacker News |
| `oob-worker.cf102-baf.workers[.]dev` | domain | OpenSourceMalware, The Hacker News |
| `oob-worker.cf99-9b3.workers[.]dev` | domain | OpenSourceMalware, The Hacker News |
| `package-proxy.cf5oobworker.workers[.]dev` | domain | OpenSourceMalware (single-source, 0.85) |
| `package-proxy.cf6oobworker.workers[.]dev` | domain | OpenSourceMalware (single-source, 0.85) |
| `package-proxy.cf7oobworker.workers[.]dev` | domain | OpenSourceMalware (single-source, 0.85) |
| `package-proxy.cf8oobworker.workers[.]dev` | domain | OpenSourceMalware (single-source, 0.85) |
| `package-proxy.cf11oobworker.workers[.]dev` | domain | OpenSourceMalware (single-source, 0.85) |
| `dl[.]wel1[.]ru` | domain | OpenSourceMalware, The Hacker News |
| `7e486657f30594afda379b97030252a09a19fe8055e25c9e371544f59bd8e9e3` | hash | OpenSourceMalware (single-source, 0.85) |
| `c214746c74cae8ece8bdaf69aa05da4db6ce013f9e77452d1eed1a002fd9ba00` | hash | OpenSourceMalware (single-source, 0.85) |

Sonatype and Unit 42 corroborate the campaign and its package families but publish no network indicators.

`dl[.]wel1[.]ru` is listed **once** rather than as five rows. Domain matching in `checkIOCBlocklist()` is an unanchored substring test, so this single entry already covers the published platform subdomains (`sdk[.]`, `ext[.]`, `pkg[.]`, `net[.]`) without each of them double-reporting a finding. A test pins all five.

### 2. axios maintainer account takeover - UNC1069 / "Sapphire Sleet" (2026-03-31)

`axios@1.14.1` / `@0.30.4` and `plain-crypto-js@4.2.1` were already version-pinned. The infrastructure was not.

| Indicator | Type |
|---|---|
| `sfrclak[.]com` (RAT C2, reached on :8000) | domain |
| `142[.]11[.]206[.]73` (its resolver) | ip |
| `92ff08773995ebc8d55ec4b8e1a225d0d1e51efa4ef88b8849d0071230c9645a` (macOS implant) | hash |
| `617b67a8e1210e4fc87c92d1d1da45a2f311c08d26e89b12307cf583c900d101` (Windows implant) | hash |
| `fcb81618bb15edfdedfb638b4c08a2af9cac9ecfa551af135a8402bf980375cf` (Linux implant) | hash |

Sources: Aikido (primary) + LevelBlue.

### 3. spellcheckpy / spellcheckerpy PyPI RAT (2026-01-20) - backfill

A campaign that was never ingested at all. Typosquats of `pyspellchecker`/`spellchecker` hiding a gzipped stage-1 in `resources/eu.json.gz`, pulling stage 2 from `updatenet[.]work`. Every published version is malicious and neither name has legitimate history, so both are blocked bare rather than version-pinned. Added `updatenet[.]work` and `172[.]86[.]73[.]139`.

**Single-source (Aikido)** - feed entries carry confidence 0.85.

## Deliberately NOT ingested

These were published as indicators but blocking them would create false positives, which is the failure mode that gets a scanner switched off:

- **The `workers[.]dev` apex.** Shared Cloudflare Workers infrastructure. Only the specific attacker sub-hosts are listed, matching existing precedent in this file. A negative test pins it.
- **`nexus[.]tcsbank[.]ru`, `repo-linux[.]tcsbank[.]ru`, `alertmanager[.]cloudpayments[.]ru`.** OpenSourceMalware embeds these with an explicitly **UNCLEAR** role - health check, decoy, or compromised third party. They are real Russian financial-services hosts, not confirmed attacker infrastructure. A negative test pins it.
- **`104[.]21[.]35[.]216`**, published by Kodem as the ChainDrop router's address. It is a Cloudflare anycast address fronting millions of sites.
- **The hijacked axios maintainer account.** A victim, per the standing rule.
- **`c[.]wel1[.]ru`.** The Hacker News lists this as a domain; OpenSourceMalware describes it as the `c.<domain>` chunk-count prefix applied to the platform subdomains, i.e. a description of the DNS mechanism rather than a distinct host. Not ingested as a domain.

## Hash verification

All five hashes round-tripped as well-formed 64-character digests (length and character-class checked locally), and two of them - the Flooding Dropper Linux payload and the axios macOS implant - were independently re-confirmed by exact-string search against sources other than the one they were fetched from. This is the standing guard against WebFetch transcription errors, which produced a phantom indicator on 2026-08-08.

## Tests

`campaigns.test.ts` gains 10 tests across three new describe blocks, all going through `scan()` on a real fixture rather than asserting against a pattern constant:

- Flooding Dropper: Worker host, package-proxy host, all five DNS-fallback subdomains through the single `dl[.]wel1[.]ru` entry, payload hash, plus a negative for the `workers[.]dev` apex and the three unattributed third-party hosts.
- axios: C2 domain, C2 IP, macOS implant hash, the pinned `axios@1.14.1`, plus a clean-version negative on `axios@1.7.9`.
- spellcheckpy: fires on a `poetry.lock` entry, does **not** fire on an npm dependency of the same name (the ecosystem-inversion guard - a missing `pypi:` prefix would move detection to the wrong ecosystem rather than weaken it), the stage-2 host, and an anchoring negative on `pyspellchecker` / `spellchecker` / `spellcheck`.

## Verification

- `npm run build` green: all 7 AAHP gates, `check:feed`, `check:handoff`, then `tsc`.
- Targeted suites green: `feed`, `threat-intel`, `campaigns`, `ioc-blocklist`, `feed-import`, `regex-complexity`, `pattern-applicability`, `issue-54-hardening` - **508 passing**, all 10 new tests among them.
- Two `IOC_KNOWN_C2_DOMAIN` failures (Phantom Bot `87e0bbc636999b.lhr[.]life`, GlassWASM `dodod[.]lat`) reproduce on **unmodified `main`** on this Windows box - verified by stashing and re-running both. They are the known Windows-only gap recorded in STATUS.md from the #126 run, where CI settled them as green on Linux.
- **CI on this PR is the authoritative full-suite verdict**, not the local run.

## Resolved: the second axios account (`nrwise`)

Raised as an open question on first push, now **settled as a deliberate non-addition** - recorded in STATUS.md so a later run does not re-open it.

Aikido lists `nrwise` (`nrwise[@]proton[.]me`) as attacker-controlled alongside the hijacked maintainer, without saying whether it is a GitHub or npm handle. It stays out, on three independent grounds:

- **The matcher makes it worthless.** `KNOWN_MALICIOUS_GITHUB_ACCOUNTS` is matched as `github\.com/<account>`, so it only fires on a github.com URL in scanned content. `github[.]com/nrwise` has **zero public repositories** - no such URL exists to be referenced. Detection value is exactly zero, not merely small.
- **The account points away from the attacker.** Dormant since 2013, no public repos, 2 followers. npm and GitHub are separate namespaces, so an identical handle implies no connection; an abandoned 13-year-old account fits an unrelated person who grabbed a short name far better than infrastructure stood up for a March 2026 npm publish. Aikido's context - a proton[.]me address, an npm-publishing attack - indicates their `nrwise` is the npm publisher account. The aged-account-takeover reading cannot be excluded, but it changes nothing: with no public repos there is still nothing to detect.
- **There is nowhere correct to file an npm handle anyway.** No npm-account collection exists in this codebase; `KNOWN_MALICIOUS_GITHUB_ACCOUNTS` is the only account list. And `axios@1.14.1`, `axios@0.30.4` and `plain-crypto-js@4.2.1` are already version-pinned, so the handle adds no coverage. Same reasoning applied to `ch4ce` in the 2026-08-08 run.

The asymmetry is one-sided: no detection gained, against a real risk of flagging a live account belonging to an actual person.

**No open decisions remain on this PR.**
