### PR TITLE
fix(docs): the update path we publish is the one that measurably froze a pin

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.28.1 |
 | Node engines | >=22.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 116 under `src/__tests__/` |
+| Test files | 117 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787337826",
-    "timestamp": "2026-08-21T18:43:47Z",
-    "commit": "a6fb7a1",
+    "session_id": "cli-1787345045",
+    "timestamp": "2026-08-21T20:44:05Z",
+    "commit": "4fea8a1",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
       "checksum": "sha256:fbfbc1750b9f99dc8ae6d18c8055279df6e2270b3f3ed0636086747fc9a9acea",
-      "updated": "2026-08-21T18:41:01Z",
+      "updated": "2026-08-21T20:30:00Z",
       "lines": 2531,
       "summary": "Model: claude-opus-5. Branch fix/consumer-name-disclosure. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
-      "updated": "2026-08-21T18:31:22Z",
+      "updated": "2026-08-21T20:30:00Z",
       "lines": 186,
       "summary": "Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:931be02f873b962f89ee315b82902c481d1e8517cb624ad48a61aa43ce10b31a",
-      "updated": "2026-08-21T18:43:46Z",
+      "updated": "2026-08-21T20:44:05Z",
       "lines": 156,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-08-21T18:31:22Z",
+      "updated": "2026-08-21T20:30:00Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-08-21T18:31:22Z",
+      "updated": "2026-08-21T20:30:00Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:739538ae71e404936134c8e4813fa90dbf74b41b23d825b253e1b42e6a1ad755",
-      "updated": "2026-08-21T18:43:46Z",
+      "checksum": "sha256:3d096bfdf360b08a51e239104beb78fc586cfd0971ad440762006e5711adc86f",
+      "updated": "2026-08-21T20:44:05Z",
       "lines": 72,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:b69559acbbfa7c11db8f7cb79f4f6d4a99911dad55bbd70d2b0b734d915cadc9",
-      "updated": "2026-08-21T18:43:46Z",
+      "checksum": "sha256:b74e6fb5cd4460e863953ef351f211e42f792bb776dcb9d20b68acec8d9569d5",
+      "updated": "2026-08-21T20:44:05Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:7812d41d930c2853dad134b4b498b87dd3497af9f2d391d26c6ba60d12ebd13f",
-      "updated": "2026-08-21T18:43:39Z",
+      "updated": "2026-08-21T20:30:00Z",
       "lines": 249,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:60261845b207a16068d9d520b25cd16522b0b52f459fb97e8ad0bf892f10fca1",
-      "updated": "2026-08-21T18:31:22Z",
+      "updated": "2026-08-21T20:30:00Z",
       "lines": 165,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-21T18:31:22Z",
+      "updated": "2026-08-21T20:30:00Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-21T18:31:22Z",
+      "updated": "2026-08-21T20:30:00Z",
       "lines": 4,
       "summary": "{"
     }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,18 +3,18 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787345045",
-    "timestamp": "2026-08-21T20:44:05Z",
-    "commit": "4fea8a1",
+    "session_id": "cli-1787345387",
+    "timestamp": "2026-08-21T20:49:48Z",
+    "commit": "095b3df",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:fbfbc1750b9f99dc8ae6d18c8055279df6e2270b3f3ed0636086747fc9a9acea",
-      "updated": "2026-08-21T20:30:00Z",
-      "lines": 2531,
-      "summary": "Model: claude-opus-5. Branch fix/consumer-name-disclosure. No version bump."
+      "checksum": "sha256:c43f57a446d16ced477849ff5bbeb53b517aa0adfcb317d2c550672a5d7e64fe",
+      "updated": "2026-08-21T20:49:39Z",
+      "lines": 2609,
+      "summary": "Model: claude-opus-5. Branch fix/consumer-update-cadence. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:931be02f873b962f89ee315b82902c481d1e8517cb624ad48a61aa43ce10b31a",
-      "updated": "2026-08-21T20:44:05Z",
+      "updated": "2026-08-21T20:49:47Z",
       "lines": 156,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:3d096bfdf360b08a51e239104beb78fc586cfd0971ad440762006e5711adc86f",
-      "updated": "2026-08-21T20:44:05Z",
+      "updated": "2026-08-21T20:49:47Z",
       "lines": 72,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:b74e6fb5cd4460e863953ef351f211e42f792bb776dcb9d20b68acec8d9569d5",
