### PR TITLE
feat(scanner): report install hooks that register OS-level persistence

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.25.12 |
 | Node engines | >=20.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 110 under `src/__tests__/` |
+| Test files | 111 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,28 +3,28 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1786526134",
-    "timestamp": "2026-08-12T09:15:34Z",
-    "commit": "13b7d2a",
+    "session_id": "cli-1786526822",
+    "timestamp": "2026-08-12T09:27:02Z",
+    "commit": "b5ca8c6",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:b58d27cbe74afc0e2fb35b75e312a64cafbdcd3c99f047b184843c581dbafd1b",
-      "updated": "2026-08-12T09:15:25Z",
-      "lines": 1033,
-      "summary": "Model: claude-opus-5. PR 2 of 3 for the v5.26.0 line. No version bump."
+      "checksum": "sha256:3fe55dd7b79cc110916dbe664b8b46393e8f9b3948b7386a875df71efde2f8c2",
+      "updated": "2026-08-12T09:26:54Z",
+      "lines": 1067,
+      "summary": "Model: claude-opus-5. PR 3 of 3 for the v5.26.0 line. No version bump. With this"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:7106bdfc08714956af7ea445eec3151b4a2bc68662546231ac66daed3af9c8bf",
-      "updated": "2026-08-12T09:15:04Z",
-      "lines": 299,
-      "summary": "Seven tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018 are complete."
+      "checksum": "sha256:ee3aa5c67d3bf85f3005ce7818aa7c8e21bdcb97bf2bb0608076d3524c169861",
+      "updated": "2026-08-12T09:26:38Z",
+      "lines": 244,
+      "summary": "Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:189ae00cd32e835573bf76f0c68c8e9ce0a71ed3ee3c043bb1d5b06a174ae9ec",
-      "updated": "2026-08-12T09:15:34Z",
+      "updated": "2026-08-12T09:27:02Z",
       "lines": 145,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -41,14 +41,14 @@
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:879ac36ce3d0d9cf2f674d9185844181241a50757b25569bb60c0faeb23644a5",
-      "updated": "2026-08-12T09:15:34Z",
+      "checksum": "sha256:0ea398d20dd033822b4c95a7b308c12090ee93d0594ab909be6c7e5f3d369a33",
+      "updated": "2026-08-12T09:27:02Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:3ef9099462dfd32b8da06757e52e9db26bb10edff11158e90c1c31dd361e0c24",
-      "updated": "2026-08-12T09:15:34Z",
+      "checksum": "sha256:19a7ddd726c5901b84ade2cccf07c5d0e358d439c14e35999721de28e601a0e8",
+      "updated": "2026-08-12T09:27:02Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,12 +77,12 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. PR 2 of 3 for the v5.26.0 line. No version bump. Seven tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018 are complete. ",
+  "quick_context": "Model: claude-opus-5. PR 3 of 3 for the v5.26.0 line. No version bump. With this Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 14143,
-    "full_read": 24185
+    "manifest_plus_core": 14049,
+    "full_read": 24091
   }
   ,"next_task_id": 20
-  ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection: tranche 1 shipped, tranche 2 remaining","status":"ready","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}
+  ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}
 }

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -6,7 +6,7 @@
 > Before a task becomes done, each box must be checked, explicitly waived with
 > rationale, or moved to a linked open follow-up.
 
-Seven tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018 are complete.
+Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete.
 
 Current version: **v5.25.12**
 
@@ -14,13 +14,13 @@ Current version: **v5.25.12**
 
 ## Status Summary
 
-AAHP 3.9.1 adoption and the verified security hardening are complete. Seven
+AAHP 3.9.1 adoption and the verified security hardening are complete. Six
 follow-ups are ready. Two decisions are owner-blocked: the Node/Babel support
 matrix and whether version-pinned npm IOCs should match on a directory scan.
 
 | Status | Count |
 |--------|-------|
-| Ready | 7 |
+| Ready | 6 |
 | Blocked | 2 |
 
 The published package is v5.25.12.
@@ -110,62 +110,6 @@ do not merge Babel 8 alone.
 - [ ] The owner selects and records the new minimum Node line.
 - [ ] Engines, both CI jobs, Babel, lockfile, and user-facing support documentation move together.
 - [ ] Build, full Linux suite, package smoke test, and release gates pass on the new matrix.
