### PR TITLE
docs: recommend pinning the Action to an exact release

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,85 +3,85 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787215281",
-    "timestamp": "2026-08-20T08:41:21Z",
-    "commit": "3a8f789",
+    "session_id": "cli-1787217736",
+    "timestamp": "2026-08-20T09:22:17Z",
+    "commit": "28fc52e",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:357cfd44da8f30afef46e46606f607cc52c7b29b7c9a2d47d471b968b79fe447",
-      "updated": "2026-08-20T08:41:18Z",
-      "lines": 2068,
-      "summary": "Model: claude-opus-5. Branch feat/lockfile-pinned-ioc. No version bump. Lands on"
+      "checksum": "sha256:81c9a43b0e3f3a1a4c4b54af58b4147bedb842be18f1c8da2f9797e1e282bf97",
+      "updated": "2026-08-20T09:20:22Z",
+      "lines": 2090,
+      "summary": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:b68600a70a1c213c272fee5eef6a0047fd695c8dd6d4c7160e2c9dc4d3ba683f",
-      "updated": "2026-08-20T08:41:18Z",
+      "updated": "2026-08-20T09:19:51Z",
       "lines": 168,
       "summary": "Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T08:41:20Z",
+      "updated": "2026-08-20T09:22:15Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-08-20T08:28:09Z",
+      "updated": "2026-08-20T08:57:30Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-08-20T08:28:09Z",
+      "updated": "2026-08-20T08:57:30Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:198dd08d15a114f8d3cd725c7a33c41f1eb61c7be28178761594b099ab603c67",
-      "updated": "2026-08-20T08:41:20Z",
+      "updated": "2026-08-20T09:22:15Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:0c577a2f7526535d5e6a550b588ed7d0bf36a36902f3ed8ba9be49a75d6a0ea3",
-      "updated": "2026-08-20T08:41:20Z",
+      "updated": "2026-08-20T09:22:15Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:efc9f9fe67b36f4e872a96e49798168a2c6950e4ec1550bbc7bca6c06184c7a2",
-      "updated": "2026-08-20T08:28:09Z",
+      "updated": "2026-08-20T08:57:30Z",
       "lines": 206,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:45ae947add23bf4d9bb2a2bb009f4acbdd00b7fe1531912f9693dea1e48bc3b9",
-      "updated": "2026-08-20T08:28:09Z",
+      "updated": "2026-08-20T08:57:30Z",
       "lines": 164,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-20T08:28:09Z",
+      "updated": "2026-08-20T08:57:30Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-20T08:28:09Z",
+      "updated": "2026-08-20T08:57:30Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch feat/lockfile-pinned-ioc. No version bump. Lands on Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 24994,
-    "full_read": 35933
+    "manifest_plus_core": 25282,
+    "full_read": 36221
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,28 @@
 
 ---
 
+## Exact version pinning documented as the default (2026-08-20, unreleased)
+
+Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump.
+
+README and `examples/github-action-basic.yml` now pin an exact release, with a
+Dependabot snippet, and `@v5` is documented as a supported transition path rather
+than the headline form. The README states what `@v5` does and does not guarantee,
+because it is better than it looks: the composite action on that branch pins an
+exact, build-gated npm version, so it is not `latest`. The failure mode is only
+after a major, when a frozen action keeps installing an old feed.
+
+One coupling worth knowing before editing these docs again: pinning an exact
+version in an example turns that file into a version site. Left unregistered it
+would silently go stale and ship stale copy-paste, so `examples/github-action-basic.yml`
+was added to `aahp.config.json` and README's `minOccurrences` raised to 2.
+**There are now 15 version sites, not 14** - read the count from the config rather
+than from any prose, including this note. CONVENTIONS.md already says "every version
+site in aahp.config.json" and needed no change; the historical "all 14" lines in
+older STATUS entries are records of what was true at the time and stay as written.
+
+The remaining half of the v6 decision (a deprecation warning on `@v5` once v6 ships,
+and the manual Marketplace re-check) is still open and unchanged.
 ## T-016 done: pinned npm IOCs now match on a directory scan (2026-08-20, unreleased)
 
 Model: claude-opus-5. Branch feat/lockfile-pinned-ioc. No version bump. Lands on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ### Changed
 
