### PR TITLE
fix(disclosure): benchmark evidence carries counts, never consumer names

### DIFF
--- a/.ai/handoff/CONVENTIONS.md
+++ b/.ai/handoff/CONVENTIONS.md
@@ -19,6 +19,24 @@
   `SECURITY.md`, `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`. Changing any of those
   is an owner decision, and the contact addresses additionally need a working
   mailbox to move to.
+- **Do not name a consumer repository in repository content.** Benchmark and
+  measurement evidence carries **counts and classes only**: write "seven consumer
+  repositories: 128 -> 92 findings", never the list of names. This project is a
+  scanner, so its own measurements read as a finding inventory, and a list of
+  names next to "10 criticals" tells a stranger which specific codebases hold
+  unfixed critical issues, and which of them are private. The counts alone prove
+  exactly the same thing about the rule change, which is the claim actually being
+  made. This applies to a rule comment or test that credits one repository with an
+  attack shape ("the `<name>` pattern") as well: describe the shape, not the
+  codebase it was found in. It applies with full force to PR titles and bodies and
+  to anything reaching a release body, because those are indexed and no later
+  commit can retract them.
+- The `consumer-repo-disclosure` gate in `aahp.config.json` is the backstop, not
+  the control. It matches the cross-repository reference SHAPE and deliberately
+  carries **no list of private repository names**, because that list committed to
+  a public config file would itself be the disclosure it exists to prevent. A
+  consumer named without that prefix will not trip it, so the written rule above
+  is what actually holds.
 - Same rule, same reason as the existing no-AI-attribution rule: both keep
   incidental personal or tooling identity out of a public artefact.
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,85 +3,85 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787300360",
-    "timestamp": "2026-08-21T08:19:20Z",
-    "commit": "e6b1b53",
+    "session_id": "cli-1787337555",
+    "timestamp": "2026-08-21T18:39:15Z",
+    "commit": "fc8fb8f",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:0c82b040342ab1137e7bcb5149e5e24e7f5f9db45714594c3e1a8422c6751960",
-      "updated": "2026-08-21T08:03:28Z",
-      "lines": 2480,
-      "summary": "Model: claude-opus-5. Branch threat-intel/2026-08-21. No version bump."
+      "checksum": "sha256:fbfbc1750b9f99dc8ae6d18c8055279df6e2270b3f3ed0636086747fc9a9acea",
+      "updated": "2026-08-21T18:38:44Z",
+      "lines": 2531,
+      "summary": "Model: claude-opus-5. Branch fix/consumer-name-disclosure. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
-      "updated": "2026-08-21T08:18:28Z",
+      "updated": "2026-08-21T18:31:22Z",
       "lines": 186,
       "summary": "Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:931be02f873b962f89ee315b82902c481d1e8517cb624ad48a61aa43ce10b31a",
-      "updated": "2026-08-21T08:19:20Z",
+      "updated": "2026-08-21T18:39:14Z",
       "lines": 156,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-07-18T08:02:38Z",
+      "updated": "2026-08-21T18:31:22Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-07-18T08:02:38Z",
+      "updated": "2026-08-21T18:31:22Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:739538ae71e404936134c8e4813fa90dbf74b41b23d825b253e1b42e6a1ad755",
-      "updated": "2026-08-21T08:19:20Z",
+      "updated": "2026-08-21T18:39:14Z",
       "lines": 72,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:b69559acbbfa7c11db8f7cb79f4f6d4a99911dad55bbd70d2b0b734d915cadc9",
-      "updated": "2026-08-21T08:19:20Z",
+      "updated": "2026-08-21T18:39:14Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:d6cebc559bb73087cf1ac38e3e09ddd4ebfc933a59c3ec05881d0abfd384440c",
-      "updated": "2026-08-20T12:42:10Z",
+      "updated": "2026-08-21T18:31:22Z",
       "lines": 231,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:60261845b207a16068d9d520b25cd16522b0b52f459fb97e8ad0bf892f10fca1",
-      "updated": "2026-08-20T12:42:10Z",
+      "updated": "2026-08-21T18:31:22Z",
       "lines": 165,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-04T08:54:14Z",
+      "updated": "2026-08-21T18:31:22Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-28T09:06:54Z",
+      "updated": "2026-08-21T18:31:22Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch threat-intel/2026-08-21. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Model: claude-opus-5. Branch fix/consumer-name-disclosure. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 30748,
-    "full_read": 42133
+    "manifest_plus_core": 31231,
+    "full_read": 42616
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,16 +3,16 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787337555",
-    "timestamp": "2026-08-21T18:39:15Z",
-    "commit": "fc8fb8f",
+    "session_id": "cli-1787337826",
+    "timestamp": "2026-08-21T18:43:47Z",
+    "commit": "a6fb7a1",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
       "checksum": "sha256:fbfbc1750b9f99dc8ae6d18c8055279df6e2270b3f3ed0636086747fc9a9acea",