-
----
-
-## T-019: Dropped-persistence detection, tranche 2
-
-**Goal:** Close, or consciously decline, the persistence-detection gap the
-2026-08-12 sweep escalated.
-
-**Measured coverage (10 fixtures against a fresh v5.25.11 build, 2026-08-12):**
-one of five ChainDrop persistence artefacts is detected, and for the wrong
-reason. LaunchAgent plist plus `launchctl load`: miss, only a 202-char
-`COMPLEX_INSTALL_SCRIPT` length heuristic. Dropped `~/.local/bin` script plus
-`chmod +x`: the drop fires nothing. systemd unit plus `systemctl --user enable`:
-total miss, `systemctl` does not appear anywhere in `dist/`. `.claude/settings.json`
-hook: two criticals. `.vscode/tasks.json` `runOn: folderOpen`: total miss.
-
-Two discriminator fixtures are the actual finding:
-- Replacing the `.claude/settings.json` hook body `curl|bash` with the realistic
-  `$HOME/.local/bin/gh-token-monitor.sh &` drops detection to zero. Autostart-hook
-  injection is not itself flagged; only an independently dangerous command that
-  happens to sit in a hook. Drop plus hook-chain is therefore fully undetected.
-- The identical `curl|bash` yields two criticals in `.claude/settings.json` and
-  zero in `.vscode/tasks.json`, with the file confirmed read. That is a recall
-  gap in a file already opened, not a scope question.
-
-A positive-control fixture fired four criticals and a benign control stayed
-clean, so the negatives are real rather than a broken harness.
-
-**Rejected outright:** a `KNOWN_PERSISTENCE_PATHS` collection.
-`checkIOCBlocklist(content, relativePath)` never tests the path, the walk is
-bounded to the scan root so `~/.local/bin` and `~/Library/LaunchAgents` are
-unreachable by construction, and `FeedIOC.type` is a closed union with no `path`
-member. Measured false-positive surface: 23 of 84 project directories in this
-estate carry a legitimate `.claude/settings.json`.
-
-**Scope decided.** Three PRs, then a v5.26.0 minor. Tranche 1 shipped: the
-`.vscode/tasks.json` recall gap and `CHAINDROP_GH_TOKEN_MONITOR_PERSISTENCE`,
-including the hook-scanner wiring needed because the core walk excludes
-`.claude/`. Measured against the five published artefacts, coverage went from
-one of five to five of five with the benign control still clean.
-
-**Remaining (tranche 2):** an `INSTALL_HOOK_PERSISTENCE_WRITE` rule scoped
-strictly to the install-script strings `install-hook-scanner.ts` already reads
-(`launchctl`, `systemctl --user enable`, `crontab`, `schtasks`, a
-`CurrentVersion\Run` key, a site-packages `.pth`). It only raises attacker cost:
-the hook string is all the scanner sees, so `node scripts/configure.js` still
-hides the call, and the CHANGELOG should say so.
-
-**Acceptance criteria:**
-- [ ] Owner selects tranche scope and whether it lands on 5.25.x or 5.26.0.
-- [ ] Every shipped rule is content- or behaviour-discriminated, never
-      path-discriminated.
-- [ ] `precision-corpus.test.ts` gains legitimate `.claude/settings.json` and
-      `.vscode/tasks.json` samples before any structural heuristic ships; it has
-      neither today.
-- [ ] Any `runOn: folderOpen` heuristic stays at info on its own.
 
 ---
 
@@ -263,6 +207,7 @@ initiative.
 
 | Item | Resolution |
 |------|------------|
+| T-019: dropped-persistence detection | Done in two tranches: `.vscode/tasks.json` recall, `CHAINDROP_GH_TOKEN_MONITOR_PERSISTENCE` (also wired into the hook scanner, since the core walk excludes `.claude/`), and `INSTALL_HOOK_PERSISTENCE_WRITE`. Coverage of the five published artefacts went from one of five to five of five. |
 | T-018: known-malware hashes never matched a file | Done: `IOC_KNOWN_MALWARE_FILE_DIGEST` computes SHA-256/MD5 per scanned file, before the scannable-extension gate, over raw bytes. The digest-text substring match is kept as a separate signal. |
 | v5.25.5: AAHP shared-primitive convergence | PR #120 merged: AAHP bumped 3.9.1->3.9.2, `aahp-dashboard.mjs` renamed to `scg-handoff-docs.mjs`, two vendored bash files deleted, shared primitives imported instead; PR #119 Action comment fix also included |
 | T-015: packaged self-scan own-definition false positive | Package-shaped trusted/untrusted regressions pass; v5.25.3 is the recovery release |

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,40 @@
 
 ---
 
