### PR TITLE
docs: add EU CRA/NIS2 compliance positioning

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787217736",
-    "timestamp": "2026-08-20T09:22:17Z",
-    "commit": "28fc52e",
+    "session_id": "cli-1787219431",
+    "timestamp": "2026-08-20T09:50:32Z",
+    "commit": "c5ef04a",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:81c9a43b0e3f3a1a4c4b54af58b4147bedb842be18f1c8da2f9797e1e282bf97",
-      "updated": "2026-08-20T09:20:22Z",
-      "lines": 2090,
+      "checksum": "sha256:6ff2cd15cd4db3575dae8cd594d2a91ebbeca60db3f6d415ac549ba2ce2fe478",
+      "updated": "2026-08-20T09:50:28Z",
+      "lines": 2137,
       "summary": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:b68600a70a1c213c272fee5eef6a0047fd695c8dd6d4c7160e2c9dc4d3ba683f",
-      "updated": "2026-08-20T09:19:51Z",
+      "updated": "2026-08-20T09:48:46Z",
       "lines": 168,
       "summary": "Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T09:22:15Z",
+      "updated": "2026-08-20T09:50:30Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-08-20T08:57:30Z",
+      "updated": "2026-08-20T09:48:46Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-08-20T08:57:30Z",
+      "updated": "2026-08-20T09:48:46Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:198dd08d15a114f8d3cd725c7a33c41f1eb61c7be28178761594b099ab603c67",
-      "updated": "2026-08-20T09:22:15Z",
+      "updated": "2026-08-20T09:50:30Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:0c577a2f7526535d5e6a550b588ed7d0bf36a36902f3ed8ba9be49a75d6a0ea3",
-      "updated": "2026-08-20T09:22:15Z",
+      "updated": "2026-08-20T09:50:30Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:efc9f9fe67b36f4e872a96e49798168a2c6950e4ec1550bbc7bca6c06184c7a2",
-      "updated": "2026-08-20T08:57:30Z",
+      "updated": "2026-08-20T09:48:46Z",
       "lines": 206,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:45ae947add23bf4d9bb2a2bb009f4acbdd00b7fe1531912f9693dea1e48bc3b9",
-      "updated": "2026-08-20T08:57:30Z",
+      "updated": "2026-08-20T09:48:46Z",
       "lines": 164,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-20T08:57:30Z",
+      "updated": "2026-08-20T09:48:46Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-20T08:57:30Z",
+      "updated": "2026-08-20T09:48:46Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,8 +80,8 @@
   "quick_context": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 25282,
-    "full_read": 36221
+    "manifest_plus_core": 25821,
+    "full_read": 36760
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -60,6 +60,53 @@ dropping the dedup turns 1 red. An earlier mutant survived and that was a gap in
 the tests, not a pass - it is recorded here because the first attempt looked like a
 proof and was not.
 
+## EU compliance positioning in the README (2026-08-20, unreleased)
+
+Model: claude-opus-5. Branch docs/eu-compliance-positioning. README only, plus
+this note. No version bump.
+
+Adds an `EU Compliance (CRA / NIS2)` section between `How It Compares` and
+`GitHub Action`, and one sentence to the intro paragraph. Four things were
+deliberately left OUT of the drafted text, and they are recorded here so a
+later pass does not reinstate them as helpful additions:
+
+1. **No company or location line.** The draft claimed a legal entity and a city.
+   Neither appears anywhere in the repository, the entity is still in formation,
+   and a public README is not the place to assert it. Removed at the owner's
+   direction.
+2. **No article or paragraph citations.** The draft cited specific CRA article
+   paragraphs. Those were not verifiable from an authoritative source here, and
+   the SBOM obligation is commonly attributed to a different provision than the
+   one drafted. Wrong statutory citations in a section aimed at compliance
+   readers are worse than no citations, so the section describes what the tool
+   PRODUCES and tells the reader to map it against the final regulation text
+   with their own legal review.
+3. **"Supports", never "satisfies" or "CRA-ready".** A scanner can contribute
+   artefacts to compliance work; it cannot make an organisation compliant. The
+   section says so in its opening paragraph.
+4. **Air-gap claim qualified.** `scan` is genuinely offline against the bundled
+   feed, but `npm <pkg>` / `pypi <pkg>` fetch the package under inspection and
+   the feed refresh fetches indicators. The unqualified "fully air-gappable"
+   would have been false for those commands.
+
+Formatting: the drafted text carried four em-dashes and two en-dashes. The
+`em-dash` forbidden-patterns rule covers README.md, so it would have failed the
+build rather than merged. Written with hyphens and colons instead, and verified
+at zero of both before the gate ran.
+
+The documented example was executed rather than assumed:
+`scan <dir> --sbom-output sbom.json` exits 0 and writes a CycloneDX 1.6
+document. The flag exists at `src/cli.ts:225`, and SLSA levels 0 to 3 match
+`src/slsa-verifier.ts:326`.
+
+**Repository topics, still open.** The related request was to replace all topics
+with a 20-item list. Replacement would have dropped 8 existing topics including
+`pypi`, `golang` and `rust`, which are supported ecosystems, and `glassworm`, a
+campaign the scanner detects by name. Additive was chosen instead, but the repo
+already holds 19 of GitHub's 20-topic maximum, so exactly ONE slot is free
+against 9 proposed additions. Which one, and whether any existing topic is worth
+trading, is deferred to a separate prioritisation review.
+
 ## Carried open items (process and design, not tied to one sweep)
 
 ### Duplicate CI runs: do NOT simply drop the `edited` PR trigger

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # supply-chain-guard
 
