### PR TITLE
docs(conventions): move branch hygiene into CONVENTIONS and correct the reaping test

### DIFF
--- a/.ai/handoff/CONVENTIONS.md
+++ b/.ai/handoff/CONVENTIONS.md
@@ -58,6 +58,66 @@ chore/<short-name>           → build, deps, tooling
 - PR title must reference the GitHub issue: `feat: description (#N)`
 - Squash-merge into main
 
+### Branch hygiene: the invariant is three-sided
+
+A finished deploy leaves exactly `main` and `v5`. That is a statement about the
+REMOTE **and** the local checkout **and** the worktree list. Checking only
+`git ls-remote` has twice reported clean while stale local branches survived.
+
+```
+git ls-remote --heads origin   # only main and v5
+git branch --list              # only main
+git worktree list              # only the shared checkout, on main
+```
+
+Two mechanics make the local side fail silently:
+
+- `git worktree add -b <branch>` creates a local branch that outlives BOTH the
+  worktree and the merge. It has survived `--delete-branch` on every PR cut this
+  way.
+- A local branch still held by a worktree makes the merge command's local delete
+  fail, and the REMOTE branch then survives while the error names only the local
+  one. Remove the worktree BEFORE merging.
+
+### Verifying a branch is safe to delete
+
+Every PR here is squash-merged, so `git branch --merged`, `git cherry` and
+`git rev-list main..branch` all report merged work as UNMERGED. Never delete on
+those. Ask GitHub first:
+
+```
+gh pr list --state all --search "head:<branch>" --json number,state,mergedAt
+git log <branch> -1 --format=%cI     # keep it if the tip is NEWER than mergedAt
+```
+
+**Normalise the timezones before comparing.** `--format=%cI` prints a local
+offset while GitHub returns UTC, so a naive string compare reads an older tip as
+newer and wrongly keeps the branch.
+
+**A repository-wide tree diff does NOT answer this**, and both obvious forms
+mislead:
+
+- `git diff main <branch>` is non-empty whenever the branch is merely BEHIND
+  main. A branch missing one daily feed sweep shows well over a thousand changed
+  lines and is still perfectly safe to delete.
+- `git diff main...<branch>` (three-dot) shows the branch's own pre-squash
+  commits, which main holds under a different SHA after the squash. It is
+  non-empty for a fully merged branch.
+
+Scope the diff to the files the branch itself changed:
+
+```
+git diff --stat main <branch> -- <the branch's changed paths>
+```
+
+Only version strings and generated feed data should differ. Anything else is
+content main does not have, and the branch stays. Confirmed on 2026-08-20:
+`fix/npm-scanner-lifecycle-hooks` showed 25 changed lines repo-wide and, scoped
+to its own files, differed by exactly two version-string lines.
+
+The one real loss case is a commit made after the merge, which no PR knows
+about. The tip-versus-`mergedAt` check above is what guards it.
+
 ## Tests
 
 - Framework: **Vitest** (`npm test`)

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,85 +3,85 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787213278",
-    "timestamp": "2026-08-20T08:07:59Z",
-    "commit": "7fc7de8",
+    "session_id": "cli-1787214158",
+    "timestamp": "2026-08-20T08:22:39Z",
+    "commit": "8fb4879",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:aba23e760456ac6b535c3234960c3d6f624566661f50b3c301992eea6b33345d",
-      "updated": "2026-08-20T08:07:55Z",
-      "lines": 2006,
-      "summary": "Deliberately a top-level section rather than another dated \"Open for the owner\". Both"
+      "checksum": "sha256:3e68224423cbec4920c7b9a39eaf5e06808e9a5520cde6fd798a18b6e41df670",
+      "updated": "2026-08-20T08:22:35Z",
+      "lines": 2036,
+      "summary": "Removing `edited` from `ci.yml`'s `pull_request` types was proposed as the root-cause"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:0b718f0429b567dda05887603dd3f2b2117b4115a615f7340b8f958694a7d263",
-      "updated": "2026-08-20T08:07:55Z",
+      "checksum": "sha256:d1a491d40b29aab2fc037f720b89ff9d4aeece4a6556f152e89886315b3b8f54",
+      "updated": "2026-08-20T08:22:12Z",
       "lines": 213,
       "summary": "Five tasks are ready, two owner decisions are blocked, and T-008/T-015/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T08:07:57Z",