+- **Exact version pinning is now the documented default for the GitHub Action.**
+  The README example and `examples/github-action-basic.yml` pin an exact release and
+  ship a Dependabot snippet to keep the pin current. Rationale stated in the README:
+  a security scanner should be a deterministic input, so you know which detection
+  logic and which IOC feed ran, and an upgrade is a reviewable change. It is the same
+  advice this tool gives about your own dependencies.
+  `@v5` remains supported and is documented as a transition path, together with what
+  it does and does not guarantee: it is a floating BRANCH whose composite action still
+  pins an exact, build-gated npm version, so it is not `latest`. The caveat is after a
+  major - if the v5 line stops shipping, `@v5` keeps resolving a frozen action pinning
+  an old npm version and the IOC feed stops updating, which for a scanner is a silent
+  false negative. An exact pin surfaces that as an out-of-date dependency instead.
+  The pinned example is registered as a `versionSite`, so `check:version-sync` fails
+  the build if it ever drifts rather than leaving stale copy-paste in the docs.
+
+
 - **`matchBareNpmIOC` is now an indexed O(1) lookup instead of a linear scan of the whole
   feed on every call (T-017).** It is the matcher every npm dependency check goes through,
   so a scan of N dependencies previously cost N passes over the feed. The index is built

--- a/README.md
+++ b/README.md
@@ -588,6 +588,11 @@ Honest caveats: Socket's registry-wide behavioral detection is deeper than anyth
 - **Pre-install vetting of a suspicious package**: `guarddog npm scan <pkg>` for an independent heuristic score, plus `supply-chain-guard npm <pkg>` for campaign-IOC and install-hook analysis, before it ever touches your machine.
 ## GitHub Action
 
+**Pin an exact version.** That is the recommended form, and it is the same advice
+this tool gives about your own dependencies: a security scanner should be a
+deterministic input, so you know which detection logic and which IOC feed ran, and
+an upgrade is a reviewable change rather than something that happens to you.
+
 ```yaml
 name: Supply Chain Security
 on: [push, pull_request]
@@ -601,11 +606,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: homeofe/supply-chain-guard@v5
+      - uses: homeofe/supply-chain-guard@v5.27.0
         with:
           fail-on: critical
           comment-on-pr: true
 ```
+
+Let Dependabot keep the pin current:
+
+```yaml
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+```
+
+### `@v5`, and what it does and does not guarantee
+
+`@v5` also works and stays supported. It is a floating **branch**, fast-forwarded
+to each release by CI, and the composite action on it pins an exact npm version
+that is bumped and build-gated on every release. So `@v5` is not `latest`: every
+resolution still installs one exact, release-gated version.
+
+The caveat is what happens after a major. If the v5 line stops being released once
+v6 ships, `@v5` keeps resolving a frozen action that pins an old npm version, and
+the IOC feed it installs stops updating. For a scanner that is a silent
+false-negative generator, and nothing in your workflow would report it. An exact
+pin turns that into a visible out-of-date dependency instead.
 
 ### Action Inputs
 

