### PR TITLE
feat(scanner): match scanned files by their own malware digest

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.25.12 |
 | Node engines | >=20.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 108 under `src/__tests__/` |
+| Test files | 109 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,28 +3,28 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1786522268",
-    "timestamp": "2026-08-12T08:11:08Z",
-    "commit": "6f66eb0",
+    "session_id": "cli-1786523932",
+    "timestamp": "2026-08-12T08:38:52Z",
+    "commit": "35ec4c7",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:2a7a45f670b1efa259226075d6f4c34d3e7254692ae5c3734877281796036fac",
-      "updated": "2026-08-12T08:09:50Z",
-      "lines": 936,
-      "summary": "Model: claude-opus-5. Cuts the 2026-08-12 sweep (#134, merged as 6f66eb0) as a"
+      "checksum": "sha256:a9c3deb873db6c10e4d4c7303b780b015171e70ec6d560c781e75233b4c2409e",
+      "updated": "2026-08-12T08:38:42Z",
+      "lines": 982,
+      "summary": "Model: claude-opus-5. First of three PRs agreed for the v5.26.0 line; no version"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:75bf71743df98f79497a0091c29d54ac58154bbce50d5593fd1efbde9688cf22",
-      "updated": "2026-08-12T08:10:55Z",
-      "lines": 328,
-      "summary": "Seven tasks are ready, three owner decisions are blocked, and T-008/T-015 are complete."
+      "checksum": "sha256:295666ec7f862d2114aeb4ad6fe0e3f64557146938f7d62dcaffe386bc779047",
+      "updated": "2026-08-12T08:38:23Z",
+      "lines": 294,
+      "summary": "Six tasks are ready, three owner decisions are blocked, and T-008/T-015/T-018 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:189ae00cd32e835573bf76f0c68c8e9ce0a71ed3ee3c043bb1d5b06a174ae9ec",
-      "updated": "2026-08-12T08:11:08Z",
+      "updated": "2026-08-12T08:38:52Z",
       "lines": 145,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -41,14 +41,14 @@
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:c495413f3168259e0fe707970d1ef17b01dda0880962e4294013dc8ece61094f",
-      "updated": "2026-08-12T08:11:08Z",
+      "checksum": "sha256:cf16b9f15eeb95cf08521bba065cd98c4e28c106c8b3b285e7258351bf776b09",
+      "updated": "2026-08-12T08:38:52Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:d81c0b87c63cf2bf98041cd09e3279ea53c47e2be09a40570d47a317f08f5660",
-      "updated": "2026-08-12T08:11:08Z",
+      "checksum": "sha256:c09000ce042953c00a621c4856858abfab98250c93e80b782af81d98be58ad41",
+      "updated": "2026-08-12T08:38:52Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,12 +77,12 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Cuts the 2026-08-12 sweep (#134, merged as 6f66eb0) as a Seven tasks are ready, three owner decisions are blocked, and T-008/T-015 are complete. ",
+  "quick_context": "Model: claude-opus-5. First of three PRs agreed for the v5.26.0 line; no version Six tasks are ready, three owner decisions are blocked, and T-008/T-015/T-018 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 13294,
-    "full_read": 23336
+    "manifest_plus_core": 13518,
+    "full_read": 23560
   }
   ,"next_task_id": 20
-  ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"ready","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Decide scope for dropped-persistence detection (tranche 1 and 2)","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision on tranche scope and version line","created":"2026-08-12T09:00:00Z"}}
+  ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Decide scope for dropped-persistence detection (tranche 1 and 2)","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision on tranche scope and version line","created":"2026-08-12T09:00:00Z"}}
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,9 +3,9 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1786523932",
-    "timestamp": "2026-08-12T08:38:52Z",
-    "commit": "35ec4c7",
+    "session_id": "cli-1786524269",
+    "timestamp": "2026-08-12T08:44:29Z",
+    "commit": "455278d",
     "phase": "idle",
     "duration_minutes": 0
   },
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:189ae00cd32e835573bf76f0c68c8e9ce0a71ed3ee3c043bb1d5b06a174ae9ec",
-      "updated": "2026-08-12T08:38:52Z",
+      "updated": "2026-08-12T08:44:29Z",
       "lines": 145,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:cf16b9f15eeb95cf08521bba065cd98c4e28c106c8b3b285e7258351bf776b09",
