### PR TITLE
docs(handoff): re-sync the STATUS snapshot after the v5.26.6 release

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787039167",
-    "timestamp": "2026-08-18T07:46:07Z",
-    "commit": "8ca7fee",
+    "session_id": "cli-1787043215",
+    "timestamp": "2026-08-18T08:53:36Z",
+    "commit": "c5be80d",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1807701c52265f32c9857b47ea14d5e7854855908fe69f8214a5035de482fd2f",
-      "updated": "2026-08-18T07:40:49Z",
-      "lines": 1680,
+      "checksum": "sha256:fd6b7d7ed62a3968ca44773ba05d810c9ec3e5375c4d6683f08bc858eff97a81",
+      "updated": "2026-08-18T08:53:21Z",
+      "lines": 1682,
       "summary": "Deliberately a top-level section rather than another dated \"Open for the owner\". Both"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:ba24e28ab8896ad973937e50d0e82307335e87f47cdee7b9bafa89ab9d96d8a5",
-      "updated": "2026-08-18T07:45:59Z",
-      "lines": 244,
+      "checksum": "sha256:e74e9bb19964024acb8f615e37adc23deebf040662c8d78213d728de4396fb9a",
+      "updated": "2026-08-18T08:53:21Z",
+      "lines": 243,
       "summary": "Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:62f6ef38070fd6c25210d5c9eac62d88e3d5ef15331780afb1634f5b94d2a88d",
-      "updated": "2026-08-18T07:46:06Z",
+      "updated": "2026-08-18T08:53:34Z",
       "lines": 152,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-08-18T07:38:34Z",
+      "updated": "2026-08-18T08:52:36Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-08-18T07:38:34Z",
+      "updated": "2026-08-18T08:52:36Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:7d342488c5cfae853c622ae7b6586dbbfa0a09286a5b6b8755827e964c6a1ef9",
-      "updated": "2026-08-18T07:46:06Z",
+      "updated": "2026-08-18T08:53:34Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:7678a93c94e430fc8dd0baa1074282de32d0b6e20ab09713d14c0f3491a1004a",
-      "updated": "2026-08-18T07:46:06Z",
+      "updated": "2026-08-18T08:53:34Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:7f1cf7867dcca4e2b77fa607fc1c9cba8bed633aed73aae09f764e3b237faf3a",
-      "updated": "2026-08-18T07:38:34Z",
+      "updated": "2026-08-18T08:52:36Z",
       "lines": 146,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:45ae947add23bf4d9bb2a2bb009f4acbdd00b7fe1531912f9693dea1e48bc3b9",
-      "updated": "2026-08-18T07:38:34Z",
+      "updated": "2026-08-18T08:52:36Z",
       "lines": 164,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-18T07:38:34Z",
+      "updated": "2026-08-18T08:52:36Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-18T07:38:34Z",
+      "updated": "2026-08-18T08:52:36Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,8 +80,8 @@
   "quick_context": "Deliberately a top-level section rather than another dated \\\"Open for the owner\\\". Both Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 21226,
-    "full_read": 31599
+    "manifest_plus_core": 21285,
+    "full_read": 31658
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -23,7 +23,6 @@ matrix and whether version-pinned npm IOCs should match on a directory scan.
 | Ready | 6 |
 | Blocked | 2 |
 
-The published package is v5.26.4.
 
 ---
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,6 +1,6 @@
 # supply-chain-guard: Current State
 
-> Updated 2026-08-17 (release v5.26.5). This is one current snapshot, not a session
+> Updated 2026-08-18 (release v5.26.6). This is one current snapshot, not a session
 > log. Historical detail belongs in CHANGELOG.md, generated LOG.md, LOG-ARCHIVE.md,
 > and git history.
 
@@ -63,9 +63,9 @@ repo, since it spans releases.
 is a floating BRANCH, not a tag. The `update-major-branch` job fast-forward-pushes
 it to each release commit (no `--force`; branches are allowed to move, so this
 does not violate the never-move-tags rule). The Action is composite, and
-`action.yml` on that branch pins an EXACT npm version, currently
-`supply-chain-guard@5.26.5`. `action.yml` is one of the 14 `versionSites`, so the
-pin is bumped and gated on every release.
+`action.yml` on that branch pins an EXACT npm version. The number is deliberately
+not repeated here: `action.yml` is one of the 14 `versionSites`, so the pin is
+bumped and gated on every release, and a copy in prose only drifts.
 
 That combination is better than it looks and should not be lost by accident:
 `@v5` gives consumers a floating convenience ref, while every resolution still