--- a/aahp.config.json
+++ b/aahp.config.json
@@ -1,20 +1,80 @@
 {
   "$schema": "./node_modules/@elvatis_com/aahp/schema/aahp-config.schema.json",
   "versionSites": [
-    { "file": "src/cli.ts", "minOccurrences": 1, "note": "CLI --version output" },
-    { "file": "src/reporter.ts", "minOccurrences": 5, "note": "text-header VERSION const + SARIF + SBOM + HTML footer + GitLab scanner version" },
-    { "file": "src/scanner.ts", "minOccurrences": 1, "note": "TOOL_VERSION const (ScanReport.tool + risk-history)" },
-    { "file": "src/npm-scanner.ts", "minOccurrences": 1, "note": "npm ScanReport.tool version" },
-    { "file": "src/pypi-scanner.ts", "minOccurrences": 1, "note": "PyPI ScanReport.tool version" },
-    { "file": "src/vscode-scanner.ts", "minOccurrences": 1, "note": "VS Code ScanReport.tool version" },
-    { "file": "src/sbom-generator.ts", "minOccurrences": 1, "note": "CycloneDX generator tool metadata version" },
-    { "file": "src/dependency-confusion.ts", "minOccurrences": 1, "note": "dependency-confusion ScanReport.tool version" },
-    { "file": "README.md", "minOccurrences": 1, "note": "pre-commit snippet rev: tag" },
-    { "file": "docs/mcp.md", "minOccurrences": 1, "note": "MCP initialize response version" },
-    { "file": "action.yml", "minOccurrences": 1, "note": "Marketplace Action installs the exact matching CLI release" },
-    { "file": ".pre-commit-hooks.yaml", "minOccurrences": 1, "note": "example rev: tag in header comment" },
-    { "file": "server.json", "minOccurrences": 2, "note": "MCP registry version + npm package version" },
-    { "file": "package-lock.json", "minOccurrences": 2, "note": "lockfile root version + packages[\"\"].version; npm writes these at install time, so a sed-based bump leaves them a release behind (was stale in v5.20.1 and v5.20.2). Resync with `npm install --package-lock-only`" }
+    {
+      "file": "src/cli.ts",
+      "minOccurrences": 1,
+      "note": "CLI --version output"
+    },
+    {
+      "file": "src/reporter.ts",
+      "minOccurrences": 5,
+      "note": "text-header VERSION const + SARIF + SBOM + HTML footer + GitLab scanner version"
+    },
+    {
+      "file": "src/scanner.ts",
+      "minOccurrences": 1,
+      "note": "TOOL_VERSION const (ScanReport.tool + risk-history)"
+    },
+    {
+      "file": "src/npm-scanner.ts",
+      "minOccurrences": 1,
+      "note": "npm ScanReport.tool version"
+    },
+    {
+      "file": "src/pypi-scanner.ts",
+      "minOccurrences": 1,
+      "note": "PyPI ScanReport.tool version"
+    },
+    {
+      "file": "src/vscode-scanner.ts",
+      "minOccurrences": 1,
+      "note": "VS Code ScanReport.tool version"
+    },
+    {
+      "file": "src/sbom-generator.ts",
+      "minOccurrences": 1,
+      "note": "CycloneDX generator tool metadata version"
+    },
+    {
+      "file": "src/dependency-confusion.ts",
+      "minOccurrences": 1,
+      "note": "dependency-confusion ScanReport.tool version"
+    },
+    {
+      "file": "README.md",
+      "minOccurrences": 2,
+      "note": "pre-commit snippet rev: tag"
+    },
+    {
+      "file": "docs/mcp.md",
+      "minOccurrences": 1,
+      "note": "MCP initialize response version"
+    },
+    {
+      "file": "action.yml",
+      "minOccurrences": 1,
+      "note": "Marketplace Action installs the exact matching CLI release"
+    },
+    {
+      "file": ".pre-commit-hooks.yaml",
+      "minOccurrences": 1,
+      "note": "example rev: tag in header comment"
+    },
+    {
+      "file": "server.json",
+      "minOccurrences": 2,
+      "note": "MCP registry version + npm package version"
+    },
+    {
+      "file": "package-lock.json",
+      "minOccurrences": 2,
+      "note": "lockfile root version + packages[\"\"].version; npm writes these at install time, so a sed-based bump leaves them a release behind (was stale in v5.20.1 and v5.20.2). Resync with `npm install --package-lock-only`"
+    },
+    {
+      "file": "examples/github-action-basic.yml",
+      "minOccurrences": 1
+    }
   ],
   "claims": [
     {
@@ -26,11 +86,26 @@
       "joinTsConcat": true,
       "floorCmd": "scripts/count-rules.mjs",
       "surfaces": [
-        { "file": "package.json", "note": "npm description" },
-        { "file": "README.md", "note": "intro + heuristics cell + architecture block" },
-        { "file": "docs/mcp.md", "note": "scan_directory description" },
-        { "file": "src/mcp-server.ts", "note": "scan_directory MCP tool description (phrase split across concatenated literals)" },
-        { "file": ".github/repo-about.txt", "note": "GitHub About/description source (CI syncs it on release)" }
+        {
+          "file": "package.json",
+          "note": "npm description"
+        },
+        {
+          "file": "README.md",
+          "note": "intro + heuristics cell + architecture block"
+        },
+        {
+          "file": "docs/mcp.md",
+          "note": "scan_directory description"
+        },
+        {
+          "file": "src/mcp-server.ts",
+          "note": "scan_directory MCP tool description (phrase split across concatenated literals)"
+        },
+        {
+          "file": ".github/repo-about.txt",
+          "note": "GitHub About/description source (CI syncs it on release)"
+        }
       ]
     },
     {
@@ -41,7 +116,10 @@
       "flags": "gi",
       "floorCmd": "scripts/count-correlation.mjs",
       "surfaces": [
-        { "file": "README.md", "note": "correlation rules bullet" }
+        {
+          "file": "README.md",
+          "note": "correlation rules bullet"
+        }
       ]
     },
     {
@@ -51,7 +129,10 @@
       "phrase": "(\\d+)\\s*categories\\b",
       "flags": "gi",
       "surfaces": [
-        { "file": "README.md", "note": "architecture: rules across N categories (editorial - no category constant in src, so no floorCmd)" }
+        {
+          "file": "README.md",
+          "note": "architecture: rules across N categories (editorial - no category constant in src, so no floorCmd)"
+        }
       ]
     }
   ],
@@ -102,23 +183,44 @@
     {
       "id": "severity-enum",
       "sources": [
-        { "file": "policy-schema.json", "pattern": "\"(critical|high|medium|low|info)\"" },
-        { "file": ".ai/handoff/CONVENTIONS.md", "pattern": "`(critical|high|medium|low|info)`" }
+        {
+          "file": "policy-schema.json",
+          "pattern": "\"(critical|high|medium|low|info)\""
+        },
+        {
+          "file": ".ai/handoff/CONVENTIONS.md",
+          "pattern": "`(critical|high|medium|low|info)`"
+        }
       ]
     },
     {
       "id": "changelog-reflink-coverage",
       "sources": [
-        { "file": "CHANGELOG.md", "pattern": "\\n## \\[(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\\] - " },
-        { "file": "CHANGELOG.md", "pattern": "\\n\\[(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\\]: " },
-        { "file": "CHANGELOG.md", "pattern": "\\n\\[\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?\\]: \\S*/(?:releases/tag/)?v(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\\b" }
+        {
+          "file": "CHANGELOG.md",
+          "pattern": "\\n## \\[(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\\] - "
+        },
+        {
+          "file": "CHANGELOG.md",
+          "pattern": "\\n\\[(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\\]: "
+        },
+        {
+          "file": "CHANGELOG.md",
+          "pattern": "\\n\\[\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?\\]: \\S*/(?:releases/tag/)?v(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\\b"
+        }
       ]
     },
     {
       "id": "changelog-unreleased-compare-base",
       "sources": [
-        { "file": "CHANGELOG.md", "pattern": "/compare/v(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\\.\\.\\.HEAD" },
-        { "file": "package.json", "pattern": "\"version\": \"(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\",\\s*\\n\\s*\"mcpName\"" }
+        {
+          "file": "CHANGELOG.md",
+          "pattern": "/compare/v(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\\.\\.\\.HEAD"
+        },
+        {
+          "file": "package.json",
+          "pattern": "\"version\": \"(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)\",\\s*\\n\\s*\"mcpName\""
+        }
       ]
     }
   ],