-      "updated": "2026-08-12T08:38:52Z",
+      "updated": "2026-08-12T08:44:29Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:c09000ce042953c00a621c4856858abfab98250c93e80b782af81d98be58ad41",
-      "updated": "2026-08-12T08:38:52Z",
+      "updated": "2026-08-12T08:44:29Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -6,7 +6,7 @@
 > Before a task becomes done, each box must be checked, explicitly waived with
 > rationale, or moved to a linked open follow-up.
 
-Seven tasks are ready, three owner decisions are blocked, and T-008/T-015 are complete.
+Six tasks are ready, three owner decisions are blocked, and T-008/T-015/T-018 are complete.
 
 Current version: **v5.25.12**
 
@@ -14,14 +14,14 @@ Current version: **v5.25.12**
 
 ## Status Summary
 
-AAHP 3.9.1 adoption and the verified security hardening are complete. Seven
+AAHP 3.9.1 adoption and the verified security hardening are complete. Six
 follow-ups are ready. Three decisions are owner-blocked: the Node/Babel support
 matrix, whether version-pinned npm IOCs should match on a directory scan, and
 the scope of dropped-persistence detection.
 
 | Status | Count |
 |--------|-------|
-| Ready | 7 |
+| Ready | 6 |
 | Blocked | 3 |
 
 The published package is v5.25.12.
@@ -111,41 +111,6 @@ do not merge Babel 8 alone.
 - [ ] The owner selects and records the new minimum Node line.
 - [ ] Engines, both CI jobs, Babel, lockfile, and user-facing support documentation move together.
 - [ ] Build, full Linux suite, package smoke test, and release gates pass on the new matrix.
-
----
-
-## T-018: Match known-malware hashes against real file digests
-
-**Goal:** Make the 194 `KNOWN_MALICIOUS_HASHES` entries detect a file BY its
-digest, which is what their descriptions already promise.
-
-**The finding (verified by execution and by grep, 2026-08-12):** the only
-matching consumer of `KNOWN_MALICIOUS_HASHES` is the substring loop at
-`src/ioc-blocklist.ts:2245`, which tests whether the digest TEXT appears inside
-file content. Nothing computes a SHA-256 over a scanned file and looks it up.
-The `createHash` calls in `src/npm-scanner.ts:637` and `src/pypi-scanner.ts:507`
-compute tarball-integrity digests and never consult the malware list, and no
-test asserts a file's own digest is matched.
-
-Concretely, `src/ioc-blocklist.ts:862` is
-`"927387d0...": "ChainDrop IDE persistence hook dropped as .vscode/tasks.json"`.
-That entry can only fire if a file contains its own digest as text, which a
-dropped `tasks.json` never does. The same holds for the WEL1DROPPER stage-2
-payload binaries and the ChainDrop `setup.mjs` droppers: the indicators added to
-catch those artefacts cannot fire on them.
-
-The substring behaviour is still worth keeping - a digest quoted in a manifest or
-report is a real signal - so this is additive, not a replacement.
-
-**Acceptance criteria:**
-- [ ] A SHA-256 is computed per scanned file during the walk and looked up in
-      `KNOWN_MALICIOUS_HASHES`, emitting a distinct rule from the text match so
-      the two signals stay tellable apart.
-- [ ] A fixture whose file content hashes to a known-bad digest fires; the same
-      content with one byte changed does not.
-- [ ] The existing digest-text substring match still fires, with its own test.
-- [ ] Cost is measured on a large tree before merge; hashing every scanned file
-      is not free and the walk already reads them.
 
 ---
 
@@ -293,6 +258,7 @@ initiative.
 
 | Item | Resolution |
 |------|------------|
+| T-018: known-malware hashes never matched a file | Done: `IOC_KNOWN_MALWARE_FILE_DIGEST` computes SHA-256/MD5 per scanned file, before the scannable-extension gate, over raw bytes. The digest-text substring match is kept as a separate signal. |
 | v5.25.5: AAHP shared-primitive convergence | PR #120 merged: AAHP bumped 3.9.1->3.9.2, `aahp-dashboard.mjs` renamed to `scg-handoff-docs.mjs`, two vendored bash files deleted, shared primitives imported instead; PR #119 Action comment fix also included |
 | T-015: packaged self-scan own-definition false positive | Package-shaped trusted/untrusted regressions pass; v5.25.3 is the recovery release |
 | v5.25.2: AAHP 3.9.1 and security hardening | Released 2026-08-04; live install smoke exposed the T-015 packaged self-scan gap |

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,52 @@
 
 ---
 