-      "updated": "2026-08-21T18:38:44Z",
+      "updated": "2026-08-21T18:41:01Z",
       "lines": 2531,
       "summary": "Model: claude-opus-5. Branch fix/consumer-name-disclosure. No version bump."
     },
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:931be02f873b962f89ee315b82902c481d1e8517cb624ad48a61aa43ce10b31a",
-      "updated": "2026-08-21T18:39:14Z",
+      "updated": "2026-08-21T18:43:46Z",
       "lines": 156,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,20 +42,20 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:739538ae71e404936134c8e4813fa90dbf74b41b23d825b253e1b42e6a1ad755",
-      "updated": "2026-08-21T18:39:14Z",
+      "updated": "2026-08-21T18:43:46Z",
       "lines": 72,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:b69559acbbfa7c11db8f7cb79f4f6d4a99911dad55bbd70d2b0b734d915cadc9",
-      "updated": "2026-08-21T18:39:14Z",
+      "updated": "2026-08-21T18:43:46Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
-      "checksum": "sha256:d6cebc559bb73087cf1ac38e3e09ddd4ebfc933a59c3ec05881d0abfd384440c",
-      "updated": "2026-08-21T18:31:22Z",
-      "lines": 231,
+      "checksum": "sha256:7812d41d930c2853dad134b4b498b87dd3497af9f2d391d26c6ba60d12ebd13f",
+      "updated": "2026-08-21T18:43:39Z",
+      "lines": 249,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
@@ -81,7 +81,7 @@
   "token_budget": {
     "manifest_only": 85,
     "manifest_plus_core": 31231,
-    "full_read": 42616
+    "full_read": 42893
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,57 @@
 
 ---
 
+## Consumer-name disclosure: removed from files, gated, written down (2026-08-21, unreleased)
+
+Model: claude-opus-5. Branch fix/consumer-name-disclosure. No version bump.
+
+An audit of this public repository for internal disclosure found three
+cross-repository references in tracked files, and one much larger disclosure in a
+merged pull request body.
+
+### What was fixed in files
+
+- `CHANGELOG.md` (entries v5.2.40 and v5.2.41) named a private repository and an
+  internal issue number as the provenance of a security fix. The provenance now
+  reads "the continuous AAHP Swarm review" with no cross-repository reference.
+  `CHANGELOG.md` becomes the GitHub Release body verbatim, so this was on its way
+  to an indexed surface.
+- `src/__tests__/rule-precision.test.ts:168` named a private consumer repository
+  as the source of the PPE attack shape the test asserts. It now describes the
+  shape instead of the codebase it was observed in.
+
+### What now prevents a repeat
+
+A third `forbiddenPatterns` rule, `consumer-repo-disclosure`, in
+`aahp.config.json`. It runs inside `check:aahp`, which `prebuild` runs, which the
+required `Build and Test` check runs, so it fails a pull request rather than
+merely reporting. Coverage was widened past the `ai-attribution` include list to
+`src/__tests__/*.ts`, `examples/*` and `.ai/handoff/*.md`, because a private name
+in a tracked handoff note in a public repository is exactly as exposed as one in
+the CHANGELOG.
+
+The rule deliberately does **not** enumerate private repository names. That list,
+committed to a public config file, would itself be the disclosure it exists to
+prevent. It matches the reference SHAPE only, which is why `CONTRIBUTING.md` now
+carries the actual rule ("benchmark evidence carries counts, never consumer
+names") and the gate is documented as the backstop, not the control.
+
+Proven in both directions: with the fix committed, `check:aahp` reports
+`forbidden-patterns: 3 rule(s), no matches`. Re-injecting the exact removed
+string into `CHANGELOG.md` turns that gate RED and fails the build; restoring it
+returns to green.
+
+### Needs a decision (owner)
+
+**A merged public pull request body names seven private consumer repositories
+next to their security-finding counts.** Editing a merged pull request body is
+the owner's call, not an agent's, so nothing was changed there. The exact
+location and the proposed remediation are in the session report. The standing
+rule that prevents the next one is now in `CONTRIBUTING.md` and in the pull
+request template checklist.
+
+---
+
 ## Threat-intel sweep: 84 advisory IOCs + arrayref dropper (2026-08-21, unreleased)
 
 Model: claude-opus-5. Branch threat-intel/2026-08-21. No version bump.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,3 +33,4 @@ What does this PR do?
 - [ ] New and existing tests pass
 - [ ] `.ai/handoff/STATUS.md` describes this change and `npm run handoff:refresh` has been run (the `aahp-verify` required check enforces it for any code change)
 - [ ] No AI/tool attribution in the commits, the title or this body (see CONTRIBUTING.md). `Build and Test` enforces it for commits and identity, `PR metadata policy` for this title and body.
+- [ ] Any benchmark or measurement evidence above reports **counts and classes only**, not consumer repository names (see CONTRIBUTING.md). This body is public and indexed, and no later commit can retract it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Changed
+
+- **Benchmark evidence in this project's own artefacts now carries counts, never
+  consumer repository names.** Two `CHANGELOG.md` entries (v5.2.40, v5.2.41) cited
+  a private repository and an internal issue number as the provenance of a security
+  fix, and a rule-precision test named a private consumer repository as the source
+  of the PPE attack shape it asserts. All three now describe the class or the shape
+  instead. `CHANGELOG.md` becomes the GitHub Release body verbatim, so these were on
+  their way to a permanently indexed surface. The rule is written down in
+  `CONTRIBUTING.md` and in the pull request template checklist.
+- **New `consumer-repo-disclosure` governance gate** (`aahp.config.json`,
+  `forbiddenPatterns`), run by `check:aahp` inside `prebuild` and therefore by the
+  required `Build and Test` check. It covers the published files, `src/**` including
+  tests, `examples/` and the tracked handoff notes. It matches the cross-repository
+  reference SHAPE and deliberately carries no list of private repository names,
+  because such a list in a public config file would itself be the disclosure it
+  exists to prevent.
+
 ## [5.28.1] - 2026-08-21
 
 ### Added
@@ -2991,7 +3009,7 @@ ecosystem and abused the `codfish/semantic-release-action` GitHub Action.
 ## [5.2.41] - 2026-06-28
 **Security: command injection in the GitHub trust scanner**
 
-Remediates a finding from the continuous AAHP Swarm review (elvatis/ideabase#24).
+Remediates a finding from the continuous AAHP Swarm review.
 `github-trust-scanner.ts` built five `gh api repos/${owner}/${repo}` calls as shell
 strings via `execSync`, with `owner` and `repo` unvalidated. Because
 `analyzeGitHubTrust` and `parseGitHubUrl` are public API, a consumer passing crafted
@@ -3006,7 +3024,7 @@ values could reach shell command execution. No rule or scan-engine change.
 ## [5.2.40] - 2026-06-28
 **Security: org-scanner command injection and suppressed findings in SARIF/SBOM**
 
-Remediates findings from the continuous AAHP Swarm review (elvatis/ideabase#24).
+Remediates findings from the continuous AAHP Swarm review.
 No rule or scan-engine behavior changed.
 
 - `org-scanner.ts`: `listOrgRepos` built `gh repo list ${org}` and ran it through a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,38 @@ Two deliberate carve-outs:
 If a revert or cherry-pick inherits a trailer from an older commit, the check
 skips it: you are not asked to rewrite history you did not author.
 
+### Benchmark evidence carries counts, never consumer names
+
+Measuring a rule change against real repositories is the strongest evidence a
+pull request here can carry, and you are encouraged to do it. Report it as
+**counts and classes only**:
+
+> Measured against the released v5.17.9 binary on **seven consumer
+> repositories**: 128 -> 92 findings, 10 -> 1 criticals.
+
+Never list the repositories by name. This project is a scanner, so its own
+measurements are read as a finding inventory: a list of names next to
+"10 criticals" tells a stranger which specific codebases hold unfixed critical
+issues, and which of them are private. The counts alone prove exactly the same
+thing about the rule change, which is the claim you are actually making.
+
+The same applies to naming one repository as the source of an attack shape
+("the `<name>` pattern") in a rule comment or a test. Describe the shape, not
+the codebase you found it in.
+
+This is not only about files. It applies with **full force to the pull request
+body and title**, and to anything that reaches a release body, because those are
+indexed and a later commit cannot retract them. `CHANGELOG.md` becomes the
+GitHub Release body verbatim.
+
+A `consumer-repo-disclosure` gate in `aahp.config.json` fails the build on the
+`<org>/<repo>` and `<org>-<name>` reference shapes across the published files,
+the source tree and the handoff notes. Read its `message` field before working
+around it: it deliberately does **not** carry a list of private repository
+names, because that list, in a public config file, would itself be the
+disclosure it exists to prevent. A consumer named without that prefix will not
+trip it, so the rule above is the real control and the gate is the backstop.
+
 ### Code Style
 
 - TypeScript strict mode

--- a/aahp.config.json
+++ b/aahp.config.json
@@ -178,6 +178,32 @@
         ".github/PULL_REQUEST_TEMPLATE.md",
         ".github/ISSUE_TEMPLATE/*.md"
       ]
+    },
+    {
+      "id": "consumer-repo-disclosure",
+      "pattern": "elvatis[/-][A-Za-z0-9]",
+      "flags": "gi",
+      "message": "Benchmark and measurement evidence carries COUNTS, never consumer repository names (see CONTRIBUTING.md). This scanner's value proposition guarantees its evidence gets read, so naming the repositories it was measured against publishes which private codebases hold which findings. Write 'seven consumer repositories: 128 -> 92 findings' instead of listing them. Note what this rule deliberately does NOT do: it does not carry a list of private repository names, because that list, in a public config file, would itself be the disclosure. It matches the 'elvatis/<repo>' and 'elvatis-<name>' SHAPES only, so a consumer named without that prefix still depends on review and on the CONTRIBUTING rule. 'elvatis.com' (the maintainer's contact address) and the '@elvatis_com/aahp' npm scope are unaffected: neither is followed by '/' or '-'. If a genuinely public sibling repository ever needs linking from a published file, add it to this rule's exclude list in the same commit, so the decision is reviewed rather than silent.",
+      "include": [
+        "CHANGELOG.md",
+        "README.md",
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+        "CODE_OF_CONDUCT.md",
+        "docs/*.md",
+        "action.yml",
+        "package.json",
+        "server.json",
+        "socket.yml",
+        "policy-schema.json",
+        ".pre-commit-hooks.yaml",
+        "src/*.ts",
+        "src/__tests__/*.ts",
+        "examples/*",
+        ".ai/handoff/*.md",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        ".github/ISSUE_TEMPLATE/*.md"
+      ]
     }
   ],
   "docSync": [

--- a/src/__tests__/rule-precision.test.ts
+++ b/src/__tests__/rule-precision.test.ts
@@ -165,7 +165,7 @@ describe("v5.18 rule precision", () => {
 
   describe("GHA_PPE_PULL_TARGET", () => {
     it("TRUE POSITIVE: PR head sha interpolated into run: on pull_request_target", () => {
-      // The elvatis/atlas pattern - the real PPE this rule exists to catch.
+      // A real-world PPE shape observed in a consumer repo - the attack this rule exists to catch.
       writeWorkflow(tempDir, "ppe.yml", [
         "on: pull_request_target",
         "jobs:",


### PR DESCRIPTION
Docs, config and one test comment. **No version bump, no release, no scanner behaviour change.**

## Why

This repository is public, and it is a scanner. That combination means its own measurements are read as a finding inventory: a list of repository names next to "10 criticals" tells a stranger which specific codebases hold unfixed critical issues, and which of them are private. The counts alone prove exactly the same thing about a rule change, which is the claim actually being made.

An audit for internal disclosure found three cross-repository references in tracked files:

| Where | What it disclosed |
| --- | --- |
| `CHANGELOG.md`, entries v5.2.40 and v5.2.41 | a private repository name plus an internal issue number, cited as the provenance of a security fix |
| `src/__tests__/rule-precision.test.ts:168` | a private consumer repository named as the source of the PPE attack shape the test asserts |

`CHANGELOG.md` becomes the GitHub Release body verbatim (`ci.yml`), so the first two were on their way to a permanently indexed surface that no later commit can retract.

All three now name the class or the shape instead. The provenance line keeps its meaning ("the continuous AAHP Swarm review"), and the test comment still records that the shape is real and observed, just not where.

## The control, and the backstop

The **control** is a written rule, in both places a contributor or an agent actually reads:

- `CONTRIBUTING.md`, a new section next to the no-AI-attribution rule it parallels.
- `.ai/handoff/CONVENTIONS.md`, in the Language section, next to the "do not name the maintainer" rule added in https://github.com/homeofe/supply-chain-guard/pull/146 for the same reason.
- A checklist line in `.github/PULL_REQUEST_TEMPLATE.md`, because this is a PR-body problem at least as much as a file problem.

The **backstop** is a third `forbiddenPatterns` rule, `consumer-repo-disclosure`, in `aahp.config.json`. It runs inside `check:aahp`, which `prebuild` runs, which the required `Build and Test` check runs, so it fails a pull request rather than merely reporting.

Coverage is deliberately wider than the `ai-attribution` include list: `src/__tests__/*.ts`, `examples/*` and `.ai/handoff/*.md` are in scope, because a private name in a tracked handoff note in a public repository is exactly as exposed as one in the CHANGELOG. That is also where one of the three findings actually lived.

### What the gate deliberately does not do

It carries **no list of private repository names**. That list, committed to a public config file, would itself be the disclosure it exists to prevent. It matches the cross-repository reference *shape* only, which is why the written rule is documented as the control and the gate as the backstop: a consumer named without that prefix will not trip it and still depends on review.

The maintainer's contact address and the published npm scope are unaffected: neither is followed by `/` or `-`. Both are asserted as negative cases below.

## Proof the gate can actually fail

A gate that reports CLEAN because it cannot fire is worse than no gate, so this was checked in both directions against the real `npm run check:aahp`, not against the regex in isolation.

**Mutation proof.** With the fix committed first, each removed disclosure was re-injected one file at a time, each injection guarded by an assertion that the substitution actually changed the file on disk:

| Mutation | Gate |
| --- | --- |
| baseline, clean tree | exit 0, `forbidden-patterns: 3 rule(s), no matches` |
| re-inject the reference into `CHANGELOG.md` | exit 1, `Governance FAILED: forbidden-patterns` |
| re-inject the reference into `rule-precision.test.ts` | exit 1, `Governance FAILED` |
| inject a reference into `.ai/handoff/STATUS.md` | exit 1, `Governance FAILED` |
| each one restored | exit 0, back to green |

**Attribution proof.** "The build went red" is not the same as "this rule fired", so the two variables were crossed. Only the bottom-right cell may be red:

| | rule absent | rule present |
| --- | --- | --- |
| **no disclosure** | exit 0, 2 rules | exit 0, 3 rules |
| **disclosure present** | **exit 0, 2 rules** | **exit 1, FAILED** |

The bottom-left cell is the pre-merge world: with the disclosure present and this rule absent, governance passes. That is what let the reference sit in `CHANGELOG.md` through 139 releases, and it is the cell that makes the new rule load-bearing rather than decorative.

The regex is also asserted directly in both directions: it matches the two reference shapes including a full URL form and an uppercase spelling, and stays silent on the maintainer contact address, the published npm scope, and the bare organisation name.

## Verification

- `npm run check:aahp`: 7 gates, no failures, `forbidden-patterns: 3 rule(s), no matches`. The new rule is counted, so it is loaded and evaluated rather than silently skipped.
- `npm run check:feed`, `npm run check:handoff`: green. `npm run handoff:refresh` has been run and `MANIFEST.json` committed.
- `npx tsc --noEmit`: clean.
- `npx vitest run src/__tests__/rule-precision.test.ts`: 35/35 pass.
- Full suite on this Windows box: 2853 passed. The failures are all pre-existing or environmental and were each checked against a pristine `origin/main` worktree before being dismissed:
  - 14 `vscode-scanner` tests that shell out to `zip`, absent here and documented in CONTRIBUTING.md.
  - 2 `campaigns` tests that fail **identically on pristine `main`**.
  - 2 load-sensitive tests that **pass in isolation** on this branch: one asserts a 15000 ms wall-clock performance budget and measured 15877 ms under full-suite parallel load, the other hit a 5000 ms per-test timeout. No scanner runtime code is touched by this PR.
- Linux CI is the authoritative verdict, as usual.

## Acceptance criteria

- [x] No cross-repository reference remains in any tracked file (`git grep` returns nothing for both reference shapes).
- [x] The rule is written down where contributors read it (`CONTRIBUTING.md`) and where agents read it (`.ai/handoff/CONVENTIONS.md`), plus the PR template checklist.
- [x] A required check fails on a re-introduced disclosure, proven by mutation against the real gate.
- [x] The failure is attributable to this specific rule, proven by the 2x2 above.
- [x] The gate does not itself publish the list of names it protects.
- [x] The maintainer's identity and contact fields are untouched, per the decision recorded in https://github.com/homeofe/supply-chain-guard/pull/146.
- [x] No version bump; `## [Unreleased]` carries the entry.

## Reported separately, not changed here

A **merged** pull request body in this repository names seven private consumer repositories together with their security-finding counts. Editing a merged PR body is the owner's call, not an agent's, so nothing was touched there and this body deliberately does not repeat the names. It is written up for the owner with the exact location and the proposed remediation, and the standing rule that prevents the next one is what this PR lands.

Merging is left to the owner; CI passing is a precondition.