+## Install-hook persistence, T-019 tranche 2 (2026-08-12, unreleased, branch feat/install-hook-persistence)
+
+Model: claude-opus-5. PR 3 of 3 for the v5.26.0 line. No version bump. With this
+merged, T-019 is complete and the version bump is the only remaining step.
+
+Adds `INSTALL_HOOK_PERSISTENCE_WRITE`: launchd, systemd, cron, Windows scheduled
+tasks, the `CurrentVersion\Run` key, the Startup folder, and an auto-imported
+`site-packages` `.pth`. Reported at **high, not critical**, so a consumer running
+`--fail-on critical` is unaffected by a new rule; a package that legitimately
+registers a service is rare but not impossible, and high is the honest level for
+it.
+
+Scope is the whole reason the false-positive surface is small. The rule reads
+only the six package.json install-script strings `install-hook-scanner.ts`
+already reads. The identical commands in ordinary source belong to any service
+manager or devops tool, where they would false-positive constantly. Ten benign
+hooks are pinned as clean, including `systemctl restart nginx`, which is not
+persistence registration and must not fire.
+
+**The limit that follows from that scope, demonstrated rather than asserted.**
+The hook string is all the rule sees. Fixture A (persistence inline in the
+postinstall) now fires; fixture C (`"install": "node index.js"`, with the
+`systemctl` call inside `index.js`) still does not, and that is correct
+behaviour for a string-level check rather than a miss. A test pins it, so if it
+ever starts passing the limit has been lifted and the CHANGELOG claim needs
+updating with it. Said plainly in the CHANGELOG: this raises the cost of the
+attack, it does not close it.
+
+Verification: 24 new tests, 12 detection and 12 benign/boundary. Mutation proof:
+neutering the mechanism regex turns exactly the 12 detection tests red and leaves
+all 12 benign and boundary tests green. `install-hook-scanner`,
+`install-hook-host-runtime-patch`, `precision-corpus`, `rule-precision`,
+`persistence-recall`, `file-digest` and `self-scan-recognition` all re-run green.
+
 ## Persistence recall, T-019 tranche 1 (2026-08-12, unreleased, branch feat/persistence-recall)
 
 Model: claude-opus-5. PR 2 of 3 for the v5.26.0 line. No version bump.

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.25.12 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 110 | src/__tests__/ file list |
+| Test files present | 111 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
   already-dropped script would otherwise reach no pattern table at all: that shape
   produced zero findings before this change. The literal is defined once and shared
   between the pattern table and the hook scanner so the two cannot drift.
+- **`INSTALL_HOOK_PERSISTENCE_WRITE`: install hooks that register OS-level persistence are
+  now reported.** Covers launchd (`launchctl`, `LaunchAgents`/`LaunchDaemons`), systemd
+  (`systemctl enable`, unit paths), cron (`crontab`, `/etc/cron.*`), Windows scheduled
+  tasks (`schtasks /create`), the `CurrentVersion\Run` key, the Startup folder, and an
+  auto-imported `site-packages` `.pth`. Installing a package should not schedule code to
+  run again later, and that step is what turns a one-shot credential stealer into a
+  permanent re-harvester. Reported at **high**, not critical, so `--fail-on critical`
+  pipelines are unaffected by the new rule.
+  Scope is deliberately narrow: it reads only the six package.json install-script strings
+  the install-hook scanner already reads. The same commands in ordinary source belong to
+  any service manager or devops tool and would false-positive constantly. **The honest
+  limit that follows: the hook string is all the rule sees, so a hook that calls out to
+  `node scripts/configure.js` hides the call entirely.** This raises the cost of the
+  attack rather than closing it, and a test pins that boundary so it stays visible.
 
 - **`IOC_KNOWN_MALWARE_FILE_DIGEST`: scanned files are now matched by their own
   SHA-256 and MD5 digests against the known-malware hash collection.** Until now the