-Open-source supply-chain security scanner for npm, PyPI, Cargo, Go, RubyGems, Composer, NuGet, Docker, Terraform, VS Code extensions, GitHub Actions and GitHub repositories. Detects malware campaigns (GlassWorm, Vidar, Shai-Hulud), fake AI tool repos, account takeovers, and 350+ threat indicators across all major lockfile formats (npm, pnpm, yarn, bun). Generates CycloneDX 1.6 SBOMs with real dependency inventories, grades SLSA provenance (parses and structurally validates in-toto/DSSE attestations), and correlates findings into attack-chain incidents.
+Open-source supply-chain security scanner for npm, PyPI, Cargo, Go, RubyGems, Composer, NuGet, Docker, Terraform, VS Code extensions, GitHub Actions and GitHub repositories. Detects malware campaigns (GlassWorm, Vidar, Shai-Hulud), fake AI tool repos, account takeovers, and 350+ threat indicators across all major lockfile formats (npm, pnpm, yarn, bun). Generates CycloneDX 1.6 SBOMs with real dependency inventories, grades SLSA provenance (parses and structurally validates in-toto/DSSE attestations), and correlates findings into attack-chain incidents. Supports EU Cyber Resilience Act SBOM and component-documentation work, and NIS2 supply chain risk-management measures.
 
 [![npm version](https://img.shields.io/npm/v/supply-chain-guard?logo=npm)](https://www.npmjs.com/package/supply-chain-guard)
 [![npm downloads](https://img.shields.io/npm/dw/supply-chain-guard?logo=npm&label=weekly%20downloads)](https://www.npmjs.com/package/supply-chain-guard)
@@ -586,6 +586,63 @@ Honest caveats: Socket's registry-wide behavioral detection is deeper than anyth
 - **CI one-two punch**: run `osv-scanner --lockfile=package-lock.json` for known CVEs and MAL- entries, then `supply-chain-guard scan .` for behavioral and campaign-IOC threats in the installed tree. Two axes, one job, both exit-code gated.
 - **Zero-install npm baseline**: `npm audit --audit-level=high` plus `npx supply-chain-guard scan .` covers advisory-known vulnerabilities and unreported malware without adding a single dependency.
 - **Pre-install vetting of a suspicious package**: `guarddog npm scan <pkg>` for an independent heuristic score, plus `supply-chain-guard npm <pkg>` for campaign-IOC and install-hook analysis, before it ever touches your machine.
+## EU Compliance (CRA / NIS2)
+
+supply-chain-guard produces artefacts and findings that **support** compliance
+work under two EU regulations that apply to software manufacturers. It does not
+make an organisation compliant: compliance remains the responsibility of the
+organisation deploying the software, and the mapping below describes what the
+tool produces, not a legal assessment.
+
+### Cyber Resilience Act (CRA)
+
+The CRA requires manufacturers of products with digital elements to identify and
+document the components they ship, to address vulnerabilities in those
+components, and to be able to reason about the integrity of what they build on.
+supply-chain-guard contributes to each of those activities:
+
+- **Component inventory:** generates a [CycloneDX 1.6](https://cyclonedx.org/)
+  SBOM from the real resolved dependency tree, as a machine-readable component
+  list you can attach to technical documentation.
+- **Dependency risk:** detects known-malicious packages and versions,
+  typosquatting, dependency confusion, and compromised publisher activity, at
+  scan time and at install time.
+- **Supply chain integrity:** grades SLSA provenance from levels 0 to 3 by
+  parsing and structurally validating in-toto/DSSE attestations, giving a
+  recorded integrity signal per project.
+
+```bash
+# Write a CycloneDX 1.6 SBOM alongside the scan report
+supply-chain-guard scan ./project --sbom-output sbom.json
+```
+
+Article and paragraph citations are deliberately omitted here. Map these outputs
+to specific provisions against the final published regulation text, with your own
+legal review, rather than against this README.
+
+### NIS2 Directive
+
+NIS2 requires essential and important entities to take measures covering supply
+chain security. The relevant capabilities are:
+
+- **Supply chain risk:** typosquatting, dependency confusion, compromised
+  packages, and malicious GitHub Actions in CI/CD workflows.
+- **Incident evidence:** the correlation engine links individual findings into
+  named attack chains with confidence scores, and reports are exportable as
+  SARIF, JSON, and CycloneDX for retention alongside an incident record.
+- **Configuration exposure:** IaC, Dockerfile, and `.npmrc` / `.yarnrc` scanning
+  surfaces misconfiguration before deployment.
+
+### Operating model
+
+Apache-2.0, no account required, and no telemetry: the scanner reports only to
+its own output. `scan` runs fully offline against the bundled threat feed, so it
+is suitable for air-gapped use. The commands that deliberately reach the network
+are the ones that exist to do so: `supply-chain-guard npm <pkg>` and
+`supply-chain-guard pypi <pkg>` fetch the package under inspection, and the feed
+refresh fetches updated indicators. Offline runs use the feed bundled with the
+installed version, so pin the version you intend to audit against.
+
 ## GitHub Action
 
 **Pin an exact version.** That is the recommended form, and it is the same advice


### PR DESCRIPTION
Adds an `EU Compliance (CRA / NIS2)` section between `How It Compares` and `GitHub Action`, plus one sentence on the intro paragraph. Existing sections are untouched: this is insert-only.

## What the section claims, and what it does not

It describes what the tool **produces**, and says in its opening paragraph that it *supports* compliance work rather than delivering compliance, which remains the responsibility of the organisation deploying it.

Four things were deliberately left out of the drafted text. The reasons are in `STATUS.md` so a later pass does not reinstate them as helpful additions:

| Omitted | Why |
|---|---|
| Company and location line | The draft asserted a legal entity and a city that appear **nowhere** in this repository, and the entity is still in formation. |
| Article / paragraph citations | Not verifiable from an authoritative source here, and the SBOM obligation is commonly attributed to a different provision than the one drafted. The section instead tells the reader to map the outputs against the final regulation text with their own legal review. |
| "satisfies" / "CRA-ready" | A scanner contributes artefacts to compliance work; it cannot make an organisation compliant. |
| Unqualified "fully air-gappable" | True of `scan`, false of `npm <pkg>` / `pypi <pkg>` and the feed refresh, which reach the network by design. The wording now distinguishes them. |

## Formatting

The drafted text carried **four em-dashes and two en-dashes**. The `em-dash` forbidden-patterns rule covers `README.md`, so it would have failed `npm run build` rather than merged. Written with hyphens and colons; verified at zero of both before the gate ran.

## Claims checked rather than assumed

- `scan <dir> --sbom-output sbom.json` was **executed**: exit 0, writes a real CycloneDX 1.6 document. The flag exists at `src/cli.ts:225`.
- SLSA "levels 0 to 3" matches `src/slsa-verifier.ts:326`.
- The drafted example passed both `--format sbom` and `--sbom-output`, which is redundant; the documented command now uses one.

## Verification

`npm run build` green: 7 governance gates including `forbidden-patterns`, feed in sync, handoff docs current. `self-scan-recognition` 16/16, since the repo scans its own README.