-      "updated": "2026-08-21T20:44:05Z",
+      "updated": "2026-08-21T20:49:47Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch fix/consumer-name-disclosure. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Model: claude-opus-5. Branch fix/consumer-update-cadence. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 31231,
-    "full_read": 42893
+    "manifest_plus_core": 32122,
+    "full_read": 43784
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,84 @@
 
 ---
 
+## The published update path was the one that froze a pin (2026-08-21, unreleased)
+
+Model: claude-opus-5. Branch fix/consumer-update-cadence. No version bump.
+
+Two questions were asked of this repository: whether the consumer-name fix
+actually reached the PUBLISHED surface, and what this project's release cadence
+and consumer-update path really are when measured rather than assumed.
+
+### The disclosure fix did reach the published surface, because it never left it
+
+`CHANGELOG.md` becomes the GitHub Release body verbatim, so the v5.2.40 and
+v5.2.41 entries looked like they were already published. They were not. Both
+release bodies were created before the changelog moved out of `README.md`, so
+`ci.yml` found no matching section and fell back to its stub, "See README.md for
+full changelog". All 44 releases of that era carry the same stub. The anchor they
+point at still resolves, and the file behind it is the corrected one.
+
+All 134 published release bodies were fetched and scanned for the reference
+shape. Zero hits. The 16 raw matches were all deliberate publications: Kubernetes
+and k3s default service CIDRs that are the scanner's own detection corpus in
+`src/internal-disclosure.ts`, and a public agent-runtime product name this
+project ships a scanner for. `CHANGELOG.md` is also not in the npm `files` list,
+so the tarball never carried it either.
+
+**The remaining exposure is the pull request body surface, and it is larger than
+the changelog was.** It was not touched: editing a merged body is the owner's
+call. Details are in the section below and in the session report.
+
+### The cadence, measured
+
+134 releases in the 155 days to 2026-08-21. 1.40 per day over the last 60 days.
+Median gap 19.8 hours, two thirds of gaps under a day, 51 percent of calendar
+days ship, 93 patch / 36 minor / 4 major.
+
+The README told consumers to pin an exact version and let Dependabot follow it on
+a `weekly` schedule. At 1.4 releases a day that recipe cannot converge: each
+weekly run opens a correct bump pull request and the next weekly run closes it as
+superseded. Measured in one consumer of this Action, counts only: eight
+consecutive weekly bump pull requests, each alive exactly seven days, each
+proposing a newer target, while the pin sat unchanged for 49 days and fell 82
+releases behind, with a green scan check every day.
+
+So the answer to "can consumers practically follow releases" is no, not with the
+configuration this project published, and that is a finding about this package
+rather than about the consumer.
+
+### What changed
+
+`README.md` now recommends `daily` with the measured rate stated as the reason,
+and says plainly that the interval is the cheap half while merging the pull
+request is the half that decides the outcome.
+
+It also drops a claim it should not have made. It said an exact pin "turns that
+into a visible out-of-date dependency". It does not. `scan` runs offline against
+the IOC feed bundled with the pinned version, so a pin that stops moving freezes
+the detection rules at that date, and no exit code, risk score or check name
+reports it. A frozen rule set is a silent false-negative generator, which is the
+same failure the surrounding paragraph warns about for the floating major ref.
+An exact pin buys a PLACE where staleness is reviewable, the bump pull request,
+which is a weaker and different claim.
+
+`src/__tests__/consumer-update-path-contract.test.ts` holds both halves, asserts
+the positive and negative directions separately, guards them with a
+snippet-exists check so a deleted snippet cannot pass vacuously, and re-asserts
+the counts-not-names rule over its own text. Mutation proof after committing the
+fix: reverting the interval fails 2 of 5, reverting the claim fails 1 of 5,
+restoring passes 5 of 5 with a clean tree.
+
+### Known limitation of this change
+
+Nothing here makes a stale pin visible to the consumer at scan time. The IOC feed
+is compiled into `src/threat-intel.ts` with per-indicator `firstSeen` dates but
+no feed-level generation date, so the scanner cannot currently report the age of
+the rules it just ran. Documenting the gap is not closing it. See the session
+report for the proposal.
+
+---
+
 ## Consumer-name disclosure: removed from files, gated, written down (2026-08-21, unreleased)
 
 Model: claude-opus-5. Branch fix/consumer-name-disclosure. No version bump.

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.28.1 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 116 | src/__tests__/ file list |
+| Test files present | 117 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
   reference SHAPE and deliberately carries no list of private repository names,
   because such a list in a public config file would itself be the disclosure it
   exists to prevent.
