### PR TITLE
perf(install-guard): index matchBareNpmIOC instead of scanning the feed per call

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.27.0 |
 | Node engines | >=20.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 112 under `src/__tests__/` |
+| Test files | 113 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,86 +3,86 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787211728",
-    "timestamp": "2026-08-20T07:42:10Z",
-    "commit": "f7598c4",
+    "session_id": "cli-1787213278",
+    "timestamp": "2026-08-20T08:07:59Z",
+    "commit": "7fc7de8",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:7463316de8004c90d37571b8079a4267417a9a054371886f11e1d7ab81e0c077",
-      "updated": "2026-08-20T07:39:38Z",
-      "lines": 1981,
+      "checksum": "sha256:aba23e760456ac6b535c3234960c3d6f624566661f50b3c301992eea6b33345d",
+      "updated": "2026-08-20T08:07:55Z",
+      "lines": 2006,
       "summary": "Deliberately a top-level section rather than another dated \"Open for the owner\". Both"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:7038d81c65390fd5c53f8617948fd355ae2bfe1cbc8b53e27b1f46b8f5cc01b8",
-      "updated": "2026-08-20T07:39:15Z",
-      "lines": 243,
-      "summary": "Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete."
+      "checksum": "sha256:0b718f0429b567dda05887603dd3f2b2117b4115a615f7340b8f958694a7d263",
+      "updated": "2026-08-20T08:07:55Z",
+      "lines": 213,
+      "summary": "Five tasks are ready, two owner decisions are blocked, and T-008/T-015/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T07:42:06Z",
+      "updated": "2026-08-20T08:07:57Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-07-18T08:02:38Z",
+      "updated": "2026-08-20T08:02:00Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-07-18T08:02:38Z",
+      "updated": "2026-08-20T08:02:00Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:1d2e211ec7bd4b9655351a4f5a348b182c673080d3feb39915460d9eb2861af2",
-      "updated": "2026-08-20T07:42:06Z",
+      "checksum": "sha256:68c846a6881a757ed0362ca5e899dcba5f1c18e4b0abaf95e2d87e04db2ace7c",
+      "updated": "2026-08-20T08:07:57Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:6b004abdbb61a9d19c23c6c063ea23ae927a96bc32431c828146c55ab4d9f007",
-      "updated": "2026-08-20T07:42:06Z",
+      "checksum": "sha256:f7da4977979beea1c12ebb09f55032c5e42468a93b9c7eab50c9994b671495fd",
+      "updated": "2026-08-20T08:07:57Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:7f1cf7867dcca4e2b77fa607fc1c9cba8bed633aed73aae09f764e3b237faf3a",
-      "updated": "2026-08-17T07:12:01Z",
+      "updated": "2026-08-20T08:02:00Z",
       "lines": 146,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:45ae947add23bf4d9bb2a2bb009f4acbdd00b7fe1531912f9693dea1e48bc3b9",
-      "updated": "2026-08-04T08:54:14Z",
+      "updated": "2026-08-20T08:02:00Z",
       "lines": 164,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-04T08:54:14Z",
+      "updated": "2026-08-20T08:02:00Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-08-20T08:02:00Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "Deliberately a top-level section rather than another dated \\\"Open for the owner\\\". Both Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete. ",
+  "quick_context": "Deliberately a top-level section rather than another dated \\\"Open for the owner\\\". Both Five tasks are ready, two owner decisions are blocked, and T-008/T-015/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 24664,
-    "full_read": 35084
+    "manifest_plus_core": 24684,
+    "full_read": 35104
   }
   ,"next_task_id": 20
-  ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}
+  ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}
 }

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -6,7 +6,7 @@
 > Before a task becomes done, each box must be checked, explicitly waived with
 > rationale, or moved to a linked open follow-up.
 
-Six tasks are ready, two owner decisions are blocked, and T-008/T-015/T-018/T-019 are complete.
+Five tasks are ready, two owner decisions are blocked, and T-008/T-015/T-017/T-018/T-019 are complete.
 
 Current version: **v5.27.0**
 