--- a/src/__tests__/install-hook-persistence.test.ts
+++ b/src/__tests__/install-hook-persistence.test.ts
@@ -1,0 +1,158 @@
+/**
+ * INSTALL_HOOK_PERSISTENCE_WRITE (T-019, tranche 2).
+ *
+ * An install hook that registers launchd, systemd, cron, a scheduled task, a
+ * Windows Run key, a Startup entry or an auto-imported .pth is scheduling code
+ * to run again later, independently of the package being installed. That is how
+ * a one-shot credential stealer becomes a permanent re-harvester.
+ *
+ * Scope is the point. The rule only reads the six package.json install-script
+ * strings this scanner already reads. The same commands in ordinary source
+ * belong to any service manager or devops tool and would false-positive
+ * constantly, so the narrow scope is what keeps the rule cheap.
+ *
+ * The last test pins the honest limit: the hook string is all the scanner sees,
+ * so indirection through a script file defeats it. That is a real boundary, not
+ * an oversight, and it is stated in the CHANGELOG.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { analyzeInstallHooks } from "../install-hook-scanner.js";
+import { scan } from "../scanner.js";
+
+const RULE = "INSTALL_HOOK_PERSISTENCE_WRITE";
+const hits = (script: string, hook = "postinstall") =>
+  analyzeInstallHooks({ [hook]: script }, "package.json").filter(
+    (f) => f.rule === RULE,
+  );
+
+let tmpRoot: string;
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "scg-ihp-"));
+});
+afterAll(() => {
+  if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("persistence mechanisms are detected", () => {
+  const cases: [string, string][] = [
+    ["macOS launchd", "cp a.plist ~/Library/LaunchAgents/x.plist && launchctl load -w ~/Library/LaunchAgents/x.plist"],
+    ["systemd user unit", "systemctl --user daemon-reload && systemctl --user enable --now x.service"],
+    ["systemd system unit", "cp x.service /etc/systemd/system/ && systemctl enable x"],
+    ["cron", "(crontab -l; echo '*/5 * * * * /tmp/x.sh') | crontab -"],
+    ["cron drop-in", "cp x /etc/cron.d/x"],
+    ["Windows scheduled task", "schtasks /create /tn Updater /tr C:\\\\x.exe /sc onlogon"],
+    ["Windows Run key", "reg add HKCU\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run /v X /d C:\\\\x.exe"],
+    ["Startup folder", "copy x.lnk \"%APPDATA%\\\\Microsoft\\\\Windows\\\\Start Menu\\\\Programs\\\\Startup\""],
+    ["python auto-import pth", "cp hook.pth /usr/lib/python3/site-packages/hook.pth"],
+  ];
+
+  for (const [label, script] of cases) {
+    it(`fires on ${label}`, () => {
+      const found = hits(script);
+      expect(found).toHaveLength(1);
+      expect(found[0].severity).toBe("high");
+    });
+  }
+
+  it("fires on every install-script hook name, not just postinstall", () => {
+    for (const hook of ["preinstall", "install", "prepare", "postuninstall"]) {
+      expect(hits("launchctl load -w x.plist", hook)).toHaveLength(1);
+    }
+  });
+
+  it("stays high rather than critical, so critical-gated pipelines are unaffected", () => {
+    // A package that legitimately registers a service exists, even if it is
+    // rare. Reporting at high keeps `--fail-on critical` consumers untouched
+    // while still surfacing it.
+    expect(hits("launchctl load x")[0].severity).toBe("high");
+  });
+});
+
+describe("ordinary build hooks stay clean", () => {
+  const benign = [
+    "node scripts/build.js",
+    "tsc",
+    "npm run build && npm run test",
+    "patch-package",
+    "husky install",
+    "node-gyp rebuild",
+    "prisma generate",
+    "echo 'thanks for installing'",
+    // Restarting a service is not registering persistence.
+    "systemctl restart nginx",
+    // "install" as a word, and a path that merely mentions run.
+    "npm install --production && node ./scripts/run-migrations.js",
+  ];
+
+  for (const script of benign) {
+    it(`ignores: ${script}`, () => {
+      expect(hits(script)).toEqual([]);
+    });
+  }
+});
+
+describe("scan routing and the honest limit", () => {
+  function fixture(name: string, files: Record<string, string>): string {
+    const dir = path.join(tmpRoot, name);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const [rel, body] of Object.entries(files)) {
+      const target = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, body);
+    }
+    return dir;
+  }
+
+  it("reports through a real directory scan", async () => {
+    const dir = fixture("inline", {
+      "package.json": JSON.stringify({
+        name: "fx",
+        version: "1.0.0",
+        scripts: { postinstall: "systemctl --user enable --now updater.service" },
+      }),
+    });
+
+    const report = await scan({ target: dir, format: "json" });
+    const found = report.findings.filter((f) => f.rule === RULE);
+
+    expect(found).toHaveLength(1);
+    expect(found[0].file).toBe("package.json");
+  });
+
+  it("does NOT see persistence hidden behind a script file", async () => {
+    // The honest boundary. The hook string is all this rule reads, so calling
+    // out to a file defeats it. Detecting that needs the script's CONTENTS,
+    // which is a different rule against a different input. Recorded rather than
+    // papered over; if this ever starts passing, the limit has been lifted and
+    // the CHANGELOG claim should be updated with it.
+    const dir = fixture("indirect", {
+      "package.json": JSON.stringify({
+        name: "fx",
+        version: "1.0.0",
+        scripts: { postinstall: "node scripts/configure.js" },
+      }),
+      "scripts/configure.js":
+        "require('child_process').execSync('systemctl --user enable --now updater.service');\n",
+    });
+
+    const report = await scan({ target: dir, format: "json" });
+    expect(report.findings.filter((f) => f.rule === RULE)).toEqual([]);
+  });
+
+  it("leaves an ordinary package clean", async () => {
+    const dir = fixture("clean", {
+      "package.json": JSON.stringify({
+        name: "fx",
+        version: "1.0.0",
+        scripts: { build: "tsc", postinstall: "node scripts/build.js" },
+      }),
+      "scripts/build.js": "console.log('build');\n",
+    });
+
+    const report = await scan({ target: dir, format: "json" });
+    expect(report.findings.filter((f) => f.rule === RULE)).toEqual([]);
+  });
+});