+      "updated": "2026-08-20T08:22:37Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-08-20T08:02:00Z",
+      "updated": "2026-08-20T08:21:43Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-08-20T08:02:00Z",
+      "updated": "2026-08-20T08:21:43Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:68c846a6881a757ed0362ca5e899dcba5f1c18e4b0abaf95e2d87e04db2ace7c",
-      "updated": "2026-08-20T08:07:57Z",
+      "updated": "2026-08-20T08:22:37Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:f7da4977979beea1c12ebb09f55032c5e42468a93b9c7eab50c9994b671495fd",
-      "updated": "2026-08-20T08:07:57Z",
+      "updated": "2026-08-20T08:22:37Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
-      "checksum": "sha256:7f1cf7867dcca4e2b77fa607fc1c9cba8bed633aed73aae09f764e3b237faf3a",
-      "updated": "2026-08-20T08:02:00Z",
-      "lines": 146,
+      "checksum": "sha256:efc9f9fe67b36f4e872a96e49798168a2c6950e4ec1550bbc7bca6c06184c7a2",
+      "updated": "2026-08-20T08:22:12Z",
+      "lines": 206,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:45ae947add23bf4d9bb2a2bb009f4acbdd00b7fe1531912f9693dea1e48bc3b9",
-      "updated": "2026-08-20T08:02:00Z",
+      "updated": "2026-08-20T08:21:43Z",
       "lines": 164,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-20T08:02:00Z",
+      "updated": "2026-08-20T08:21:43Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-20T08:02:00Z",
+      "updated": "2026-08-20T08:21:43Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "Deliberately a top-level section rather than another dated \\\"Open for the owner\\\". Both Five tasks are ready, two owner decisions are blocked, and T-008/T-015/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Removing `edited` from `ci.yml`'s `pull_request` types was proposed as the root-cause Five tasks are ready, two owner decisions are blocked, and T-008/T-015/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 24684,
-    "full_read": 35104
+    "manifest_plus_core": 25048,
+    "full_read": 35987
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Decide whether version-pinned npm IOCs should match on a directory scan","status":"blocked","priority":"high","depends_on":[],"blocked_by":"Owner decision: behaviour change with real false-positive surface","created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -14,7 +14,7 @@ Current version: **v5.27.0**
 
 ## Status Summary
 
-AAHP 3.9.1 adoption and the verified security hardening are complete. Six
+AAHP 3.9.1 adoption and the verified security hardening are complete. Five
 follow-ups are ready. Two decisions are owner-blocked: the Node/Babel support
 matrix and whether version-pinned npm IOCs should match on a directory scan.
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -8,6 +8,36 @@
 
 ## Carried open items (process and design, not tied to one sweep)
 
+### Duplicate CI runs: do NOT simply drop the `edited` PR trigger
+
+Removing `edited` from `ci.yml`'s `pull_request` types was proposed as the root-cause
+fix for duplicate runs on one head commit. It is not safe as stated, and the workflow
+already says why: `edited` exists so the **AI-attribution gate** re-runs on a title or
+body edit. The default types (opened/synchronize/reopened) do not fire on an edit, so
+without it a PR can go green and then have the attribution footer pasted into the body
+with nothing re-checking it. This repo is public and that rule is CI-enforced. The
+concurrency group exists *because* of `edited`, not independently of it.
+
+The real defect is that a seconds-long policy check is welded into `Build and Test`,
+which is expensive and is a REQUIRED context. An edit therefore re-runs the whole
+build to re-check a string.
+
+Proposed fix, not yet applied because it needs one coordinated step:
+
+- Split the attribution gate into its own job or workflow that keeps
+  `[opened, synchronize, reopened, edited]`.
+- Narrow `Build and Test` to `[opened, synchronize, reopened]`.
+
+**The coordination step:** the gate then reports under a NEW check name, so
+`required_status_checks.contexts` on `main` must gain it in the same change. Get that
+wrong in either direction and you either leave a window where nothing enforces
+attribution, or add a required check that never runs and blocks every merge. Branch
+protection also needs a PAT: `GITHUB_TOKEN` has no `administration` permission.
+
+Until then the documented `gh run rerun` recovery stands. Note the current behaviour is
+luck, not design: on v5.26.7 the cancelled twin was last and blocked the merge; on
+v5.27.0 the successful one was last and it did not.
+
 Deliberately a top-level section rather than another dated "Open for the owner". Both
 items outlive any single sweep, and an entry filed under a sweep heading is
 effectively gone once the next sweep adds its own list. Neither is urgent.