@@ -20,7 +20,7 @@ matrix and whether version-pinned npm IOCs should match on a directory scan.
 
 | Status | Count |
 |--------|-------|
-| Ready | 6 |
+| Ready | 5 |
 | Blocked | 2 |
 
 
@@ -112,37 +112,6 @@ do not merge Babel 8 alone.
 
 ---
 
-## T-017: Index matchBareNpmIOC so npm IOC lookup is O(1)
-
-**Goal:** Give `matchBareNpmIOC` the same indexed lookup `matchPackageIOC`
-already has, so npm IOC matching stops being a linear scan of the whole feed.
-
-**Why now:** `matchPackageIOC` is an indexed O(1) lookup (see the comment at
-`src/install-guard.ts:270`); `matchBareNpmIOC` (`:242`) still walks the entire
-feed per call. Two consequences:
-
-- Production: every dependency checked by `src/scanner.ts` and
-  `src/npm-scanner.ts` costs one full pass over 9,374 package entries.
-- Tests: `collection-reachability.test.ts` calls the real matcher once per
-  entry, which is ~85M comparisons and about 3.3s. It went red on CI during the
-  v5.25.6 release at the default 5s timeout, and the cost grows with the SQUARE
-  of the feed, which is now growing by thousands of entries per import.
-
-The 30s timeout added there is a stopgap, not the fix. If it goes red again,
-index the matcher instead of raising the number.
-
-**Acceptance criteria:**
-- [ ] `matchBareNpmIOC` resolves through an index, with identical semantics:
-      a bare-name IOC still matches any version, a pinned IOC still matches only
-      an exact version, and ecosystem-prefixed entries are still skipped.
-- [ ] The index is built once per feed rather than per call, matching how
-      `matchPackageIOC` does it.
-- [ ] `collection-reachability.test.ts` passes comfortably inside the default
-      timeout, and the explicit 30s override plus its comment are removed.
-- [ ] A mutation proof: break the pinned-version branch and watch a test go red.
-
----
-
 ## T-016: Decide whether version-pinned npm IOCs should match on a directory scan (blocked)
 
 **Goal:** Close the gap between what the feed knows and what `scan` reports, or
@@ -206,6 +175,7 @@ initiative.
 
 | Item | Resolution |
 |------|------------|
+| T-017: matchBareNpmIOC was a linear scan per call | Done: indexed on a WeakMap keyed by feed identity, with the linear implementation kept as `matchBareNpmIOCLinear` and a parity suite asserting the two agree across the whole bundled feed. collection-reachability went from 3,317ms to 21ms and its 30s stopgap is removed. |
 | T-019: dropped-persistence detection | Done in two tranches: `.vscode/tasks.json` recall, `CHAINDROP_GH_TOKEN_MONITOR_PERSISTENCE` (also wired into the hook scanner, since the core walk excludes `.claude/`), and `INSTALL_HOOK_PERSISTENCE_WRITE`. Coverage of the five published artefacts went from one of five to five of five. |
 | T-018: known-malware hashes never matched a file | Done: `IOC_KNOWN_MALWARE_FILE_DIGEST` computes SHA-256/MD5 per scanned file, before the scannable-extension gate, over raw bytes. The digest-text substring match is kept as a separate signal. |
 | v5.25.5: AAHP shared-primitive convergence | PR #120 merged: AAHP bumped 3.9.1->3.9.2, `aahp-dashboard.mjs` renamed to `scg-handoff-docs.mjs`, two vendored bash files deleted, shared primitives imported instead; PR #119 Action comment fix also included |

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -151,6 +151,31 @@ anything, since nothing in CI reports it.
 
 ---
 