+- **The README now recommends a `daily` Dependabot interval instead of `weekly`,
+  measured against this project's own release rate.** 134 releases in the 155 days
+  to 2026-08-21, about 1.4 a day over the last two months, a median of 20 hours
+  between releases. A weekly schedule cannot track that: each run opens a correct
+  bump pull request and the next run closes it as superseded, so an unattended pin
+  never moves. Measured in one consumer of this Action: eight consecutive weekly
+  bump pull requests, each alive exactly seven days, each proposing a newer target,
+  while the pin sat unchanged for 49 days and fell 82 releases behind with a green
+  scan check every day.
+- **Corrected the README's claim that an exact pin makes staleness visible.** It
+  does not. `scan` runs offline against the IOC feed bundled with the pinned
+  version, so a pin that stops moving freezes the detection rules at that date,
+  and no exit code, risk score or check name reports it. An exact pin creates a
+  place where staleness becomes reviewable, the bump pull request, which is a
+  weaker and different claim than staleness being self-announcing. The README now
+  states the distinction and what it costs when those pull requests are never
+  merged.
 
 ## [5.28.1] - 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -687,8 +687,23 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
 ```
+
+**`daily`, not `weekly`, and this project's release rate is why.** Measured over
+the 155 days to 2026-08-21: 134 releases, about 1.4 a day over the last two
+months, with a median of 20 hours between releases and two thirds of the gaps
+under a day. A weekly schedule cannot track that. Each weekly run opens a correct
+bump pull request, and the next weekly run closes it as superseded and opens
+another, so an unattended pin never moves at all. Measured in one consumer of
+this Action: eight consecutive weekly bump pull requests, each alive for exactly
+seven days, each proposing a newer target than the last, while the pin itself sat
+unchanged for 49 days and fell 82 releases behind. Every scan check was green
+throughout, because a stale pin is not a failing scan.
+
+The interval is the cheap half. The half that actually decides the outcome is
+whether somebody merges the pull request, and no setting in this file supplies
+that.
 
 ### `@v5`, and what it does and does not guarantee
 
@@ -701,7 +716,19 @@ The caveat is what happens after a major. If the v5 line stops being released on
 v6 ships, `@v5` keeps resolving a frozen action that pins an old npm version, and
 the IOC feed it installs stops updating. For a scanner that is a silent
 false-negative generator, and nothing in your workflow would report it. An exact
-pin turns that into a visible out-of-date dependency instead.
+pin is what turns that into a reviewable out-of-date dependency instead.
+
+**Be precise about what an exact pin does and does not buy you, because a frozen
+exact pin is the same silent false negative.** It ages exactly as quietly. This
+scanner runs offline against the IOC feed bundled with the pinned version, so a
+pin that stops moving freezes the detection rules at that date, and neither the
+exit code, the risk score nor the check name changes to say so. The scan output
+carries no age for the feed it just used. What an exact pin buys is a *place*
+where the staleness becomes reviewable: the bump pull request. That is a
+different claim from the staleness being visible on its own, and the measurement
+above is what the difference costs. If those pull requests are opened and
+superseded without ever being merged, the pin is frozen, the rule set is ageing,
+and nothing in this tool will tell you.
 
 ### Action Inputs
 

--- a/src/__tests__/consumer-update-path-contract.test.ts
+++ b/src/__tests__/consumer-update-path-contract.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The consumer update path published in the README is a contract, not prose.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * This project releases roughly 1.4 times a day: 134 releases in the 155 days to
+ * 2026-08-21, a median of 20 hours between them, two thirds of the gaps under a
+ * day. The README tells consumers to pin an exact version and let Dependabot keep
+ * the pin current, so the interval in that published snippet decides whether the
+ * advice works at all.
+ *
+ * It recommended `weekly`, and `weekly` cannot track this cadence. Each weekly run
+ * opens a correct bump pull request; the next weekly run closes it as superseded
+ * and opens another. Measured in one consumer of this Action: eight consecutive
+ * weekly bump pull requests, each alive for exactly seven days, each proposing a
+ * newer target than the last, while the pin itself sat unchanged for 49 days and
+ * fell 82 releases behind. Every scan check was green throughout, because a stale
+ * pin is not a failing scan. The README was publishing the recipe that produced
+ * that outcome.
+ *
+ * WHY A TEST AND NOT JUST THE EDIT
+ * --------------------------------
+ * A documentation fix has nothing behind it. The next person to touch the snippet
+ * has no way to know the interval was chosen against a measurement rather than
+ * typed out of habit, and `weekly` is the habitual value. This test is the thing
+ * that makes the choice survive.
+ *
+ * NOTE ON SCOPE: this asserts the PUBLISHED RECOMMENDATION only. It cannot assert
+ * that any consumer merges the pull requests, and that, not the interval, is what
+ * finally decides whether a pin moves. See the README section for the distinction.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const read = (rel: string) => fs.readFileSync(path.join(REPO, rel), "utf-8");
+
+/**
+ * Prose in this README is hard-wrapped and the file is checked out with CRLF on
+ * Windows, so a sentence-level assertion written as one line matches neither.
+ * Collapsing every whitespace run to a single space makes the assertions depend
+ * on the words rather than on the wrap column or the checkout's line endings.
+ */
+const flat = (s: string) => s.replace(/\s+/g, " ");
+
+/**
+ * Extract the `.github/dependabot.yml` snippet the README publishes for
+ * consumers. Returning null rather than throwing lets the "snippet exists at all"
+ * assertion fail with its own message instead of an unrelated parse error.
+ * `\r?\n` because the fence terminator differs by checkout line endings.
+ */
+function consumerDependabotSnippet(readme: string): string | null {
+  const fences = readme.match(/```yaml\r?\n[\s\S]*?```/g) ?? [];
+  for (const fence of fences) {
+    if (fence.includes(".github/dependabot.yml")) return fence;
+  }
+  return null;
+}
+
+describe("README consumer update path", () => {
+  const readme = read("README.md");
+
+  it("still publishes a Dependabot snippet for consumers", () => {
+    // Guards every assertion below: a deleted snippet must fail loudly rather
+    // than let the interval checks pass vacuously on an empty string.
+    expect(consumerDependabotSnippet(readme)).not.toBeNull();
+  });
+
+  it("recommends a daily interval, because the release cadence is ~1.4/day", () => {
+    const snippet = consumerDependabotSnippet(readme)!;
+    expect(snippet).toMatch(/interval:\s*["']?daily["']?/);
+  });
+
+  it("does NOT recommend weekly, the interval that measurably froze a pin", () => {
+    const snippet = consumerDependabotSnippet(readme)!;
+    // The negative direction is the one that actually regressed, so it is
+    // asserted separately rather than inferred from the positive match.
+    expect(snippet).not.toMatch(/interval:\s*["']?weekly["']?/);
+  });
+
+  it("does not claim a stale exact pin announces itself", () => {
+    // The scanner runs offline against the IOC feed bundled with the pinned
+    // version. Nothing in the exit code, risk score or check name reports the
+    // pin's age, so the README must not promise that it does.
+    expect(flat(readme)).toMatch(
+      /exact pin is what turns that into a reviewable out-of-date dependency/,
+    );
+    expect(flat(readme)).not.toMatch(
+      /exact pin turns that into a visible out-of-date dependency/,
+    );
+  });
+
+  it("names no consumer repository while citing the measurement", () => {
+    // Same rule as the consumer-repo-disclosure gate: counts, never names.
+    // Asserted here too because this test's own docblock cites the measurement.
+    const self = read("src/__tests__/consumer-update-path-contract.test.ts");
+    for (const text of [readme, self]) {
+      expect(text).not.toMatch(/elvatis[/-][A-Za-z0-9]/);
+    }
+  });
+});


### PR DESCRIPTION
## What this changes

The README tells consumers to pin an exact version and let Dependabot keep the
pin current on a `weekly` schedule. Measured against this project's own release
rate, `weekly` cannot track it, so the recipe we publish is the recipe that
freezes a pin.

**Measured cadence** (GitHub Releases API, all 134 releases, the 155 days to
2026-08-21):

| Measure | Value |
|---|---|
| Releases | 134 in 155 days |
| Rate, last 60 days | 84 releases, 1.40 per day |
| Median gap between releases | 19.8 hours |
| Gaps under 24 hours | 88 of 133 (66 percent) |
| Calendar days that shipped | 79 of 156 (51 percent) |
| Bump kinds | 93 patch, 36 minor, 4 major |

**Measured consequence** in one consumer of this Action (counts only, no
repository named, per the rule added in
[#164](https://github.com/homeofe/supply-chain-guard/pull/164)): eight
consecutive weekly bump pull requests, each alive for exactly seven days, each
proposing a newer target than the last, while the pin itself sat unchanged for
49 days and fell **82 releases** behind. Every scan check was green throughout,
because a stale pin is not a failing scan. That is the documented recipe
executing exactly as written.

## The second half: a claim this README should not have been making

The README said an exact pin "turns that into a visible out-of-date dependency".
It does not, and for a scanner the difference matters more than usual. `scan`
runs offline against the IOC feed bundled with the pinned version, so a pin that
stops moving freezes the detection rules at that date, and no exit code, risk
score or check name reports it. A frozen rule set is a silent false-negative
generator, which is the exact failure mode the surrounding paragraph warns about
for `@v5`.

What an exact pin actually buys is a *place* where the staleness becomes
reviewable, the bump pull request. That is a weaker and different claim than
staleness announcing itself, and the measurement above is what the difference
costs when those pull requests are opened and superseded without ever being
merged. The README now states the distinction instead of implying the
configuration is sufficient.

## Why a test and not just the edit

A documentation fix has nothing behind it, and `weekly` is the habitual value
that any later edit would drift back to.
`src/__tests__/consumer-update-path-contract.test.ts` holds the recommendation:
it asserts the positive and the negative direction **separately** rather than
inferring one from the other, guards both with a snippet-exists assertion so a
deleted snippet cannot pass vacuously, and re-asserts the counts-not-names
disclosure rule over its own text, since its docblock cites a consumer
measurement.

Mutation proof, run after committing the fix so the proof could not destroy it,
each substitution guarded by an assertion that it changed the file and left the
CRLF count intact:

| Mutation | Result |
|---|---|
| `interval: daily` reverted to `weekly` | 2 of 5 tests fail |
| "reviewable out-of-date dependency" reverted to "visible" | 1 of 5 tests fail |
| Baseline restored | 5 of 5 pass, working tree clean |

## Acceptance criteria

- [x] The consumer Dependabot snippet in `README.md` recommends `daily`, with the
      measured release rate stated next to it as the reason.
- [x] The README no longer claims an exact pin makes staleness visible, and states
      what it does buy instead.
- [x] The README states that the interval is the cheap half and that whether
      anyone merges the pull request is what decides the outcome.
- [x] A contract test asserts both directions separately and cannot pass
      vacuously against a deleted snippet.
- [x] Mutation proof: reverting either half of the fix turns the new test red;
      restoring it turns it green again.
- [x] `npm run prebuild` passes (all 7 governance gates, feed check, handoff
      check), and `npx tsc --noEmit` is clean.
- [x] No consumer repository is named anywhere in the change, including in the
      test docblock and this pull request body.
- [x] Generated handoff docs regenerated with `npm run handoff:refresh` rather
      than hand-edited.

## Validation

Run locally on Windows: `npm run prebuild` exits 0 with all seven governance
gates passing, `npx tsc --noEmit` is clean, and the new suite file passes 5 of 5.
Per this project's local-testing rule only the single affected suite file was run
here; the full suite verdict is CI's. `check:handoff` was verified to fail on this
branch and pass on unmodified `main` before being fixed, so the staleness was
mine and not the environment.

Green CI on this pull request is a precondition for merging it, not a summary of
what was already checked. Please do not merge until the required checks have
concluded on this head commit.

## Note for the reviewer

`.ai/handoff/MANIFEST.json` is regenerated here and is also touched by
[#165](https://github.com/homeofe/supply-chain-guard/pull/165). If both land,
resolve that file by regenerating it with `npm run handoff:refresh` after the
merge rather than by picking one side, since it is a generated artefact.