### PR DESCRIPTION
Docs only. **No version bump, no scanner change.** Steps 2a and 2b of the agreed follow-up. **Step 2c (the `edited` CI trigger) is deliberately not here — see below.**

## Branch hygiene moves to CONVENTIONS.md

It lived in `CLAUDE.md`, which is **gitignored** in this repo, so per-machine corrections never reached a fresh clone or the second subscription's checkout. `CONVENTIONS.md` is versioned and is the single authoritative source for collaboration rules.

Two things are now written down that were previously only learned by getting them wrong:

**The invariant is three-sided.** "Exactly `main` and `v5`" is a statement about the remote **and** the local checkout **and** the worktree list. Checking only `ls-remote` has twice reported clean while stale local branches survived. Two mechanics make the local side fail silently:

- `git worktree add -b <branch>` creates a local branch that outlives **both** the worktree and the merge — it has survived `--delete-branch` on every PR cut that way, including three in this session.
- A branch still held by a worktree makes the merge command's local delete fail, and the **remote** branch then survives while the error names only the local one.

## The reaping test is corrected

This is the substantive fix. A repository-wide tree diff does **not** answer whether a branch is safe to delete, and both obvious forms mislead:

| Form | Why it misleads |
|---|---|
| `git diff main <branch>` | Non-empty whenever the branch is merely **behind** main. A branch missing one daily feed sweep shows >1,000 changed lines and is still perfectly safe. |
| `git diff main...<branch>` | Shows the branch's **pre-squash** commits, which main holds under a different SHA. Non-empty for a fully merged branch. |

The test that works is scoping the diff to the files the branch itself changed — only version strings and generated feed data should differ.

Confirmed on 2026-08-20: `fix/npm-scanner-lifecycle-hooks` showed **25 changed lines repo-wide**, and scoped to its own files differed by **exactly two version-string lines**. The previously documented "diff is empty" check would have flagged it as unsafe and kept a dead branch.

The timezone note is included too: `--format=%cI` prints a local offset while GitHub returns UTC, so a naive string compare reads an older tip as newer and wrongly keeps the branch.

## Why the `edited` trigger is not removed here

Recorded in STATUS.md rather than acted on, because the proposed fix is unsafe as stated.

`edited` is **load-bearing**: the workflow comment says it exists so the **AI-attribution gate** re-runs on a title or body edit. The default types do not fire on an edit, so without it a PR can go green and then have the attribution footer pasted into the body with nothing re-checking it. This repo is public and that rule is CI-enforced. The concurrency group exists *because* of `edited`.

The real defect is that a seconds-long policy check is welded into `Build and Test`, which is expensive **and a required context**. Proposed instead: split the gate into its own job keeping `[opened, synchronize, reopened, edited]`, and narrow `Build and Test` to `[opened, synchronize, reopened]`.

That needs one coordinated step: the gate then reports under a **new check name**, so `required_status_checks.contexts` on `main` must gain it in the same change. Get it wrong in either direction and you either leave a window where nothing enforces attribution, or add a required check that never runs and blocks every merge. Branch protection also needs a PAT, since `GITHUB_TOKEN` has no `administration` permission.

Happy to do it as its own PR with the protection update sequenced explicitly.

## Verification

`npm run build` green: 7 governance gates, feed in sync at 12,870 entries, handoff docs current. Also re-syncs a task-count sentence in `NEXT_ACTIONS.md` that disagreed with its own table after T-017 closed.