+## T-017 done: matchBareNpmIOC indexed (2026-08-20, unreleased, branch perf/index-bare-npm-ioc)
+
+Model: claude-opus-5. No version bump.
+
+`matchBareNpmIOC` walked the entire feed on every call, and it is the matcher
+every npm dependency check goes through. Now indexed on a `WeakMap` keyed by feed
+array identity, mirroring `matchPackageIOC`. The linear version is kept as
+`matchBareNpmIOCLinear` and a parity suite asserts the two agree across every npm
+entry in the bundled feed, in both the pinned-exact and bare-name branches.
+
+Measured, not asserted: `collection-reachability.test.ts` went from 3,317ms to
+**21ms**, and the 30s stopgap it was carrying is removed. Worth noting the feed
+grew from 9,374 to 12,551 package IOCs between those two measurements, so the
+improvement is understated by the comparison.
+
+Mutation proof: making the index drop the pinned version - so a pinned IOC would
+match any version - turns exactly 3 of the 6 parity tests red, and restoring it
+returns 6/6.
+
+One deliberate asymmetry: the parity suite itself carries a 120s budget. That is
+NOT the same kind of number as the stopgap removed here. Proving parity means
+running the linear reference once per case, so it is O(cases x feed) by
+construction. If it ever needs raising, sample the cases rather than weaken the
+assertion.
+
 ## Release v5.27.0 (2026-08-20)
 
 Model: claude-opus-5. Contents: the 2026-08-20 threat-intel sweep and the

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.27.0 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 112 | src/__tests__/ file list |
+| Test files present | 113 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Changed
+
+- **`matchBareNpmIOC` is now an indexed O(1) lookup instead of a linear scan of the whole
+  feed on every call (T-017).** It is the matcher every npm dependency check goes through,
+  so a scan of N dependencies previously cost N passes over the feed. The index is built
+  once per feed array and cached on a `WeakMap` keyed by array identity, so a
+  caller-supplied feed and the shared bundled feed each get their own and neither leaks -
+  the same arrangement `matchPackageIOC` already used.
+  The previous implementation is kept as `matchBareNpmIOCLinear` purely as a reference, and
+  a new parity suite asserts the two agree across every npm entry in the bundled feed, in
+  both the pinned-exact and bare-name branches. An index bug in this matcher would be a
+  silent false negative, which is invisible in a way a crash is not.
+  Measured effect: `collection-reachability.test.ts`, which calls the real matcher once per
+  feed entry, went from 3,317ms to **21ms**, and its 30s timeout stopgap is removed. That
+  test had gone red on CI during the v5.25.6 release, and its cost grew with the SQUARE of
+  the feed, which now adds 100-200 entries per daily sweep.
+
 ## [5.27.0] - 2026-08-20
 
 ### Added