@@ -131,7 +233,9 @@
     ]
   },
   "check": {
-    "skip": ["handoff"]
+    "skip": [
+      "handoff"
+    ]
   },
   "pinnedDep": {
     "name": "@elvatis_com/aahp",

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ marked values.
 
 | File | What it does |
 | --- | --- |
-| [`github-action-basic.yml`](github-action-basic.yml) | Minimal GitHub Actions workflow using the published Action (`homeofe/supply-chain-guard@v5`). Scans on every push and PR, fails on high severity findings, posts results as a PR comment. |
+| [`github-action-basic.yml`](github-action-basic.yml) | Minimal GitHub Actions workflow using the published Action, pinned to an exact release (the recommended form; `@v5` also works but goes stale once the v5 line stops shipping). Scans on every push and PR, fails on high severity findings, posts results as a PR comment. |
 | [`bot-pr-gate.yml`](bot-pr-gate.yml) | Gate for bot PRs (Dependabot / Renovate). Runs only when a bot opens the PR, diff-scans just the files changed against `origin/main`, and blocks auto-merge if the updated dependency tree trips malware indicators. |
 | [`gitlab-ci.yml`](gitlab-ci.yml) | GitLab CI job template. Installs the CLI, scans with JSON output, fails on high severity, and uploads the report as a job artifact. |
 | [`circleci-config.yml`](circleci-config.yml) | CircleCI job on `cimg/node`. Installs the CLI, scans with JSON output, fails on high severity, and stores the report as a build artifact. |

--- a/examples/github-action-basic.yml
+++ b/examples/github-action-basic.yml
@@ -23,7 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: homeofe/supply-chain-guard@v5
+      # Pinned to an exact release on purpose: a security scanner should be a
+      # deterministic input, so you know which detection logic and IOC feed ran.
+      # `@v5` also works (a floating branch, fast-forwarded on each release), but
+      # it goes silently stale once the v5 line stops shipping. Dependabot keeps
+      # this line current; see the README for the config.
+      - uses: homeofe/supply-chain-guard@v5.27.0
         with:
           # Fail the check on high or critical findings.
           fail-on: high


### PR DESCRIPTION
Step 4 of the agreed follow-up. **Docs and config only. No version bump, no scanner change.**

## What changed

The README example and `examples/github-action-basic.yml` now pin an exact release, with a Dependabot snippet to keep the pin current. The rationale is stated rather than assumed:

> a security scanner should be a deterministic input, so you know which detection logic and which IOC feed ran, and an upgrade is a reviewable change

which is the same advice this tool gives about your own dependencies.

## `@v5` is documented, not demoted quietly

It stays supported, and the README now says what it does **and does not** guarantee — because it is better than it looks and that was worth writing down:

- `@v5` is a floating **branch**, fast-forwarded by CI on each release, and the composite action on it pins an **exact, build-gated npm version**. So `@v5` is not `latest`; every resolution still installs one exact release.
- The failure mode is only **after a major**. If the v5 line stops shipping once v6 lands, `@v5` keeps resolving a frozen action pinning an old npm version, and the IOC feed stops updating — a silent false negative that nothing in the consumer's workflow would report. An exact pin turns that into a visible out-of-date dependency.

## One coupling this had to resolve

Pinning an exact version inside an example **turns that file into a version site**. Left unregistered it would silently go stale and ship stale copy-paste — the exact failure this change is meant to prevent.

So `examples/github-action-basic.yml` is added to `aahp.config.json` and README's `minOccurrences` is raised to 2. `check:version-sync` now reports **15 sites** and fails the build if either drifts, rather than relying on anyone remembering.

| File | Before | After |
|---|---|---|
| `README.md` | 1 occurrence | 2 (`rev:` + the `uses:` pin) |
| `examples/github-action-basic.yml` | not a version site | registered, 1 |

`CONVENTIONS.md` already says "every version site in `aahp.config.json`" and needed no change. The "all 14" lines in older STATUS entries are records of what was true at the time and stay as written; only the gitignored local CLAUDE.md needed its count corrected.

## Verification

`npm run build` green: 7 governance gates including `version-sync` across all 15 sites, feed in sync at 12,870 entries, handoff docs current.
