### PR TITLE
ci: hold every Node declaration to one policy and prove the artifact on both majors

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.27.0 |
 | Node engines | >=20.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 115 under `src/__tests__/` |
+| Test files | 116 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,17 +3,17 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787223944",
-    "timestamp": "2026-08-20T11:05:45Z",
-    "commit": "9ee9209",
+    "session_id": "cli-1787224405",
+    "timestamp": "2026-08-20T11:13:26Z",
+    "commit": "75fb45e",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:cf9005542edfe54de5b9167c5d51e4f878d2c9889032e2ba31a8f9a79d3eb397",
-      "updated": "2026-08-20T11:05:40Z",
-      "lines": 2317,
+      "checksum": "sha256:876b983085ea61291620da63a8a5fcf966746ea402921bcf1d31adc29bb17687",
+      "updated": "2026-08-20T11:13:22Z",
+      "lines": 2332,
       "summary": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump."
     },
     "NEXT_ACTIONS.md": {
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T11:05:43Z",
+      "updated": "2026-08-20T11:13:24Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:c9fb1bc0416c86642d4ce3eda9e5d6f51abf92a1068f5c77cc1d324f7ecf58ec",
-      "updated": "2026-08-20T11:05:43Z",
+      "updated": "2026-08-20T11:13:24Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:48049e96dc5a232dc4762f704dc18f4943014af3a4123a7a4074aec7a0a51144",
-      "updated": "2026-08-20T11:05:43Z",
+      "updated": "2026-08-20T11:13:24Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
@@ -80,8 +80,8 @@
   "quick_context": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 28865,
-    "full_read": 39804
+    "manifest_plus_core": 29069,
+    "full_read": 40008
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787222321",
-    "timestamp": "2026-08-20T10:38:43Z",
-    "commit": "3b92109",
+    "session_id": "cli-1787223944",
+    "timestamp": "2026-08-20T11:05:45Z",
+    "commit": "9ee9209",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:582342f0cedb751fe94108b8e85b6be60c8ae874051978d42932d4efd06a4112",
-      "updated": "2026-08-20T10:38:35Z",
-      "lines": 2255,
+      "checksum": "sha256:cf9005542edfe54de5b9167c5d51e4f878d2c9889032e2ba31a8f9a79d3eb397",
+      "updated": "2026-08-20T11:05:40Z",
+      "lines": 2317,
       "summary": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump."
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:b68600a70a1c213c272fee5eef6a0047fd695c8dd6d4c7160e2c9dc4d3ba683f",
-      "updated": "2026-08-20T10:05:07Z",
-      "lines": 168,
+      "checksum": "sha256:50629bb0e2091c26805ae206b2b41a392150601f6fa69b38015e79d2413ca262",
+      "updated": "2026-08-20T11:05:40Z",
+      "lines": 199,
       "summary": "Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:df02447ed46de8d46e4f2387f6c4cdc20a01c0929a733bc3db9b1c3238fad584",
-      "updated": "2026-08-20T10:38:40Z",
+      "updated": "2026-08-20T11:05:43Z",
       "lines": 154,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-08-20T10:05:07Z",
+      "updated": "2026-08-20T10:46:58Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-08-20T10:05:07Z",
+      "updated": "2026-08-20T10:46:58Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:87585d1a7f6af0e3d0e71674c492367ce1898f987200eca8310a0d20b750b524",
-      "updated": "2026-08-20T10:38:40Z",
+      "checksum": "sha256:c9fb1bc0416c86642d4ce3eda9e5d6f51abf92a1068f5c77cc1d324f7ecf58ec",
+      "updated": "2026-08-20T11:05:43Z",
       "lines": 70,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:f3c42810ec8e0f07276230376f402689d323a0e4665439badf58f05593ae2ccc",
-      "updated": "2026-08-20T10:38:40Z",
+      "checksum": "sha256:48049e96dc5a232dc4762f704dc18f4943014af3a4123a7a4074aec7a0a51144",
+      "updated": "2026-08-20T11:05:43Z",
       "lines": 62,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:efc9f9fe67b36f4e872a96e49798168a2c6950e4ec1550bbc7bca6c06184c7a2",
-      "updated": "2026-08-20T10:05:07Z",
+      "updated": "2026-08-20T10:46:58Z",
       "lines": 206,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:45ae947add23bf4d9bb2a2bb009f4acbdd00b7fe1531912f9693dea1e48bc3b9",
-      "updated": "2026-08-20T10:05:07Z",
+      "updated": "2026-08-20T10:46:58Z",
       "lines": 164,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-20T10:05:07Z",
+      "updated": "2026-08-20T10:46:58Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-20T10:05:07Z",
+      "updated": "2026-08-20T10:46:58Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,8 +80,8 @@
   "quick_context": "Model: claude-opus-5. Branch docs/recommend-exact-pinning. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 27605,
-    "full_read": 38544
+    "manifest_plus_core": 28865,
+    "full_read": 39804
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -98,17 +98,48 @@ the production extraction backend or weakening Linux coverage.
 
 ---
 
-## T-013: Move to Babel 8 and a supported Node line (blocked)
+## T-013: Move to Babel 8 and a supported Node line (owner decision outstanding)
 
 **Goal:** Upgrade Babel and the supported Node/CI matrix as one compatible change.
 
-**Blocked by:** Owner decision on raising package engines and both CI jobs together;
-do not merge Babel 8 alone.
+**What is now in place.** The compatibility contract, the evidence to act on it and
+the machinery to execute it all exist, so the remaining step is a decision rather
+than an investigation. `docs/node-support.md` holds the policy as a
+machine-readable block, and `src/__tests__/node-version-contract.test.ts` holds
+every declaration site to it. The complete suite plus a clean-room install of the
+packed tarball now run on Node 20 and Node 22 on every commit.
+
+**What the survey found, and it was not what the task assumed.** The repository
+already disagreed with itself. `package.json` promised `>=20.0.0`, CI built,
+tested and published on 20, while `action.yml` and the `Dockerfile` both executed
+on 22. The two most-used distribution channels were running on a major CI never
+exercised. Node 20 also reached end of life on 2026-04-30, verified against the
+upstream nodejs/Release schedule, so the artifact was being published from an
+unpatched runtime.
+
+**Blocked by:** Owner decision on raising `engines.node`, which is a promise
+broken for every consumer still on Node 20 and therefore not an agent's call.
+Everything else is mechanical once it is made: set `enginesFloor` and
+`testedMajors` in `docs/node-support.md` and the gate names every file that has to
+follow.
 
 **Acceptance criteria:**
+- [x] Every Node declaration site identified and reconciled to one authoritative policy.
+- [x] CI runs the COMPLETE build and suite on both majors, with no reduced smoke lane.
+- [x] The publishing path is validated on both majors without a public release: pack, tarball contents against the manifest, clean-room install, entry point, bin mapping, type declarations, metadata and an end-to-end scan from the installed artifact.
+- [x] A deterministic drift gate exists, mutation-proved 9/9, and the artifact validation is mutation-proved 3/3.
 - [ ] The owner selects and records the new minimum Node line.
-- [ ] Engines, both CI jobs, Babel, lockfile, and user-facing support documentation move together.
-- [ ] Build, full Linux suite, package smoke test, and release gates pass on the new matrix.
+- [ ] Engines, Babel, lockfile and user-facing support documentation move together with it.
+
+**Tracked exception: the npm publish job still runs on Node 20.** It is the one
+lane that cannot be rehearsed, because it runs only on a tag push and
+authenticates by OIDC, which no dry run exercises; a failed publish burns a
+version number, and that bill has been paid before when npm 12 dropped Node 20.
+Owner: the maintainer. Exit condition, mechanically checkable: set `publishMajor`
+to 22 in `docs/node-support.md`, which makes the gate require the publish job to
+declare 22. The condition for doing so is a green `compat (Node 22)` leg on `main`
+across at least one release cycle. Tracked here rather than in a GitHub issue
+because this repository holds zero open issues by rule.
 
 ---
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -225,6 +225,68 @@ pull_request event. The assertion now resolves the `||` fallback for that event
 before comparing. Recorded because the first version looked like a proof and was
 not.
 
+## T-013: Node compatibility contract, evidence lanes and drift gate (2026-08-20)
+
+Model: claude-opus-5. Branch node/22-compat-contract. No version bump.
+
+**The survey came back different from the task's premise.** T-013 was written as
+"move to a supported Node line". The inventory found the repository already
+disagreeing with itself: `package.json` promised `>=20.0.0`, CI built, tested and
+PUBLISHED on 20, and `action.yml` and the `Dockerfile` both ran on 22. So the
+composite Action and the container image, the two things people actually run,
+executed on a major CI never exercised, and had for months with everything green,
+because nothing compared the files to each other.
+
+Node 20 reached end of life on 2026-04-30. That was read from the upstream
+nodejs/Release schedule rather than recalled. For a supply-chain security tool,
+building and publishing the artifact from an unpatched runtime is a defect in the
+product, not housekeeping.
+
+**What shipped.** One authoritative policy in `docs/node-support.md`, as a
+machine-readable block inside its own documentation so the doc cannot drift from
+the config. `src/__tests__/node-version-contract.test.ts` parses it and holds
+every declaration site to it, including two invariants that were being violated:
+the runtime major must be tested, and the publish major must be tested.
+
+CI now runs the complete build, every governance gate and the full suite on Node
+20 and Node 22, with no reduced smoke lane. `scripts/validate-package.sh` runs
+inside each matrix leg: it packs, checks the tarball against the manifest,
+installs it into a directory sharing nothing with the checkout, and drives the CLI
+and the programmatic entry point from that install, ending in a real scan.
+
+**The check name stayed put, deliberately.** Making `build` a matrix would have
+renamed its check to `Build and Test (20)` and `Build and Test (22)` and deleted
+the context branch protection waits for, which is the deadlock PR #159 measured
+two days' work earlier in this same session. Instead the matrix runs under
+`compat (Node N)` and a one-step aggregator keeps `Build and Test` as a single
+required context with a single producer. It carries `if: always()` because a
+SKIPPED job is not a failing one, so without it a red matrix could report as a
+non-failure.
+
+**Evidence.** Drift gate: 20 assertions, 9 of 9 mutations caught, including
+action.yml reverting to 20, the Dockerfile reverting to 20, dropping 22 from the
+matrix, lowering the engines floor, moving the publish job to an untested major,
+the devcontainer staying on the EOL major, a user-facing example advertising an
+untested major, and the policy document itself claiming an untested runtime major.
+
+Artifact validation: 34 checks, 3 of 3 artifact defects caught. The first run of
+that mutation harness was INVALID and is recorded as such: it reported 3 of 3
+caught while the clean tree also exited 127, because Python spawned a bash whose
+PATH had no `node`, so every run failed for the same unrelated reason. Re-run from
+bash, one mutation then SURVIVED: dropping `policy-schema.json` from `files[]` was
+invisible, because every assertion read `files[]` and confirmed the tarball
+matched it, so deleting an entry removed the file and the check together. A
+manifest-independent floor of required runtime assets was added, and the mutation
+is caught.
+
+**What is deliberately NOT done.** `engines.node` still says `>=20.0.0`. Raising
+it is a promise broken for every consumer still on Node 20, in a package installed
+inside other people's pipelines where the Node version is often not theirs to
+choose. That is an owner decision, it is recorded as the outstanding half of T-013,
+and the gate makes executing it mechanical. The publish job also still runs on
+Node 20, tracked as a named exception with an owner and a mechanically checkable
+exit condition in `docs/node-support.md`.
+
 ## Carried open items (process and design, not tied to one sweep)
 
 ### Duplicate CI runs: do NOT simply drop the `edited` PR trigger

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -279,6 +279,21 @@ matched it, so deleting an entry removed the file and the check together. A
 manifest-independent floor of required runtime assets was added, and the mutation
 is caught.
 
+**CI evidence, read off the run rather than off the tick.** PR #160, head sha
+75fb45e, CI run 32362440688. `compat (Node 20)` ran on node v20.20.2 and
+`compat (Node 22)` on node v22.23.2; both reported 116 of 116 test files
+passing, which is the whole suite and not a subset, and both finished with
+"Packaged artifact OK" covering tarball contents, clean-room install, metadata,
+bin mapping, entry point, declarations and an end-to-end scan. This is the first
+time this project has ever run its suite on Node 22.
+
+That run was also the first PR under the three required contexts, so it doubles
+as the branch-protection verification the CI split needed: `Build and Test`,
+`aahp-verify` and `PR metadata policy` were all present and green on the head
+sha, the aggregator reported once, and the PR read CLEAN. The contract is
+satisfiable on a normal PR, which is the property scenario D showed could not be
+taken for granted.
+
 **What is deliberately NOT done.** `engines.node` still says `>=20.0.0`. Raising
 it is a promise broken for every consumer still on Node 20, in a package installed
 inside other people's pipelines where the Node version is often not theirs to

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.27.0 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 115 | src/__tests__/ file list |
+| Test files present | 116 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "supply-chain-guard",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "postCreateCommand": "sudo apt-get update && sudo apt-get install -y zip && npm ci",
   "customizations": {
     "vscode": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  # Keeps the digest-pinned node:20-alpine base image in the Dockerfile fresh:
+  # Keeps the digest-pinned node:22-alpine base image in the Dockerfile fresh:
   # the FROM lines pin by sha256 digest, so security updates only arrive via
   # these deliberate weekly bump PRs.
   - package-ecosystem: "docker"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,26 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: Build and Test
+  # Complete build and test on every Node major this package supports.
+  #
+  # The contract: the package must install, pass every governance gate, pass the
+  # FULL suite, and run FROM ITS PACKED TARBALL on each major it claims. There is
+  # deliberately no reduced smoke lane, because a lane that runs less than the
+  # real suite proves less than the real suite, and the difference is exactly
+  # where a version incompatibility hides.
+  #
+  # This matrix is the authoritative Node policy for CI.
+  # src/__tests__/node-version-contract.test.ts fails the build if any other
+  # declaration site in the repo drifts from it. See docs/node-support.md.
+  compat:
+    name: compat (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      # Both majors always report. Stopping the 22 leg because 20 failed would
+      # hide the compatibility difference this matrix exists to surface.
+      fail-fast: false
+      matrix:
+        node: ['20', '22']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -55,7 +72,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node }}
           cache: 'npm'
 
       - name: Install dependencies
@@ -157,8 +174,7 @@ jobs:
           if [ "$fail" -ne 0 ]; then
             exit 1
           fi
-          echo "No AI attribution in PR title, body or commit messages."
-
+          echo "No AI attribution in commit messages or author identity."
       # AAHP conformance (v3.6+): the pinned @elvatis_com/aahp CLI self-checks handoff
       # set, MANIFEST schema, grounding, the exact-version dep pin, changelog format and
       # version sync. --no-install forces the pinned node_modules copy, not a fetched one.
@@ -168,13 +184,55 @@ jobs:
       - name: Test
         run: npm run test:coverage
 
+      # Validates the ARTIFACT rather than the working tree: packs, inspects what
+      # came out, installs the tarball into a directory that shares nothing with
+      # this checkout, and drives the CLI and the programmatic entry point from
+      # that install. A build that emits nothing, an entry point aimed at a
+      # missing file, an unshipped data file or a bin that is not executable all
+      # survive a green suite and break on `npm install`. Running it inside the
+      # matrix is what makes it a compatibility check and not just a packaging one.
+      - name: Validate the packaged artifact
+        run: bash scripts/validate-package.sh
+
       - name: Upload coverage summary
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-summary
+          # Per-major name: two matrix legs uploading one artifact name collide.
+          name: coverage-summary-node${{ matrix.node }}
           path: coverage/coverage-summary.json
           retention-days: 14
+
+  # Aggregator. "Build and Test" is a REQUIRED status check, and its NAME is a
+  # contract with branch protection, so it stays one context with one producer
+  # even though the work now runs once per Node major.
+  #
+  # Renaming the matrix job to this instead would produce "Build and Test (20)"
+  # and "Build and Test (22)" and delete the context branch protection waits for,
+  # blocking every PR on a check that never arrives. That failure mode is not
+  # hypothetical: it was measured on PR #159, where a workflow missing the
+  # `synchronize` trigger left head shas with no run of a required check at all.
+  #
+  # `if: always()` matters. Without it this job is SKIPPED when a matrix leg
+  # fails, and a skipped required check is not a failing one, so a red matrix
+  # could report as a non-failure. It runs unconditionally and decides explicitly.
+  build:
+    name: Build and Test
+    needs: [compat]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every Node major to have passed
+        env:
+          COMPAT_RESULT: ${{ needs.compat.result }}
+        run: |
+          echo "Node compatibility matrix result: $COMPAT_RESULT"
+          if [ "$COMPAT_RESULT" != "success" ]; then
+            echo "::error title=Node compatibility::At least one Node major did not pass. Open the compat legs to see which."
+            exit 1
+          fi
+          echo "Every Node major in the compatibility matrix passed."
+
 
   publish:
     name: Publish to npm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ npm test
 
 The repository ships a [dev container](.devcontainer/devcontainer.json). Open the
 repo in VS Code and choose "Reopen in Container" (or use GitHub Codespaces) - it
-installs Node 20, the `zip` CLI, and runs `npm ci` automatically. In the
+installs Node 22, the `zip` CLI, and runs `npm ci` automatically. In the
 container ALL tests pass, including the 14 vscode-scanner tests that need the
 `zip` binary.
 

--- a/docs/node-support.md
+++ b/docs/node-support.md
@@ -1,0 +1,101 @@
+# Node.js support policy
+
+This file is the single authoritative statement of which Node versions this
+project supports, tests, publishes from and develops against. It is not a
+description of the configuration: `src/__tests__/node-version-contract.test.ts`
+parses the block below and fails the build if any declaration site in the
+repository disagrees with it. Change the policy here and the gate will tell you
+every file that has to follow.
+
+## The policy
+
+```json
+{
+  "enginesFloor": "20.0.0",
+  "testedMajors": [20, 22],
+  "publishMajor": 20,
+  "runtimeMajor": 22,
+  "devBaseline": 22
+}
+```
+
+| field | meaning | where it must appear |
+| --- | --- | --- |
+| `enginesFloor` | the lowest Node a consumer may install on | `engines.node` in `package.json` |
+| `testedMajors` | every major the complete build and suite runs on | the `compat` matrix in `ci.yml` |
+| `publishMajor` | the major the npm artifact is published from | the `publish` job in `ci.yml` |
+| `runtimeMajor` | the major the published Action and image execute on | `action.yml`, `Dockerfile` |
+| `devBaseline` | what a contributor should develop on | `.devcontainer/devcontainer.json` |
+
+Two invariants make the rest of it hold, and both are asserted:
+
+- **`runtimeMajor` must be in `testedMajors`.** This one was violated. Until
+  this policy existed, the published Action and the published container image
+  both ran on Node 22 while CI built and tested only on Node 20, so the two
+  most-used distribution channels executed on a major that nothing verified.
+- **`publishMajor` must be in `testedMajors`.** An artifact must not be built by
+  a toolchain the suite has never run under.
+
+## Why 22 and not only 20
+
+Node 20 reached end of life on 2026-04-30, confirmed against the upstream
+`nodejs/Release` schedule rather than from memory. It receives no further
+security patches. Node 22 is supported until 2027-04-30.
+
+For a tool whose entire purpose is supply-chain security, building and shipping
+from an unpatched runtime is a defect in the product, not a housekeeping detail.
+
+## Why the floor is still 20
+
+Raising `engines.node` is a promise broken for every consumer still on Node 20,
+and this project is installed inside other people's CI where the Node version is
+often not theirs to choose. The floor moves only once the evidence is in, and the
+evidence is the point of the current arrangement: the complete suite, the
+governance gates and a clean-room install of the packed tarball all run on both
+majors, every commit.
+
+## The one exception, and how it ends
+
+**Exception: the npm publish job still runs on Node 20 (`publishMajor: 20`).**
+
+- **Why.** The publish job is the only lane that cannot be rehearsed. It runs
+  solely on a semver tag push, it authenticates by OIDC against the npm Trusted
+  Publisher, and OIDC cannot be exercised by a dry run. A failed publish cannot
+  be retried on the same version, because tags here are immutable, so the cost of
+  being wrong is a burned version number. It has been paid before: npm 12 dropped
+  Node 20, `npm@latest` hard-failed EBADENGINE, and the v5.11.0 publish broke.
+- **What reduces the risk meanwhile.** Everything upstream of the OIDC call is
+  now proven on Node 22 every commit, because `scripts/validate-package.sh` packs
+  the tarball, inspects its contents against the manifest, installs it into a
+  clean directory and runs the CLI and the programmatic entry point from that
+  install, on both majors.
+- **Owner.** The repository maintainer.
+- **Exit condition, mechanically checkable.** Set `publishMajor` to 22 in the
+  block above and delete this section. The gate then requires the `publish` job
+  in `ci.yml` to declare Node 22, and requires 22 to be in `testedMajors`. The
+  condition for doing so is that the packaged-artifact lane has been green on
+  `main` on the Node 22 leg across at least one release cycle, which is visible
+  in the Actions history for the `compat (Node 22)` job.
+- **Tracked in.** `.ai/handoff/NEXT_ACTIONS.md`, not a GitHub issue. This
+  repository holds zero open issues by rule, so an issue is not a durable place
+  to track anything here.
+
+## Moving the floor to 22 later
+
+The migration is mechanical once the decision is made, and the gate drives it:
+
+1. Set `enginesFloor` to `22.0.0` and `testedMajors` to `[22, 24]` here.
+2. Run the build. The drift gate names every file that still says 20, including
+   the user-facing examples, which are asserted to reference only tested majors
+   precisely so that they cannot be forgotten.
+3. Update `engines.node`, the matrix and whatever else the gate listed.
+4. Ship it as a minor at least, and say so in the changelog: for a consumer
+   pinned to Node 20 this changes whether the package installs cleanly.
+
+## What is deliberately not governed here
+
+Threat intelligence and test fixtures mention Node versions as data, not as
+policy: a Dockerfile fixture pinned to `node:20-alpine` exists to be scanned, and
+the advice string in the Dockerfile scanner names a version because it is example
+output. The gate excludes `src/`, test fixtures and `CHANGELOG.md` for that
+reason, and the exclusion list in the test names each one with its reason.

--- a/scripts/validate-package.sh
+++ b/scripts/validate-package.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# Validate the PUBLISHED ARTIFACT, not the working tree.
+#
+# `npm test` proves the source passes its suite. It says nothing about whether
+# the thing a consumer actually installs works, because the tarball is a
+# different set of files: `files` in package.json ships dist plus five loose
+# assets, and a build that emits nothing, an entry point that points at a
+# missing file, a type declaration that never got generated or a bin mapping
+# that is not executable all survive a green `npm test` and break on install.
+#
+# So this packs the repo, inspects what came out, installs the tarball into a
+# directory that shares nothing with this checkout, and exercises the CLI and the
+# programmatic entry point FROM THAT INSTALL. Everything it asserts is a promise
+# package.json already makes, read out of package.json rather than hardcoded, so
+# adding an export or renaming a bin cannot silently escape the check.
+#
+# Runs once per Node major in the CI compatibility matrix, which is what turns it
+# from a packaging check into a compatibility check.
+#
+# Local use: bash scripts/validate-package.sh
+#   Needs a POSIX shell, tar, and a writable temp dir. On Windows/MSYS set
+#   SCG_VALIDATE_TMP to an explicit native path, because MSYS and native node
+#   disagree about where /tmp is and node will not find what the shell wrote.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+fail=0
+ok()   { echo "  [ok]   $1"; }
+bad()  { echo "  [FAIL] $1"; fail=1; }
+note() { echo "  ---    $1"; }
+
+NAME=$(node -p "require('./package.json').name")
+VERSION=$(node -p "require('./package.json').version")
+echo "Validating packaged artifact: $NAME@$VERSION on node $(node -v)"
+echo
+
+# --- 1. the tarball must exist and be produced by the real pack path ----------
+WORK="${SCG_VALIDATE_TMP:-$(mktemp -d)}"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+note "packing into $WORK"
+TARBALL="$WORK/$(npm pack --silent --pack-destination "$WORK")"
+if [ -f "$TARBALL" ]; then
+  ok "npm pack produced $(basename "$TARBALL") ($(wc -c <"$TARBALL") bytes)"
+else
+  bad "npm pack produced no tarball"; exit 1
+fi
+
+LIST="$WORK/contents.txt"
+# Listed from inside $WORK with a RELATIVE name on purpose: an absolute
+# Windows path like C:/... reads as a remote host spec to MSYS tar, which then
+# tries to resolve a host called "C". Harmless on the Linux runners, but it
+# makes this script unusable locally, which is where it gets debugged.
+( cd "$WORK" && tar -tzf "$(basename "$TARBALL")" ) | sed 's#^package/##' | sort >"$LIST"
+note "$(wc -l <"$LIST" | tr -d ' ') entries in the tarball"
+
+have() { grep -qxF "$1" "$LIST"; }
+
+# --- 2. every generated file the manifest promises must be IN the tarball -----
+# Read the promises out of package.json so this cannot drift from the manifest.
+MAIN=$(node -p "require('./package.json').main || ''")
+TYPES=$(node -p "require('./package.json').types || ''")
+
+for f in "$MAIN" "$TYPES"; do
+  [ -n "$f" ] || continue
+  if have "$f"; then ok "manifest entry present in tarball: $f"
+  else bad "manifest points at $f but the tarball does not contain it"; fi
+done
+
+while IFS= read -r binpath; do
+  [ -n "$binpath" ] || continue
+  if have "$binpath"; then ok "bin target present in tarball: $binpath"
+  else bad "bin maps to $binpath but the tarball does not contain it"; fi
+done < <(node -p "const b=require('./package.json').bin;Object.values(typeof b==='string'?{x:b}:(b||{})).join('\n')")
+
+while IFS= read -r asset; do
+  [ -n "$asset" ] || continue
+  case "$asset" in *"*"*) continue ;; esac   # globs are checked via dist below
+  if have "$asset"; then ok "declared asset present: $asset"
+  else bad "files[] declares $asset but the tarball does not contain it"; fi
+done < <(node -p "(require('./package.json').files||[]).join('\n')")
+
+# A manifest-driven check is blind in one direction, and the mutation run proved
+# it: every assertion above reads `files[]` and confirms the tarball contains what
+# it declares, so DELETING an entry from `files[]` removes the file from the
+# package AND removes the check that would have missed it. Caught by mutating
+# package.json to drop policy-schema.json, which sailed through.
+#
+# So the runtime assets have a floor that does not come from the manifest. This
+# list is duplicated on purpose. Adding to it should be a deliberate act, and
+# removing from it should require saying why in a diff someone reviews.
+for required in action.yml README.md LICENSE socket.yml policy-schema.json; do
+  if have "$required"; then ok "required runtime asset ships: $required"
+  else bad "required runtime asset MISSING from the tarball: $required"; fi
+done
+
+# A build that emitted nothing still packs a valid, useless tarball.
+DIST_JS=$(grep -c '^dist/.*\.js$'   "$LIST" || true)
+DIST_DTS=$(grep -c '^dist/.*\.d\.ts$' "$LIST" || true)
+if [ "$DIST_JS"  -gt 20 ]; then ok "dist carries $DIST_JS compiled .js files"
+else bad "dist carries only $DIST_JS .js files, the build did not emit"; fi
+if [ "$DIST_DTS" -gt 20 ]; then ok "dist carries $DIST_DTS .d.ts type declarations"
+else bad "dist carries only $DIST_DTS .d.ts files, declarations were not emitted"; fi
+
+# --- 3. things that must NOT ship --------------------------------------------
+# A scanner that ships its own test fixtures ships malicious sample payloads to
+# every consumer, and the fixtures are large. Sources leaking is a smaller
+# problem but still means the manifest is not doing what it says.
+for pattern in '^src/' '^\.ai/' '^scripts/' '\.test\.ts$' '^tsconfig' '^feed\.json$' '^\.github/'; do
+  n=$(grep -cE "$pattern" "$LIST" || true)
+  if [ "$n" -eq 0 ]; then ok "tarball ships nothing matching $pattern"
+  else bad "tarball ships $n entries matching $pattern"; grep -E "$pattern" "$LIST" | head -3 | sed 's/^/         /'; fi
+done
+
+# --- 4. install into a directory that shares nothing with this checkout -------
+CLEAN="$WORK/clean"
+mkdir -p "$CLEAN"
+cd "$CLEAN"
+npm init -y >/dev/null 2>&1
+# --ignore-scripts on purpose: a consumer install must work without running any
+# lifecycle script of ours, and this package declares none for install.
+if npm install --silent --no-audit --no-fund --ignore-scripts "$TARBALL" >"$WORK/install.log" 2>&1; then
+  ok "clean-room install succeeded from the tarball"
+else
+  bad "clean-room install failed"; tail -20 "$WORK/install.log" | sed 's/^/         /'; cd "$REPO"; exit 1
+fi
+
+INSTALLED="$CLEAN/node_modules/$NAME"
+[ -d "$INSTALLED" ] && ok "installed at node_modules/$NAME" || bad "package not found under node_modules"
+
+# --- 5. metadata survived the round trip -------------------------------------
+I_NAME=$(node -p "require('$INSTALLED/package.json').name")
+I_VER=$(node -p "require('$INSTALLED/package.json').version")
+[ "$I_NAME" = "$NAME" ]    && ok "installed name matches: $I_NAME"       || bad "name drifted: $I_NAME vs $NAME"
+[ "$I_VER"  = "$VERSION" ] && ok "installed version matches: $I_VER"     || bad "version drifted: $I_VER vs $VERSION"
+
+I_ENG=$(node -p "JSON.stringify(require('$INSTALLED/package.json').engines||null)")
+note "installed engines: $I_ENG"
+
+# --- 6. the bin mapping actually resolves and runs ----------------------------
+while IFS= read -r binname; do
+  [ -n "$binname" ] || continue
+  LINK="$CLEAN/node_modules/.bin/$binname"
+  if [ -e "$LINK" ]; then ok "bin '$binname' linked into node_modules/.bin"
+  else bad "bin '$binname' was not linked"; continue; fi
+  if OUT=$("$LINK" --version 2>&1); then
+    if [ "$(echo "$OUT" | tr -d '[:space:]')" = "$VERSION" ]; then
+      ok "packaged CLI reports $OUT"
+    else
+      bad "packaged CLI reported '$OUT', package.json says '$VERSION'"
+    fi
+  else
+    bad "packaged CLI failed to run: $OUT"
+  fi
+done < <(node -p "const b=require('./node_modules/$NAME/package.json').bin;Object.keys(typeof b==='string'?{'$NAME':b}:(b||{})).join('\n')")
+
+# --- 7. the programmatic entry point loads and its exports are callable -------
+# require() from the INSTALL, so a bad main/exports field fails here the way it
+# would for a consumer, rather than resolving through the local source tree.
+if node -e "
+  const m = require('$NAME');
+  const expected = ['scan', 'formatReport'];
+  const missing = expected.filter((k) => typeof m[k] !== 'function');
+  if (missing.length) { console.error('missing exports: ' + missing.join(', ')); process.exit(1); }
+  console.log(Object.keys(m).length);
+" >"$WORK/require.log" 2>&1; then
+  ok "require('$NAME') resolved and exports $(cat "$WORK/require.log") names, including scan and formatReport"
+else
+  bad "require('$NAME') failed"; sed 's/^/         /' "$WORK/require.log"
+fi
+
+# --- 8. type declarations resolve the way a TypeScript consumer resolves them --
+if [ -n "$TYPES" ] && [ -f "$INSTALLED/$TYPES" ]; then
+  ok "type declarations present at $TYPES"
+  # index.d.ts is a re-export barrel, so it carries `export { x } from "./y.js"`
+  # and no `export declare` of its own. Assert on what a barrel actually looks
+  # like, then follow one re-export to a leaf that does declare something, which
+  # is what a consumer's compiler has to be able to do.
+  if grep -qE '^export (\{|type |declare )' "$INSTALLED/$TYPES"; then
+    ok "type declarations carry re-exports"
+  else
+    bad "$TYPES exports nothing recognisable"
+  fi
+  LEAF="$INSTALLED/dist/scanner.d.ts"
+  if [ -f "$LEAF" ] && grep -qE 'declare (function|const|class) ' "$LEAF"; then
+    ok "a re-exported leaf declaration resolves (dist/scanner.d.ts)"
+  else
+    bad "re-export target dist/scanner.d.ts is missing or declares nothing"
+  fi
+else
+  bad "types field points at $TYPES which is not in the install"
+fi
+
+# --- 9. end to end: the packaged CLI scans a real directory --------------------
+# The whole point of the artifact. A CLI that starts and then cannot complete a
+# scan because a data file was left out of `files` passes every check above.
+# Invoked as `scan <path> --format json`: this CLI is subcommand-driven, a bare
+# path is an unknown command, and the flag is --format rather than --json. Both
+# mistakes exit non-zero and look exactly like a broken artifact, so the
+# invocation is worth stating precisely. --no-history keeps the check from
+# writing .scg-history into the fixture it just created.
+FIXTURE="$WORK/fixture"
+mkdir -p "$FIXTURE"
+printf '{\n  "name": "fixture",\n  "version": "1.0.0",\n  "dependencies": { "express": "4.18.2" }\n}\n' >"$FIXTURE/package.json"
+BIN1=$(node -p "const b=require('$INSTALLED/package.json').bin;Object.keys(typeof b==='string'?{'$NAME':b}:(b||{}))[0]")
+set +e
+SCAN_OUT=$("$CLEAN/node_modules/.bin/$BIN1" scan "$FIXTURE" --format json --no-history 2>&1); SCAN_RC=$?
+set -e
+# Exit code is a findings verdict, not a health signal: this CLI exits non-zero
+# when it finds something. Only a crash means the artifact is broken.
+if echo "$SCAN_OUT" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{JSON.parse(d);process.exit(0)})" 2>/dev/null; then
+  ok "packaged CLI completed a scan and emitted parseable JSON (exit $SCAN_RC)"
+else
+  bad "packaged CLI did not emit parseable JSON (exit $SCAN_RC)"
+  echo "$SCAN_OUT" | head -15 | sed 's/^/         /'
+fi
+
+cd "$REPO"
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "Packaged artifact OK on node $(node -v): tarball contents, clean-room install, metadata, bin, entry point, declarations and an end-to-end scan all verified."
+else
+  echo "Packaged artifact validation FAILED on node $(node -v)."
+fi
+exit "$fail"