--- a/src/__tests__/bare-npm-index-parity.test.ts
+++ b/src/__tests__/bare-npm-index-parity.test.ts
@@ -1,0 +1,119 @@
+/**
+ * T-017: matchBareNpmIOC index parity and cost.
+ *
+ * The index replaces a linear scan that ran once PER CALL, so a scan of N
+ * dependencies cost N x feed. The reference implementation is kept and this
+ * suite proves the two agree across the WHOLE bundled feed. Without that, an
+ * index bug is a silent false negative in the most security-critical matcher in
+ * the project - and a false negative here is invisible, unlike a crash.
+ *
+ * Same arrangement as the matchPackageIOC / matchPackageIOCLinear parity test.
+ */
+import { describe, it, expect } from "vitest";
+import { matchBareNpmIOC, matchBareNpmIOCLinear } from "../install-guard.js";
+import { getBundledFeed } from "../threat-intel.js";
+import type { FeedIOC } from "../threat-intel.js";
+
+const feed = getBundledFeed();
+
+/** Every npm-namespace entry, split into the name and version the matcher parses. */
+function npmEntries(): { name: string; version?: string }[] {
+  const out: { name: string; version?: string }[] = [];
+  for (const ioc of feed) {
+    if (ioc.type !== "package" || ioc.value.includes(":")) continue;
+    const at = ioc.value.lastIndexOf("@");
+    out.push(
+      at > 0
+        ? { name: ioc.value.substring(0, at), version: ioc.value.substring(at + 1) }
+        : { name: ioc.value },
+    );
+  }
+  return out;
+}
+
+describe("matchBareNpmIOC index parity", () => {
+  // Explicit budget, and deliberately NOT the same thing as the 30s stopgap this
+  // change removes from collection-reachability.test.ts. That one was hiding a
+  // real complexity problem in production code. This cost is inherent to the
+  // proof: parity means running the linear reference once per case, so it is
+  // O(cases x feed) by construction and gets slower as the feed grows. If it
+  // ever needs raising again, sample the cases - do not weaken the assertion.
+  it("agrees with the linear reference on every entry in the bundled feed", { timeout: 120_000 }, () => {
+    const mismatches: string[] = [];
+    for (const { name, version } of npmEntries()) {
+      // Both the exact version and the version-less form, since the two take
+      // different branches (pinned-exact vs bare-name-any).
+      for (const v of [version, undefined]) {
+        const a = matchBareNpmIOC(name, v, feed);
+        const b = matchBareNpmIOCLinear(name, v, feed);
+        if (a !== b) mismatches.push(`${name}@${v ?? "(none)"}: ${a?.value} vs ${b?.value}`);
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it("agrees on a wrong version, which must NOT match a pinned entry", () => {
+    const pinned = npmEntries().filter((e) => e.version).slice(0, 400);
+    expect(pinned.length).toBeGreaterThan(0);
+    for (const { name } of pinned) {
+      const bogus = "0.0.0-not-a-real-version";
+      expect(matchBareNpmIOC(name, bogus, feed)).toBe(
+        matchBareNpmIOCLinear(name, bogus, feed),
+      );
+    }
+  });
+
+  it("agrees on names that are absent from the feed", () => {
+    for (const name of ["lodash", "react", "@types/node", "definitely-not-in-the-feed-xyz"]) {
+      expect(matchBareNpmIOC(name, "1.0.0", feed)).toBe(
+        matchBareNpmIOCLinear(name, "1.0.0", feed),
+      );
+    }
+  });
+
+  it("preserves first-match-wins when one name has several entries", () => {
+    // Feed order is the tie-breaker in both implementations. Find a name that
+    // genuinely has more than one entry rather than assuming one exists.
+    const counts = new Map<string, number>();
+    for (const { name } of npmEntries()) counts.set(name, (counts.get(name) ?? 0) + 1);
+    const multi = [...counts.entries()].filter(([, n]) => n > 1).slice(0, 50);
+    expect(multi.length).toBeGreaterThan(0);
+    for (const [name] of multi) {
+      expect(matchBareNpmIOC(name, undefined, feed)).toBe(
+        matchBareNpmIOCLinear(name, undefined, feed),
+      );
+    }
+  });
+
+  it("does not leak between two distinct feed arrays", () => {
+    // The cache is keyed on array identity, so a caller-supplied feed must not
+    // inherit the shared feed's index.
+    const custom: FeedIOC[] = [
+      { type: "package", value: "totally-made-up-pkg@9.9.9", severity: "critical", confidence: 1 } as FeedIOC,
+    ];
+    expect(matchBareNpmIOC("totally-made-up-pkg", "9.9.9", custom)?.value).toBe(
+      "totally-made-up-pkg@9.9.9",
+    );
+    // The same name must still be absent from the real feed.
+    expect(matchBareNpmIOC("totally-made-up-pkg", "9.9.9", feed)).toBeNull();
+  });
+
+  it("is dramatically cheaper than the linear scan it replaces", () => {
+    // Not a wall-clock budget (those are the gates that went red under load in
+    // the first place). This asserts the RATIO on the same machine in the same
+    // run, which is what the complexity change actually claims.
+    const names = npmEntries().slice(0, 1500).map((e) => e.name);
+
+    matchBareNpmIOC(names[0], undefined, feed); // warm the index
+
+    const t0 = performance.now();
+    for (const n of names) matchBareNpmIOC(n, undefined, feed);
+    const indexed = performance.now() - t0;
+
+    const t1 = performance.now();
+    for (const n of names) matchBareNpmIOCLinear(n, undefined, feed);
+    const linear = performance.now() - t1;
+
+    expect(indexed).toBeLessThan(linear);
+  });
+});

--- a/src/__tests__/collection-reachability.test.ts
+++ b/src/__tests__/collection-reachability.test.ts
@@ -117,19 +117,13 @@ describe("collection reachability", () => {
   // Guard B - every package feed entry is reachable by a matcher some caller invokes
   // -------------------------------------------------------------------------
 
-  // Deliberately quadratic, and given a timeout to match. The guard is only
-  // meaningful if it calls the REAL matchers rather than a test-local index, and
-  // matchBareNpmIOC is a linear scan of the feed (unlike matchPackageIOC, which
-  // is an indexed O(1) lookup). So this is one linear scan per npm entry:
-  // 9,050 npm entries against 9,374 package entries is ~85M comparisons, ~3.3s.
-  //
-  // It cost the v5.25.6 release a red CI run at the default 5s timeout, after the
-  // 2026-08-06 backlog import grew the feed 46% and made this ~2x slower. The
-  // cost grows with the SQUARE of the feed, so the fix is to index
-  // matchBareNpmIOC the way matchPackageIOC already is - tracked as T-017. Until
-  // then this headroom absorbs several more imports; if it goes red again, index
-  // the matcher rather than raising the number a second time.
-  it("every package feed entry is reachable by an invoked matcher", { timeout: 30_000 }, () => {
+  // Was deliberately quadratic and carried a 30s timeout: it calls the REAL
+  // matchers once per entry, and matchBareNpmIOC used to be a linear scan of the
+  // whole feed, so the cost grew with the SQUARE of the feed. T-017 indexed that
+  // matcher, so this now runs inside the default budget and the override is gone.
+  // If it ever goes red again, that is a signal about the matcher, not a number
+  // to raise.
+  it("every package feed entry is reachable by an invoked matcher", () => {
     const feed = getBundledFeed();
     // The ecosystems any real caller passes: the file scanners plus the offline
     // MCP ioc_lookup enum. Kept as a literal so that widening it is a conscious

--- a/src/install-guard.ts
+++ b/src/install-guard.ts
@@ -244,6 +244,30 @@ export function matchBareNpmIOC(
   version: string | undefined,
   feed: FeedIOC[],
 ): FeedIOC | null {
+  // Candidates are held in original feed order, so "first match wins" is
+  // preserved exactly, identical to the linear reference below.
+  const candidates = getBareNpmIndex(feed).get(name);
+  if (!candidates) return null;
+
+  for (const { ioc, version: iocVersion } of candidates) {
+    if (iocVersion === undefined) return ioc; // bare-name IOC: any version
+    if (version !== undefined && iocVersion === version) return ioc;
+  }
+  return null;
+}
+
+/**
+ * Reference implementation, kept so the index has something to be proved
+ * against. install-guard.test.ts asserts the two agree across the WHOLE bundled
+ * feed; without that, an index bug becomes a silent false negative in the most
+ * security-critical matcher in the project. Same arrangement as
+ * matchPackageIOCLinear in threat-intel.ts.
+ */
+export function matchBareNpmIOCLinear(
+  name: string,
+  version: string | undefined,
+  feed: FeedIOC[],
+): FeedIOC | null {
   for (const ioc of feed) {
     if (ioc.type !== "package") continue;
     // Skip ecosystem-prefixed entries; npm names never contain ":".
@@ -258,6 +282,49 @@ export function matchBareNpmIOC(
     if (version !== undefined && iocVersion === version) return ioc;
   }
   return null;
+}
+
+/** One indexed candidate: the entry plus its parsed version (undefined = bare). */
+interface IndexedBareNpmIOC {
+  ioc: FeedIOC;
+  version: string | undefined;
+}
+
+/**
+ * Lazily-built lookup index over a feed array, keyed by bare npm package name.
+ *
+ * Keyed on the feed array identity via a WeakMap, so a caller-supplied feed and
+ * the memoized shared feed each get their own index and neither leaks. Mirrors
+ * packageIndexCache in threat-intel.ts.
+ *
+ * Why this exists (T-017): the linear scan cost one full pass over the feed PER
+ * CALL, so a scan of N dependencies cost N x feed. The feed grows by 100-200
+ * entries per daily sweep, and collection-reachability.test.ts, which calls the
+ * real matcher once per entry, is quadratic in feed size - it went red on CI
+ * during the v5.25.6 release and was carrying a 30s timeout as a stopgap.
+ */
+const bareNpmIndexCache = new WeakMap<FeedIOC[], Map<string, IndexedBareNpmIOC[]>>();
+
+function getBareNpmIndex(feed: FeedIOC[]): Map<string, IndexedBareNpmIOC[]> {
+  const cached = bareNpmIndexCache.get(feed);
+  if (cached) return cached;
+
+  const index = new Map<string, IndexedBareNpmIOC[]>();
+  for (const ioc of feed) {
+    if (ioc.type !== "package") continue;
+    if (ioc.value.includes(":")) continue;
+
+    const at = ioc.value.lastIndexOf("@");
+    const iocName = at > 0 ? ioc.value.substring(0, at) : ioc.value;
+    const iocVersion = at > 0 ? ioc.value.substring(at + 1) : undefined;
+
+    const bucket = index.get(iocName);
+    if (bucket) bucket.push({ ioc, version: iocVersion });
+    else index.set(iocName, [{ ioc, version: iocVersion }]);
+  }
+
+  bareNpmIndexCache.set(feed, index);
+  return index;
 }
 
 function checkSpec(spec: InstallPackageSpec, feed: FeedIOC[]): Finding[] {


### PR DESCRIPTION
T-017. **No version bump.**

## What was wrong

`matchBareNpmIOC` is the matcher every npm dependency check goes through, and it walked the **entire feed on every call**. A scan of N dependencies cost N full passes. `matchPackageIOC` had already been indexed; this one had not.

## The change

An index built once per feed array, cached on a `WeakMap` keyed by array identity so a caller-supplied feed and the shared bundled feed each get their own and neither leaks. Same arrangement `matchPackageIOC` uses.

The previous implementation is **kept** as `matchBareNpmIOCLinear`, and a new parity suite asserts the two agree across every npm entry in the bundled feed, in both branches (pinned-exact, and bare-name-matches-any). That proof matters more than the speed: an index bug here is a **silent false negative**, invisible in a way a crash is not.

## Measured, not asserted

| | Before | After |
|---|---|---|
| `collection-reachability.test.ts` | 3,317 ms | **21 ms** |
| Timeout override on it | 30 s stopgap | **removed** |

The feed grew from **9,374 to 12,551** package IOCs between those two measurements, so the comparison understates the change. That test had already gone red on CI during the v5.25.6 release, and its cost grew with the *square* of the feed — which now adds 100-200 entries per daily sweep.

**Mutation proof:** making the index drop the pinned version, so a pinned IOC would match any version, turns exactly **3 of the 6** parity tests red. Restoring it returns 6/6.

## One deliberate asymmetry

The parity suite carries a 120 s budget. That is **not** the same kind of number as the stopgap this removes. The stopgap was hiding a real complexity problem in production code; this cost is inherent to the proof, since parity means running the linear reference once per case and is O(cases x feed) by construction. If it ever needs raising, sample the cases rather than weaken the assertion — the comment in the file says so.

## Verification

- 6 new parity tests; `install-guard`, `collection-reachability`, `ioc-blocklist`, `threat-intel` and `feed` re-run: **124 passing**.
- `npm run build` green: 7 governance gates, feed in sync at 12,870 entries, handoff docs current.
- The full suite is hours on Windows, so **CI on this PR is the authoritative verdict**.

## Why this lands first

It is also the prerequisite for T-016. Matching the feed's 9,597 version-pinned npm IOCs against lockfile-resolved dependencies would have been ~100M comparisons per scan with the old linear matcher. With the index it is free.