--- a/src/install-hook-scanner.ts
+++ b/src/install-hook-scanner.ts
@@ -27,6 +27,30 @@ const HOST_RUNTIME_PATH_RE =
 const CODE_MUTATE_RE =
   /\b(?:patch|inject|mutate|overwrite|rewrite|monkey[-\s]?patch|codemod)\b|\bsed\s+-i\b|\.patch(?:\.sh)?\b/i;
 
+// ── INSTALL_HOOK_PERSISTENCE_WRITE detection ────────────────────────────────
+// An install hook that registers code to run AGAIN LATER, independently of the
+// package being installed: a launchd agent, a systemd unit, a cron entry, a
+// scheduled task, a Windows Run key, a Startup-folder entry, or a Python .pth
+// that the interpreter auto-imports.
+//
+// Scoped deliberately to the six package.json install-script strings this module
+// already reads. That is the whole reason its false-positive surface is small:
+// installing persistence from an install hook has essentially no legitimate
+// form, whereas the same commands in ordinary source belong to any service
+// manager, installer or devops tool and would false-positive constantly.
+//
+// It also means the check only sees the hook STRING. A hook that shells out to
+// `node scripts/configure.js` hides the call completely, so this raises the cost
+// of the attack rather than closing it. Said plainly in the CHANGELOG too.
+//
+// Each alternative is specific enough to stand alone, or pairs two required
+// parts (`schtasks` with `/create`, `site-packages` with `.pth`). Gaps are
+// bounded so the expression cannot backtrack pathologically on a long one-liner.
+
+/** Registration of a persistence mechanism with the operating system. */
+const PERSISTENCE_WRITE_RE =
+  /\blaunchctl\b|\bsystemctl\b[^\n]{0,40}\b(?:enable|link)\b|\bcrontab\b|\bschtasks\b[^\n]{0,60}\/create\b|Library[\\/]+Launch(?:Agents|Daemons)|\.config[\\/]+systemd[\\/]+user|\/etc\/systemd\/system|\/etc\/cron\.[a-z]+|Start\s?Menu[\\/]+Programs[\\/]+Startup|CurrentVersion[\\/]+Run\b|site-packages[^\n]{0,80}\.pth\b/i;
+
 interface InstallScripts {
   preinstall?: string;
   postinstall?: string;
@@ -78,6 +102,20 @@ export function analyzeInstallHooks(
         confidence: 0.95,
         category: "malware",
         recommendation: "Never download and execute code during npm install. This is almost certainly malicious.",
+      });
+    }
+
+    // Registering OS-level persistence from an install hook
+    if (PERSISTENCE_WRITE_RE.test(script)) {
+      findings.push({
+        rule: "INSTALL_HOOK_PERSISTENCE_WRITE",
+        description: `${hook} script registers OS-level persistence (launchd, systemd, cron, a scheduled task, a Run key, a Startup entry, or an auto-imported .pth). Installing a package should not schedule code to run again later, and this is how a one-shot credential stealer becomes a permanent re-harvester.`,
+        severity: "high",
+        file: relativePath,
+        match: truncate(`${hook}: ${script}`),
+        confidence: 0.8,
+        category: "malware",
+        recommendation: "Do not let a package install persistence at install time. Install with --ignore-scripts, inspect what the hook schedules, and remove any launchd/systemd/cron entry it already created. Background services should be an explicit, user-invoked step.",
       });
     }
 