--- a/src/__tests__/node-version-contract.test.ts
+++ b/src/__tests__/node-version-contract.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Node version policy: one source of truth, mechanically enforced.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Before this gate, the repository disagreed with itself about Node and nothing
+ * noticed. `package.json` promised `>=20.0.0`, CI built, tested and PUBLISHED on
+ * 20, and the two artefacts people actually run - the composite Action in
+ * `action.yml` and the container image in the `Dockerfile` - both executed on 22.
+ * So the two most-used distribution channels ran on a major that CI never
+ * exercised, and had done for months. Nothing was red, because nothing compared
+ * the files to each other.
+ *
+ * Node 20 also reached end of life on 2026-04-30, which makes the disagreement
+ * worse than untidy: the artifact consumers install was being built and published
+ * by an unpatched runtime, in a package whose entire subject is supply-chain risk.
+ *
+ * The policy itself lives in docs/node-support.md as a machine-readable block, so
+ * the documentation cannot drift from the configuration either: this test parses
+ * that block and holds every declaration site to it. Changing the policy is
+ * editing one JSON object and then doing what the failures say.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const read = (rel: string) => fs.readFileSync(path.join(REPO, rel), "utf-8");
+
+interface NodePolicy {
+  enginesFloor: string;
+  testedMajors: number[];
+  publishMajor: number;
+  runtimeMajor: number;
+  devBaseline: number;
+}
+
+const POLICY_DOC = "docs/node-support.md";
+
+/** The single authoritative policy, parsed out of its own documentation. */
+function policy(): NodePolicy {
+  const doc = read(POLICY_DOC);
+  const block = doc.match(/```json\s*\n([\s\S]*?)\n```/);
+  if (!block) throw new Error(`no json policy block in ${POLICY_DOC}`);
+  return JSON.parse(block[1]!) as NodePolicy;
+}
+
+const P = policy();
+
+/** `node-version: '20'` / `node-version: "22"` / `node-version: 20`. */
+function nodeVersions(yaml: string): string[] {
+  return [...yaml.matchAll(/node-version:\s*['"]?([0-9.]+)['"]?/g)].map((m) => m[1]!);
+}
+
+/** Every Node major mentioned as a version in a chunk of text. */
+function majorsMentioned(text: string): number[] {
+  const found = new Set<number>();
+  const patterns = [
+    /node-version:\s*['"]?(\d+)/g,
+    /node:(\d+)/g,
+    /javascript-node:(\d+)/g,
+    /\bNode(?:\.js)?\s+(\d\d)\b/g,
+    /cimg\/node:(\d+)/g,
+  ];
+  for (const re of patterns) {
+    for (const m of text.matchAll(re)) found.add(Number(m[1]));
+  }
+  return [...found];
+}
+
+describe("node version policy", () => {
+  describe("the policy is internally coherent", () => {
+    it("the runtime major is one the suite actually runs on", () => {
+      // The invariant that was violated. action.yml and the Dockerfile execute on
+      // runtimeMajor; if CI never runs there, the published artefacts are the
+      // least tested thing in the project.
+      expect(P.testedMajors).toContain(P.runtimeMajor);
+    });
+
+    it("the publish major is one the suite actually runs on", () => {
+      // An artifact must not be built by a toolchain the suite has never run under.
+      expect(P.testedMajors).toContain(P.publishMajor);
+    });
+
+    it("every tested major is at or above the engines floor", () => {
+      const floor = Number(P.enginesFloor.split(".")[0]);
+      for (const m of P.testedMajors) expect(m).toBeGreaterThanOrEqual(floor);
+    });
+
+    it("the engines floor is itself tested", () => {
+      // Promising `>=20` while testing only 22 is promising something unverified.
+      expect(P.testedMajors).toContain(Number(P.enginesFloor.split(".")[0]));
+    });
+  });
+
+  describe("normative sites match the policy exactly", () => {
+    it("package.json engines.node is the declared floor", () => {
+      const pkg = JSON.parse(read("package.json"));
+      expect(pkg.engines?.node).toBe(`>=${P.enginesFloor}`);
+    });
+
+    it("the CI compat matrix is exactly the tested majors", () => {
+      const ci = read(".github/workflows/ci.yml");
+      const m = ci.match(/matrix:\s*\n\s*node:\s*\[([^\]]*)\]/);
+      expect(m, "no compat matrix found in ci.yml").toBeTruthy();
+      const declared = m![1]!
+        .split(",")
+        .map((s) => Number(s.trim().replace(/['"]/g, "")))
+        .sort((a, b) => a - b);
+      expect(declared).toEqual([...P.testedMajors].sort((a, b) => a - b));
+    });
+
+    it("the CI publish job runs on the publish major", () => {
+      const ci = read(".github/workflows/ci.yml");
+      // Slice the publish job out so the compat matrix's setup-node cannot satisfy this.
+      const job = ci.slice(ci.indexOf("\n  publish:"), ci.indexOf("\n  release:"));
+      expect(job.length).toBeGreaterThan(0);
+      expect(nodeVersions(job)).toEqual([String(P.publishMajor)]);
+    });
+
+    it("action.yml runs the published Action on the runtime major", () => {
+      expect(nodeVersions(read("action.yml"))).toEqual([String(P.runtimeMajor)]);
+    });
+
+    it("every Dockerfile stage uses the runtime major", () => {
+      const froms = [...read("Dockerfile").matchAll(/^FROM\s+node:(\d+)-/gm)].map((m) => m[1]!);
+      expect(froms.length, "expected at least one FROM node: stage").toBeGreaterThan(0);
+      for (const f of froms) expect(f).toBe(String(P.runtimeMajor));
+    });
+
+    it("the devcontainer is the declared dev baseline", () => {
+      const dc = read(".devcontainer/devcontainer.json");
+      expect(dc).toContain(`javascript-node:${P.devBaseline}`);
+    });
+
+    it("the supporting workflows run on a tested major", () => {
+      // Not pinned to one value: these gate the repo, not the artifact, so any
+      // major the suite covers is a defensible choice. Drifting OUTSIDE the
+      // covered set is not.
+      for (const wf of [".github/workflows/aahp-verify.yml", ".github/workflows/demo.yml"]) {
+        for (const v of nodeVersions(read(wf))) {
+          expect(P.testedMajors, `${wf} declares node ${v}`).toContain(Number(v.split(".")[0]));
+        }
+      }
+    });
+  });
+
+  describe("user-facing copy does not advertise an untested major", () => {
+    // These are non-normative, but they are what a reader copies into their own
+    // pipeline, and a security tool recommending an end-of-life runtime is its
+    // own kind of finding. Asserting membership rather than a fixed value is what
+    // makes the future floor move mechanical: drop 20 from testedMajors and every
+    // one of these turns red until it is updated.
+    const userFacing = [
+      "examples/azure-pipelines.yml",
+      "examples/bot-pr-gate.yml",
+      "examples/circleci-config.yml",
+      "examples/gitlab-ci.yml",
+      "examples/README.md",
+      "docs/github-actions-sarif.yml",
+      "CONTRIBUTING.md",
+    ];
+
+    for (const file of userFacing) {
+      it(`${file} only mentions tested majors`, () => {
+        const majors = majorsMentioned(read(file));
+        for (const m of majors) {
+          expect(P.testedMajors, `${file} mentions Node ${m}`).toContain(m);
+        }
+      });
+    }
+
+    it("the dependabot comment names the image the Dockerfile actually uses", () => {
+      // Found stale while taking the inventory: the comment said node:20-alpine
+      // while the Dockerfile had been on node:22-alpine since v5.x. A comment that
+      // describes the wrong file is how the next person reasons from a false premise.
+      const db = read(".github/dependabot.yml");
+      const mentioned = [...db.matchAll(/node:(\d+)-alpine/g)].map((m) => Number(m[1]));
+      for (const m of mentioned) expect(m).toBe(P.runtimeMajor);
+    });
+  });
+
+  describe("the exclusions are deliberate", () => {
+    it("scanner fixtures and threat intel are data, not policy", () => {
+      // Guard against someone "fixing" the gate by widening it into src/, which
+      // would start rewriting fixtures that exist precisely to contain an old
+      // version string. Named here so the exclusion is a decision, not an oversight.
+      const excluded = ["src/", "CHANGELOG.md", ".ai/handoff/", "feed.json"];
+      for (const e of excluded) expect(read(POLICY_DOC)).toBeTruthy();
+      expect(excluded.length).toBe(4);
+      // The fixtures really do carry an out-of-policy version, which is why the
+      // gate must never be pointed at them.
+      expect(read("src/__tests__/dockerfile-scanner.test.ts")).toContain("node:20-alpine");
+    });
+  });
+});

--- a/src/__tests__/workflow-trigger-contract.test.ts
+++ b/src/__tests__/workflow-trigger-contract.test.ts
@@ -169,6 +169,11 @@ describe("workflow trigger contract", () => {
   it("dependabot is exempted at step level, not job level", () => {
     // A skipped JOB reports a non-success conclusion for its check context. The
     // job must run and the step must skip, so the required check stays conclusive.
-    expect(META).toMatch(/- name: No AI attribution in PR title or body\n\s+if: github\.actor != 'dependabot\[bot\]'/);
+    // `\s+` rather than `\n\s+`: this repository is worked on from Windows as
+    // well as Linux and has no .gitattributes forcing LF, so the same file is
+    // CRLF in one checkout and LF in another. A hardcoded \n passes on the CI
+    // runner and fails on a Windows clone, which is a test that reports on the
+    // checkout rather than on the thing it claims to assert.
+    expect(META).toMatch(/- name: No AI attribution in PR title or body\s+if: github\.actor != 'dependabot\[bot\]'/);
   });
 });


### PR DESCRIPTION
## What the survey found, which is not what the task assumed

T-013 was written as "move to a supported Node line". Taking the inventory first showed the repository already disagreeing with itself:

| declaration | Node | exercised by CI? |
| --- | --- | --- |
| `package.json` engines floor | `>=20.0.0` | - |
| CI build + test | 20 | yes |
| CI publish | 20 | yes |
| **`action.yml`** (the published Action) | **22** | **no** |
| **`Dockerfile`** (the published image) | **22** | **no** |
| devcontainer | 20 | no |

The composite Action and the container image, the two things people actually run, were executing on a major CI never exercised, and had been for months with everything green, because nothing compared the files to each other.

Node 20 also reached **end of life on 2026-04-30**, read from the upstream `nodejs/Release` schedule rather than recalled. For a tool whose subject is supply-chain risk, building and publishing the artifact from an unpatched runtime is a defect in the product, not housekeeping.

## One policy, enforced rather than described

`docs/node-support.md` is the single authoritative statement, written as a machine-readable block inside its own documentation so the doc and the config cannot drift apart. `src/__tests__/node-version-contract.test.ts` parses that block and holds every declaration site to it, including the two invariants that were being violated:

- **the runtime major must be in the tested majors** (`action.yml`, `Dockerfile`)
- **the publish major must be in the tested majors**

## Complete suite on both majors, and the artifact itself

CI now runs the complete build, every governance gate and the full suite on Node 20 and Node 22. There is deliberately no reduced smoke lane: a lane that runs less than the real suite proves less than the real suite, and the difference is exactly where a version incompatibility hides.

`scripts/validate-package.sh` runs inside each matrix leg and validates the **artifact** rather than the working tree. It packs, checks the tarball against the manifest, installs it into a directory that shares nothing with the checkout, and drives the CLI and the programmatic entry point from that install, ending in a real scan. A build that emits nothing, an entry point aimed at a missing file, an unshipped data file or a bin that is not executable all survive a green suite and break on `npm install`.

## The required check name did not move

Making the build job a matrix would have renamed its check to `Build and Test (20)` and `Build and Test (22)` and deleted the context branch protection waits for. That is not hypothetical: it is the deadlock measured on #159 earlier today, where a workflow missing a trigger left head shas with no run of a required check at all.

So the matrix runs as `compat (Node N)` and a one-step aggregator keeps `Build and Test` a single required context with a single producer. It carries `if: always()`, because a **skipped** job is not a failing one, and without it a red matrix could report as a non-failure.

## What is deliberately not done

`engines.node` still says `>=20.0.0`. Raising it breaks a promise for every consumer still on Node 20, in a package installed inside other people's pipelines where the Node version is often not theirs to choose. That is an owner decision, recorded as the outstanding half of T-013, and the gate makes executing it mechanical: change two fields in the policy block and it names every file that has to follow.

The npm publish job also still runs on Node 20, as a **named exception** with an owner and a mechanically checkable exit condition in `docs/node-support.md`. It is the one lane that cannot be rehearsed: it runs only on a tag push, authenticates by OIDC which no dry run exercises, and a failed publish burns a version number, a bill already paid once when npm 12 dropped Node 20.

## Evidence

| gate | assertions | mutations |
| --- | --- | --- |
| Node drift gate | 20 | 9/9 caught |
| Packaged artifact validation | 34 | 3/3 caught |

Mutations caught by the drift gate: `action.yml` reverting to 20, the Dockerfile reverting to 20, dropping 22 from the matrix, lowering the engines floor, moving the publish job to an untested major, the devcontainer staying on the EOL major, a user-facing example advertising an untested major, a stale dependabot comment, and the policy document itself claiming an untested runtime major.

Two things went wrong while producing that evidence, and both are recorded rather than smoothed over:

- **The first artifact mutation run was invalid.** It reported 3/3 caught while the clean tree also exited 127, because the harness spawned a shell whose PATH had no `node`, so every run failed for the same unrelated reason. Re-run correctly from bash, one mutation then **survived**: dropping an asset from `files[]` was invisible, because every assertion read `files[]` and confirmed the tarball matched it, so deleting an entry removed the file and its check together. A manifest-independent floor of required runtime assets was added and the mutation is caught.
- **A newline assumption** in the workflow-trigger contract test made it pass on an LF checkout and fail on a CRLF one. Fixed, and the relaxed assertion was re-mutated to confirm it did not become a tautology.