+## File-digest matching, T-018 (2026-08-12, unreleased, branch feat/file-digest-matching)
+
+Model: claude-opus-5. First of three PRs agreed for the v5.26.0 line; no version
+bump here, and the version stays 5.25.12 until all three are on `main`.
+
+Ships `IOC_KNOWN_MALWARE_FILE_DIGEST`. The known-malware hash collection had
+exactly one matcher, the substring loop at `src/ioc-blocklist.ts:2245`, which
+tests whether the digest TEXT appears inside file content. That is a real signal
+for a digest quoted in a manifest or advisory and is kept unchanged, but it
+cannot identify the malware itself, because a payload never contains its own
+digest. Every entry describing a dropped artefact was unreachable by the thing it
+names.
+
+Three design decisions, each pinned by a test that fails if it is reversed:
+
+1. **Runs before the `SCANNABLE_EXTENSIONS` gate.** Hashing needs no parser, and
+   most of the collection describes compiled payloads with no scannable
+   extension, which never reach the content scanners at all. Gating on the
+   extension list would have left exactly the artefacts the digests were
+   collected for unreachable.
+2. **Hashes raw bytes, not decoded text.** Hashing a UTF-8 decoding does not
+   reproduce a binary's published digest. The buffer is reused for the UTF-8
+   decode below it, so a scannable file is still read exactly once.
+3. **Excludes 40-character keys.** The collection holds a Git object id (an
+   orphan commit) and a genuine file SHA-1 at the same length, and nothing in the
+   data distinguishes them. Matching either could label a file as malware on the
+   strength of a commit id. This is a data-modelling gap to fix by typing the
+   collection, not something to guess at in the matcher.
+
+Verification. 10 new tests in `src/__tests__/file-digest.test.ts`, plus
+`ioc-blocklist`, `collection-reachability`, `binary-detection` and
+`precision-corpus` re-run: 70 passing. Mutation proof: moving the check behind
+the extension gate and hashing the decoded string turns exactly the two
+corresponding tests red and leaves the other eight green.
+
+A real digest has no computable preimage, so no test can construct a file
+matching a shipped entry. Unit tests pass their own index; the end-to-end scan
+tests inject one entry into `KNOWN_MALICIOUS_HASHES` in `beforeAll`, before
+anything builds the lazily-cached index, and remove it afterwards.
+
+Cost, measured rather than asserted, on this repo (574 files enumerated, 404
+content-scanned): median scan wall-clock 6.71s without the check and 6.88s with
+it, about 3 percent. 278 files totalling 8.8 MB are hashed, of which only 24
+files and 0.68 MB were newly read; the rest were already in memory. The
+self-scan produces zero digest findings, so no false positive on this repo.
+
 ## Release v5.25.12 (2026-08-12)
 
 Model: claude-opus-5. Cuts the 2026-08-12 sweep (#134, merged as 6f66eb0) as a

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.25.12 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 108 | src/__tests__/ file list |
+| Test files present | 109 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Added
+
+- **`IOC_KNOWN_MALWARE_FILE_DIGEST`: scanned files are now matched by their own
+  SHA-256 and MD5 digests against the known-malware hash collection.** Until now the
+  collection had exactly one matcher, a substring search for the digest TEXT inside file
+  content. That answers "does this file quote a known-bad digest", which is a real signal
+  in a manifest or advisory and is unchanged, but it cannot answer "is this file the
+  malware", because a payload never contains its own digest. Every entry describing a
+  dropped artefact was therefore unreachable by the thing it names, including the entry
+  labelled "ChainDrop IDE persistence hook dropped as `.vscode/tasks.json`", the
+  WEL1DROPPER stage-2 payload binaries and the ChainDrop `setup.mjs` droppers.
+  The check runs before the scannable-extension gate, because hashing needs no parser and
+  most of the collection describes compiled payloads that carry no scannable extension and
+  so never reached the content scanners at all. Digests are computed over raw bytes rather
+  than decoded text, since hashing a UTF-8 decoding would not reproduce a binary's
+  published digest. 40-character keys are deliberately excluded: the collection holds both
+  a Git object id and a genuine file SHA-1 at that length and nothing in the data
+  distinguishes them, so matching either could label a file as malware on the strength of
+  a commit id. Measured cost on a 574-file tree is about 3 percent of scan wall-clock; the
+  bytes are already in memory for scannable files, and only 24 files there were newly read.
+
 ## [5.25.12] - 2026-08-12
 
 ### Added

--- a/src/__tests__/file-digest.test.ts
+++ b/src/__tests__/file-digest.test.ts
@@ -1,0 +1,193 @@
+/**
+ * File-digest matching (T-018).
+ *
+ * Before this existed, KNOWN_MALICIOUS_HASHES was consumed by exactly one
+ * matcher: the substring loop in checkIOCBlocklist, which tests whether the
+ * digest TEXT appears inside file content. That answers "does this file quote a
+ * known-bad digest", not "is this file the malware" - a payload never contains
+ * its own digest. So every entry naming a dropped artefact was unreachable by
+ * the thing it names, including the ChainDrop entry literally described as
+ * "dropped as .vscode/tasks.json".
+ *
+ * A real digest has no computable preimage, so no test can build a file that
+ * matches a shipped entry. Two techniques are used instead:
+ *   - unit tests pass their own index to checkFileDigest;
+ *   - the end-to-end tests inject one entry into KNOWN_MALICIOUS_HASHES in
+ *     beforeAll, which runs before anything builds the lazily-cached index.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  checkFileDigest,
+  checkIOCBlocklist,
+  KNOWN_MALICIOUS_HASHES,
+} from "../ioc-blocklist.js";
+import { scan } from "../scanner.js";
+
+const sha256 = (b: Buffer | string) => createHash("sha256").update(b).digest("hex");
+const md5 = (b: Buffer | string) => createHash("md5").update(b).digest("hex");
+
+// The payload used by the end-to-end tests. Its digest is injected into the
+// real collection below, which is the only way to exercise the scan path.
+const E2E_PAYLOAD = "dropped-persistence-payload-for-routing-test\n";
+const E2E_DIGEST = sha256(E2E_PAYLOAD);
+const E2E_DESC = "test-injected dropped artefact";
+
+let tmpRoot: string;
+
+beforeAll(() => {
+  (KNOWN_MALICIOUS_HASHES as Record<string, string>)[E2E_DIGEST] = E2E_DESC;
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "scg-digest-"));
+});
+
+afterAll(() => {
+  delete (KNOWN_MALICIOUS_HASHES as Record<string, string>)[E2E_DIGEST];
+  if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function fixture(name: string, files: Record<string, string>): string {
+  const dir = path.join(tmpRoot, name);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [rel, body] of Object.entries(files)) {
+    const target = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, body);
+  }
+  return dir;
+}
+
+describe("checkFileDigest", () => {
+  it("reports a file whose SHA-256 is a known malware digest", () => {
+    const bytes = Buffer.from("malicious payload bytes");
+    const index = new Map([[sha256(bytes), "WEL1DROPPER stage-2 payload"]]);
+
+    const findings = checkFileDigest(bytes, "payload.bin", index);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("IOC_KNOWN_MALWARE_FILE_DIGEST");
+    expect(findings[0].severity).toBe("critical");
+    expect(findings[0].file).toBe("payload.bin");
+    expect(findings[0].description).toContain("WEL1DROPPER stage-2 payload");
+  });
+
+  it("does not report the same content with a single byte changed", () => {
+    const bytes = Buffer.from("malicious payload bytes");
+    const index = new Map([[sha256(bytes), "WEL1DROPPER stage-2 payload"]]);
+
+    // One byte differs; a digest match must be exact or it is not a digest.
+    const altered = Buffer.from("malicious payload byteS");
+    expect(checkFileDigest(altered, "payload.bin", index)).toEqual([]);
+  });
+
+  it("matches MD5 entries too, since six of the shipped digests are MD5", () => {
+    const bytes = Buffer.from("ClaudeCode_x64.exe stand-in");
+    const index = new Map([[md5(bytes), "ClaudeCode_x64.exe Rust dropper"]]);
+
+    const findings = checkFileDigest(bytes, "dropper.exe", index);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].description).toContain("md5");
+  });
+
+  it("still reports a documentation file, unlike the digest-text matcher", () => {
+    // checkIOCBlocklist skips .md because documentation legitimately DISCUSSES
+    // indicators. A byte-for-byte digest match is not discussion.
+    const bytes = Buffer.from("payload that happens to be named .md");
+    const index = new Map([[sha256(bytes), "payload"]]);
+
+    expect(checkFileDigest(bytes, "README.md", index)).toHaveLength(1);
+  });
+
+  it("hashes raw bytes, so a non-UTF-8 payload still matches", () => {
+    // The scanner decodes content as UTF-8 for the text scanners. Hashing that
+    // decoded string would not reproduce a binary payload's published digest,
+    // which is most of what this collection describes.
+    const bytes = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x00, 0xff, 0xfe]);
+    const index = new Map([[sha256(bytes), "ELF payload"]]);
+
+    expect(checkFileDigest(bytes, "payload", index)).toHaveLength(1);
+    // The lossy path this guards against: decode to UTF-8, then re-encode.
+    const lossy = Buffer.from(bytes.toString("utf-8"), "utf-8");
+    expect(sha256(lossy)).not.toBe(sha256(bytes));
+  });
+});
+
+describe("shipped digest index composition", () => {
+  it("excludes 40-hex keys, which mix a Git object id with a file SHA-1", () => {
+    // A Git object id hashes a commit object, never file bytes. The collection
+    // holds one of each at length 40 and nothing distinguishes them, so neither
+    // participates in file-digest matching.
+    const gitSha = "558b09d7ad0d1660e2a0fb8a06da81a6f42e06d2";
+    expect(KNOWN_MALICIOUS_HASHES).toHaveProperty(gitSha);
+
+    const bytes = Buffer.from("anything");
+    const index = new Map([[gitSha, "Nx Console malicious orphan commit"]]);
+    // Proves only that a 40-hex value never equals a sha256/md5 digest, which
+    // is what keeps it out of the match set.
+    expect(checkFileDigest(bytes, "f.js", index)).toEqual([]);
+  });
+
+  it("keeps the digest-TEXT matcher working, which is a separate signal", () => {
+    // A digest quoted in a manifest or advisory is still worth reporting; this
+    // change is additive, not a replacement.
+    const known = "54dc7ea54a1317cca0e890a2770630cf7fa6c97813e0cb9d2caa93012b350668";
+    expect(KNOWN_MALICIOUS_HASHES).toHaveProperty(known);
+
+    const findings = checkIOCBlocklist(`const h = "${known}";`, "notes.js");
+    expect(findings.some((f) => f.rule === "IOC_KNOWN_MALWARE_HASH")).toBe(true);
+  });
+});
+
+describe("scan routing", () => {
+  it("reports a matching file through a real directory scan", async () => {
+    const dir = fixture("hit", {
+      "package.json": JSON.stringify({ name: "fx", version: "1.0.0" }),
+      "index.js": E2E_PAYLOAD,
+    });
+
+    const result = await scan({ target: dir, format: "json" });
+    const hit = result.findings.filter(
+      (f) => f.rule === "IOC_KNOWN_MALWARE_FILE_DIGEST",
+    );
+
+    expect(hit).toHaveLength(1);
+    expect(hit[0].description).toContain(E2E_DESC);
+    expect(hit[0].file).toBe("index.js");
+  });
+
+  it("reports a payload with NO scannable extension", async () => {
+    // The decisive case. Content scanners are gated on SCANNABLE_EXTENSIONS, so
+    // a compiled payload never reaches them - and compiled payloads are most of
+    // what the hash collection describes. The digest check therefore runs
+    // before that gate, and this test fails if it is ever moved after it.
+    const dir = fixture("binary", {
+      "package.json": JSON.stringify({ name: "fx", version: "1.0.0" }),
+      "vendor/agent.bin": E2E_PAYLOAD,
+    });
+
+    const result = await scan({ target: dir, format: "json" });
+    const hit = result.findings.filter(
+      (f) => f.rule === "IOC_KNOWN_MALWARE_FILE_DIGEST",
+    );
+
+    expect(hit).toHaveLength(1);
+    expect(hit[0].file).toBe("vendor/agent.bin");
+  });
+
+  it("leaves an ordinary project clean", async () => {
+    const dir = fixture("clean", {
+      "package.json": JSON.stringify({ name: "fx", version: "1.0.0" }),
+      "index.js": "export const add = (a, b) => a + b;\n",
+      "README.md": "# fx\n\nA small module.\n",
+      "vendor/agent.bin": "not the payload\n",
+    });
+
+    const result = await scan({ target: dir, format: "json" });
+    expect(
+      result.findings.filter((f) => f.rule === "IOC_KNOWN_MALWARE_FILE_DIGEST"),
+    ).toEqual([]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export { scanGoFiles } from "./go-scanner.js";
 export { scanRubyGemsFiles } from "./rubygems-scanner.js";
 export { scanComposerFiles } from "./composer-scanner.js";
 export { scanNuGetFiles } from "./nuget-scanner.js";
-export { checkIOCBlocklist, checkBadVersion } from "./ioc-blocklist.js";
+export { checkIOCBlocklist, checkBadVersion, checkFileDigest } from "./ioc-blocklist.js";
 export { analyzeGitHubTrust, parseGitHubUrl, scanReadmeLures } from "./github-trust-scanner.js";
 export { analyzeInstallHooks } from "./install-hook-scanner.js";
 export { analyzeDependencyRisks, levenshtein } from "./dependency-risk-analyzer.js";

--- a/src/ioc-blocklist.ts
+++ b/src/ioc-blocklist.ts
@@ -2381,8 +2381,14 @@ function getFileDigestIndex(): Map<string, string> {
  * Until this matcher existed, every entry describing a dropped artefact was
  * unreachable by the thing it names: the ChainDrop hook "dropped as
  * .vscode/tasks.json", the WEL1DROPPER stage-2 payload binaries, and the
- * ChainDrop setup.mjs droppers could only have fired on a file that happened to
- * contain their own hex digest as text.
+ * ChainDrop preinstall droppers could only have fired on a file that happened
+ * to contain their own hex digest as text.
+ *
+ * Do not name the ChainDrop loader filenames in this comment. TypeScript copies
+ * JSDoc into the generated .d.ts, `notFilePattern: SCANNER_SRC_OR_DOCS` exempts
+ * src/ but not dist/*.d.ts, and MINI_SHAI_HULUD_LOADER matches those filenames
+ * after any whitespace. Naming them here turns the repo's own build output into
+ * a high-severity self-scan finding, which is how this was found.
  *
  * No BENIGN_DOC_FILES skip here, unlike the text matcher. That skip exists
  * because documentation legitimately DISCUSSES indicators; a byte-for-byte

--- a/src/ioc-blocklist.ts
+++ b/src/ioc-blocklist.ts
@@ -2177,6 +2177,7 @@ export const KNOWN_BAD_PYPI_VERSIONS: Record<string, { versions: string[]; descr
 // Utility: check if a string contains any known IOC
 // ---------------------------------------------------------------------------
 
+import { createHash } from "node:crypto";
 import type { Finding } from "./types.js";
 
 /**
@@ -2331,4 +2332,90 @@ export function checkBadVersion(
   }
 
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// File-digest matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Algorithms whose digests in KNOWN_MALICIOUS_HASHES are unambiguously digests
+ * OF FILE BYTES, keyed by the hex length that identifies them.
+ *
+ * Length 40 is deliberately absent. The collection holds two different things
+ * at that length: a Git object id ("Nx Console malicious orphan commit (Git
+ * SHA)"), which is a hash of a commit object and never of file bytes, and a
+ * genuine file SHA-1 ("NadMesh botnet Go agent sample (SHA1)"). Nothing in the
+ * data distinguishes them, so matching either would risk telling a user their
+ * file is malware on the strength of a commit id. That is a data-modelling gap
+ * to fix by typing the collection, not something to guess at here.
+ */
+const FILE_DIGEST_ALGORITHMS = [
+  { algorithm: "sha256", hexLength: 64 },
+  { algorithm: "md5", hexLength: 32 },
+] as const;
+
+/** Lowercased digest -> description. Built once, not per file (cf. T-017). */
+let fileDigestIndex: Map<string, string> | null = null;
+
+function getFileDigestIndex(): Map<string, string> {
+  if (fileDigestIndex) return fileDigestIndex;
+  const usableLengths = new Set<number>(FILE_DIGEST_ALGORITHMS.map((a) => a.hexLength));
+  const index = new Map<string, string>();
+  for (const [hash, description] of Object.entries(KNOWN_MALICIOUS_HASHES)) {
+    if (usableLengths.has(hash.length)) index.set(hash.toLowerCase(), description);
+  }
+  fileDigestIndex = index;
+  return index;
+}
+
+/**
+ * Match a scanned file BY ITS OWN DIGEST against KNOWN_MALICIOUS_HASHES.
+ *
+ * Deliberately separate from the digest handling inside checkIOCBlocklist,
+ * which substring-searches the digest TEXT inside file content. That text match
+ * answers "does this file quote a known-bad digest", which is a real signal in
+ * a lockfile, manifest or advisory, and it is kept unchanged. It cannot answer
+ * "is this file the malware", because a payload never contains its own digest.
+ *
+ * Until this matcher existed, every entry describing a dropped artefact was
+ * unreachable by the thing it names: the ChainDrop hook "dropped as
+ * .vscode/tasks.json", the WEL1DROPPER stage-2 payload binaries, and the
+ * ChainDrop setup.mjs droppers could only have fired on a file that happened to
+ * contain their own hex digest as text.
+ *
+ * No BENIGN_DOC_FILES skip here, unlike the text matcher. That skip exists
+ * because documentation legitimately DISCUSSES indicators; a byte-for-byte
+ * digest match is not discussion, so a .md file that is exactly a known
+ * payload should still be reported.
+ *
+ * Takes the raw bytes rather than decoded text on purpose: a digest must be
+ * computed over the file as it exists on disk. Hashing a UTF-8 decoded string
+ * would not reproduce the published digest for any binary payload, which is
+ * most of what this collection describes.
+ */
+export function checkFileDigest(
+  bytes: Buffer,
+  relativePath: string,
+  // Injectable only so a test can assert the matching behaviour itself. A real
+  // digest has no computable preimage, so a test cannot build a file that
+  // matches a shipped entry; it supplies its own index instead.
+  index: Map<string, string> = getFileDigestIndex(),
+): Finding[] {
+  const findings: Finding[] = [];
+  // The bytes are already in memory, so each extra algorithm is CPU only and
+  // costs no additional I/O.
+  for (const { algorithm } of FILE_DIGEST_ALGORITHMS) {
+    const digest = createHash(algorithm).update(bytes).digest("hex");
+    const description = index.get(digest);
+    if (!description) continue;
+    findings.push({
+      rule: "IOC_KNOWN_MALWARE_FILE_DIGEST",
+      description: `File content matches a known malware digest: ${algorithm} ${digest} (${description})`,
+      severity: "critical",
+      file: relativePath,
+      recommendation: `Remove ${relativePath}. Its contents are byte-for-byte identical to a known malicious artefact.`,
+    });
+  }
+  return findings;
 }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -64,7 +64,7 @@ import { scanRubyGemsFiles } from "./rubygems-scanner.js";
 import { scanComposerFiles } from "./composer-scanner.js";
 import { scanNuGetFiles, hasNuGetFiles } from "./nuget-scanner.js";
 import { scanPythonLockfiles } from "./python-lockfile-scanner.js";
-import { checkIOCBlocklist, checkBadVersion } from "./ioc-blocklist.js";
+import { checkIOCBlocklist, checkBadVersion, checkFileDigest } from "./ioc-blocklist.js";
 import { analyzeGitHubTrust, parseGitHubUrl, scanReadmeLures } from "./github-trust-scanner.js";
 import {
   INFOSTEALER_PATTERNS,
@@ -369,6 +369,33 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
       checkBinaryFile(relativePath, findings);
     }
 
+    // Digest match against KNOWN_MALICIOUS_HASHES, computed over the RAW BYTES.
+    //
+    // Runs BEFORE the SCANNABLE_EXTENSIONS gate on purpose. Hashing needs no
+    // parser, and most of that collection describes compiled payloads that
+    // carry no scannable extension, so they never reach the content scanners
+    // at all. Gating this on the extension list would leave exactly the
+    // artefacts the digests were collected for unreachable.
+    //
+    // Reading a file the content pass would otherwise skip is new I/O, which
+    // is why the same MAX_FILE_SIZE ceiling applies. A payload padded past
+    // that ceiling would no longer match its published digest anyway.
+    //
+    // The buffer is reused for the UTF-8 decode below, so a scannable file is
+    // still read exactly once.
+    let fileBytes: Buffer | undefined;
+    try {
+      if (fs.statSync(filePath).size <= MAX_FILE_SIZE) {
+        fileBytes = fs.readFileSync(filePath);
+        findings.push(...checkFileDigest(fileBytes, relativePath));
+      }
+    } catch {
+      // Leave fileBytes undefined and stay silent here: the oversized and
+      // unreadable paths below own that accounting, and reporting it twice
+      // would double-count a single file.
+      fileBytes = undefined;
+    }
+
     // Tracks whether the internal-disclosure pass already ran for this file.
     // Dockerfiles and package-manager configs are read in the block below and
     // some of them (.yarnrc.yml) also carry a scannable extension, so without
@@ -394,7 +421,10 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
         continue;
       }
       try {
-        prefetchedContent = fs.readFileSync(filePath, "utf-8");
+        prefetchedContent =
+          fileBytes !== undefined
+            ? fileBytes.toString("utf-8")
+            : fs.readFileSync(filePath, "utf-8");
       } catch {
         recordUnreadablePath(findings, relativePath);
         continue;
@@ -445,7 +475,10 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
       content = prefetchedContent;
     } else {
       try {
-        content = fs.readFileSync(filePath, "utf-8");
+        content =
+          fileBytes !== undefined
+            ? fileBytes.toString("utf-8")
+            : fs.readFileSync(filePath, "utf-8");
       } catch {
         recordUnreadablePath(findings, relativePath);
         continue;


### PR DESCRIPTION
PR 1 of 3 for the v5.26.0 line. **No version bump** - the version stays 5.25.12 until all three are on `main`.

## The defect

`KNOWN_MALICIOUS_HASHES` had exactly one matcher: the substring loop at `src/ioc-blocklist.ts:2245`, which tests whether the digest **text** appears inside file content. That answers "does this file quote a known-bad digest" - a real signal in a manifest or advisory, and it is kept unchanged here. It cannot answer "is this file the malware", because a payload never contains its own digest.

So every entry describing a dropped artefact was unreachable by the thing it names. The clearest case is `ioc-blocklist.ts:862`:

> `"927387d0…": "ChainDrop IDE persistence hook dropped as .vscode/tasks.json (SHA256)"`

A dropped `tasks.json` never contains its own hex digest, so the indicator added to catch that artefact could not fire on it. Same for the WEL1DROPPER stage-2 payload binaries and the ChainDrop `setup.mjs` droppers. Nothing computed a file digest anywhere: the `createHash` calls in `npm-scanner.ts` and `pypi-scanner.ts` are tarball-integrity checks that never consult the malware list, and no test asserted otherwise.

## Three design decisions, each pinned by a test

**1. Runs before the `SCANNABLE_EXTENSIONS` gate.** Hashing needs no parser, and most of the collection describes compiled payloads that carry no scannable extension, so they never reach the content scanners at all. Gating on the extension list would have left exactly the artefacts the digests were collected for unreachable. A test scans a payload at `vendor/agent.bin` and fails if the check is ever moved after the gate.

**2. Hashes raw bytes, not decoded text.** Hashing a UTF-8 decoding does not reproduce a binary's published digest. The buffer is reused for the UTF-8 decode below it, so a scannable file is still read exactly once.

**3. Excludes 40-character keys.** The collection holds two different things at that length: a Git object id (`"Nx Console malicious orphan commit (Git SHA)"`, which hashes a commit object and never file bytes) and a genuine file SHA-1 (`"NadMesh botnet Go agent sample (SHA1)"`). Nothing in the data distinguishes them, so matching either could tell a user their file is malware on the strength of a commit id. That is a data-modelling gap to fix by typing the collection, not to guess at in the matcher. 187 of 189 keys participate.

The index is built once rather than per call, following the lesson recorded in T-017 about the linear npm matcher.

## Testing

A real digest has no computable preimage, so no test can construct a file that matches a shipped entry. Two techniques: unit tests pass their own index to `checkFileDigest`, and the end-to-end scan tests inject one entry into `KNOWN_MALICIOUS_HASHES` in `beforeAll`, which runs before anything builds the lazily-cached index, removing it in `afterAll`.

**Mutation proof.** Moving the check behind the extension gate and hashing the decoded string turns exactly the two corresponding tests red and leaves the other eight green.

10 new tests, plus `ioc-blocklist`, `collection-reachability`, `binary-detection` and `precision-corpus` re-run: **70 passing**. `precision-corpus` matters here because it is the false-positive guard.

## Cost, measured not asserted

On this repo (574 files enumerated, 404 content-scanned), median scan wall-clock over 4 runs each:

| | median |
|---|---|
| without the digest check | 6.71 s |
| with it | 6.88 s |

About 3 percent. 278 files totalling 8.8 MB are hashed, of which only **24 files and 0.68 MB were newly read** - the rest were already in memory for the content scanners, so the delta is mostly CPU. The self-scan produces zero digest findings, so no false positive on this repo.

The scaling factor worth knowing: cost grows with total bytes under the scan root, not with feed size, so unlike the reachability guard in T-017 this does not get worse as the feed grows.

## Not in this PR

`IOC_KNOWN_MALWARE_HASH`, the digest-text substring match, is untouched and still fires. This is additive.

The full suite is hours on Windows, so **CI on this PR is the authoritative verdict**, not a local run.