### PR DESCRIPTION
PR 3 of 3 for the v5.26.0 line, completing T-019. **No version bump** - with this merged, the bump is the only remaining step.

## The rule

`INSTALL_HOOK_PERSISTENCE_WRITE`. An install hook that registers launchd, systemd, cron, a Windows scheduled task, a `CurrentVersion\Run` key, a Startup entry, or an auto-imported `site-packages` `.pth` is scheduling code to run again later, independently of the package being installed. That step is what turns a one-shot credential stealer into a permanent re-harvester, and it is exactly what the ChainDrop chain does.

Reported at **high, not critical**, so a consumer running `--fail-on critical` is not affected by a newly added rule. A package that legitimately registers a service is rare but not impossible, and high is the honest level for it.

## Scope is the reason the FP surface is small

The rule reads only the six package.json install-script strings `install-hook-scanner.ts` already reads. The identical commands in ordinary source belong to any service manager, installer or devops tool, where they would false-positive constantly.

Ten benign hooks are pinned clean, including `systemctl restart nginx` - restarting a service is not registering one, and it must not fire.

## The limit, demonstrated rather than asserted

The hook string is all the rule sees. From the original fixture set:

| Fixture | Hook | Result |
|---|---|---|
| A | `... && launchctl load -w ~/Library/LaunchAgents/...` | **fires** |
| C | `"install": "node index.js"` (the `systemctl` call lives in `index.js`) | does **not** fire |

That is correct behaviour for a string-level check, not a miss. Detecting C needs the script's *contents*, which is a different rule against a different input. A test pins the boundary, so if it ever starts passing the limit has been lifted and the CHANGELOG claim should be updated with it.

**Stated plainly in the CHANGELOG: this raises the cost of the attack, it does not close it.**

## Verification

- **24 new tests**: 12 detection, 12 benign/boundary.
- **Mutation proof**: neutering the mechanism regex turns exactly the 12 detection tests red and leaves all 12 benign and boundary tests green.
- Re-run green: `install-hook-scanner`, `install-hook-host-runtime-patch`, `precision-corpus`, `rule-precision`, plus `persistence-recall` and `file-digest` from PRs 1 and 2, and `self-scan-recognition` (the gate that caught PR 1).
- The full suite is hours on Windows, so **CI on this PR is the authoritative verdict**.

## Where the three PRs leave things

| | Before | After |
|---|---|---|
| ChainDrop persistence artefacts detected | 1 of 5 | **5 of 5** |
| Known-malware hashes that can match a file | 0 of 194 | **187 of 189 eligible** |
| `.vscode/tasks.json` dangerous commands | not inspected | inspected |

Ready for the v5.26.0 bump once this lands.