@@ -144,7 +144,9 @@ released version leaves zero open pull requests. The bump is dev-only
 ## Threat-intel sweep 2026-08-18
 
 Model: claude-opus-5. Prepared by the scheduled daily job, which never releases.
-Branch `threat-intel/2026-08-18`, unreleased.
+Shipped as v5.26.6 (PR #148, merged c5be80d); the `threat-intel/2026-08-18`
+branch is deleted. The sweep and the version bump landed as one squash-merge,
+which is the documented way to avoid back-to-back merges cancelling CI.
 
 **The 2026-08-14 backfill question is answered, and it did not need the importer
 change.** It was carried as "NEEDS A DECISION" from the v5.26.3 sweep and repeated
@@ -1167,7 +1169,7 @@ not include it, and `feed.test.ts` does not cover the value-shape contract.
 
 ---
 
-## At a Glance
+## At a Glance (historical, as of the v5.25.9 cut - superseded)
 
 v5.25.8 was published (#127). v5.25.9 is being cut from it and is a threat-intel
 release: the 2026-08-09 advisory sweep, merged as #128, which added 64 package


### PR DESCRIPTION
Docs only. **No version bump, no scanner change.**

## Why

The scheduled session that cut v5.26.6 died on an expired OAuth token roughly 50 minutes in, **after** the release had fully published. I audited what it left behind.

**Everything shipped is intact**, verified independently rather than taken on trust:

- npm `5.26.6` published; tag `v5.26.6` on `main` HEAD `c5be80d`; GitHub Release live, not a draft; `v5` fast-forwarded to the same commit.
- The published tarball is byte-identical to what the registry and the SLSA attestation both claim (sha1/sha512/integrity all agree), and the provenance predicate resolves to source commit `c5be80d`.
- Every non-`dist` file in the package matches the tag by blob hash; `dist/cli.js` is a real built CLI, not a stub.
- All 14 `versionSites` carry 5.26.6, including the multi-occurrence ones where a sed-based bump has historically left the lockfile a release behind.
- All five CI runs for the release concluded success.

What it did **not** finish is the hand-written half of the handoff snapshot. That half is structurally invisible to CI, because `check:handoff` only gates the GENERATED files (DASHBOARD/TRUST/LOG/MANIFEST) and the `NEXT_ACTIONS` version header.

## The four corrections

| Where | Was | Why it matters |
|---|---|---|
| `STATUS.md:3` | `Updated 2026-08-17 (release v5.26.5)` | The first line a reader trusts. Verified as a regression: the header was bumped on each of v5.26.2 to v5.26.5, and only v5.26.6 reverted. |
| `STATUS.md:147` | `Branch threat-intel/2026-08-18, unreleased.` | **Most consequential.** That sweep *is* v5.26.6 and the branch is deleted. Left as-is it could lead a later agent to re-merge or re-release finished work. |
| `STATUS.md:66` | prose quoting the pin as `@5.26.5` | Actual pin is `@5.26.6`. |
| `NEXT_ACTIONS.md:26` | `The published package is v5.26.4.` | Contradicted the gated header four lines above it, and had already drifted through two releases. |

## Two of these are fixed by deletion, not by re-syncing

The `action.yml` pin and the published-package version are both **already owned by a gate** — `action.yml` is a `versionSite`, and the `Current version: **vX.Y.Z**` header is checked by `scripts/scg-handoff-docs.mjs`. The prose copies existed only to drift, and the freshness gate never matched them because it only recognises the header form.

So the pin sentence no longer repeats the number, and the duplicate version sentence is gone. Re-syncing them would have set up the same drift for the next release.

## Also

A dateless `## At a Glance` block from the v5.25.9 era sits mid-file claiming v5.25.8 is the released package and naming a long-deleted release branch. It now says it is historical and superseded, rather than reading as current state to anyone scrolling past the top.

## Verification

`npm run build` green: 7 governance gates, `feed.json` in sync at 12,523 entries, handoff docs regenerated and in sync. No personal name and no em-dashes in the touched files, per the conventions added yesterday.
