### PR TITLE
feat(threat-intel): IOCs for 2026-08-22

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,10 +11,10 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1b0b50a17bc818e59d1773fea20c421633d2e6ea1de520f92f33a0d259a17b6e",
+      "checksum": "sha256:15bd1c2dfbd8e54f2d1907d9c7fc265d87152b0b93b0ec27fb015e815c4228ab",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2727,
-      "summary": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump."
+      "lines": 2791,
+      "summary": "Model: claude-opus-5. Branch threat-intel/2026-08-22. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Model: claude-opus-5. Branch threat-intel/2026-08-22. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 32959,
-    "full_read": 44621
+    "manifest_plus_core": 34210,
+    "full_read": 45872
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,70 @@
 
 ---
 
+## Threat-intel sweep 2026-08-22: a 4,363-entry backfill answered with one rule (unreleased)
+
+Model: claude-opus-5. Branch threat-intel/2026-08-22. No version bump.
+
+The scheduled import proposed 4,409 new IOCs and refused to exit clean: at the
+default `--limit 250`, 2,659 of the remainder would age out of the `--days 14`
+window before any later run could reach them.
+
+### What the backlog actually was
+
+4,363 of the 4,409 were a single publisher's namespace, `@zalastax/nolb-*`,
+backfilled into the GitHub Advisory Database on 2026-08-14 from
+ossf/malicious-packages. All are all-versions ranges on names published in
+Jan/Feb 2023. The real signal in the window was the other 46.
+
+Two registry checks decided the response, and the first one was misleading on its
+own. A liveness check said the packages exist, are not unpublished, and predate
+the advisory by three years, which reads as a live gap. Reading the version
+contents corrected it: they are npm SECURITY HOLDING PACKAGES. Of a 14-name
+spread sample, 12 carry only a `0.0.1-security` placeholder and 2 still have
+their original 2023 version alongside it. So the payload is largely gone and the
+names have no legitimate release history, which is what makes a bare-name rule
+safe here, the same reasoning the SANDWORM_MODE set already uses.
+
+Taken as feed entries, they would have grown the bundled feed 34% (12,962 to
+17,325) and added roughly 1 MB to `feed.json`, shipped to every consumer, for one
+publisher's taken-down 2023 squats. They are covered by one anchored pattern in
+`MALICIOUS_PACKAGE_PATTERNS` instead, and the 46 real entries were imported
+normally through the project's own writer.
+
+### Needs a decision
+
+**`MALICIOUS_PACKAGE_PATTERNS` does not reach the generic directory scan.** It is
+read by the npm-scanner name check and its `package.json` fallback. The directory
+scan in `scanner.ts` matches exact feed names only, deliberately, because the
+pattern table holds broad rules such as `^[a-z]{20,}$` that would produce false
+positives there. That is the surface the GitHub Action runs, so a
+pattern-only campaign is invisible to it.
+
+Taken-down names make the residual gap small in this case, but the general
+question is open and it is not this job's call to settle: should the directory
+scan consult a NARROW subset of the pattern table, or should any campaign that
+matters on that surface always be paid for in feed entries? Today's answer was
+the pattern, on the grounds that the names are dead. A live campaign of this
+shape would need the other answer, and there is currently nothing that forces
+that choice to be made deliberately.
+
+Second, smaller: the importer has no way to exclude a namespace, so every future
+run will re-propose these 4,363 and refuse to exit clean until they age out
+around 2026-08-28. Runs in that window need `--allow-backlog` or a namespace
+filter in `scripts/import-threat-feed.mjs`.
+
+### Enrichment (STEP 1b) found nothing addable
+
+Socket, Aikido, StepSecurity, safedep, OX Security and The Hacker News were all
+checked for write-ups newer than the v5.28.1 sweep. Every atomic indicator they
+publish is already in the blocklist: the keyv/cacheable Shai-Hulud domains and
+both payload hashes, the arrayref build-time dropper, WEL1DROPPER, the Alibaba
+RAT cluster, Joyfill and the fake Corepack site. The one genuinely new cluster,
+`@postman-cse`, had its advisory published 2026-08-22 00:44 UTC and has no vendor
+write-up yet, so there were no atomic indicators to add beyond the version pins.
+
+---
+
 ## The required handoff gate compared main to itself on every push (2026-08-22, unreleased)
 
 Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Added
+
+- **Threat feed: 46 package IOCs imported from the GitHub Advisory Database**
+  (2026-08-08 to 2026-08-22), covering 41 npm and 5 PyPI indicators. The largest
+  cluster is `@postman-cse/okta-aio-linux-arm64`, 21 versions of a
+  dependency-confusion package aimed at an internal Postman scope, now an npm
+  security holding package. Also `@gfe/lx-watcher` (2 versions), the PyPI
+  typosquats `boto4`, `scrambleeer` and `requests-crypt`, and a set of
+  all-versions npm names including `kelly-sizing`,
+  `polymarket-trading-developer-tool` and `saas-f-testing`. Scanner tests cover
+  the npm version pin, the PyPI ecosystem routing and the clean neighbouring
+  versions as negative cases.
+- **`@zalastax/nolb-*` name-reservation flood: one anchored rule instead of 4,363
+  feed entries.** OpenSSF malicious-packages classified a single publisher's bulk
+  namespace-squat as CWE-506 and the GitHub Advisory Database backfilled it on
+  2026-08-14, which put 4,363 advisories into one import window, all of them
+  all-versions ranges on `@zalastax/nolb-<suffix>` names published in Jan/Feb 2023.
+  Registry checks on 2026-08-22 found these are npm security holding packages:
+  12 of a 14-name spread sample carry only a `0.0.1-security` placeholder and 2
+  still have their original 2023 version. Taking them as feed entries would have
+  grown the bundled feed 34% (12,962 to 17,325) and added about 1 MB to
+  `feed.json` for one publisher's taken-down squats, so they are covered by a
+  single anchored pattern instead. Every advisory in the scope carries the
+  `nolb-` prefix (1,000 of 1,000 sampled) and the rule is anchored to it, so a
+  non-`nolb` package in the same scope does not match.
+
 ### Changed
 
 - **Benchmark evidence in this project's own artefacts now carries counts, never

--- a/feed.json
+++ b/feed.json
@@ -2,7 +2,7 @@
   "schema": 1,
   "package": "supply-chain-guard",
   "version": "5.28.1",
-  "entryCount": 12962,
+  "entryCount": 13008,
   "entries": [
     {
       "type": "domain",
@@ -104915,6 +104915,374 @@
       "campaign": "arrayref Build-Time Dropper",
       "source": "StepSecurity, Wiz",
       "firstSeen": "2026-08-20"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.8.10",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.8.11",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.9.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.9.1",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.1",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.2",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.3",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.4",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.5",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.6",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.7",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.8",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.10.9",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.11.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.11.1",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.11.2",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.11.3",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.11.6",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.11.5",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "@postman-cse/okta-aio-linux-arm64@0.11.4",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-h84r-259m-g3fg, MAL-2026-14357",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "lumen-pages-community@9.9.9",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-cf4g-g969-7qvx, MAL-2026-14356",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "fuel-react@91.0.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-77vr-cf3r-2v4w, MAL-2026-14355",
+      "firstSeen": "2026-08-22"
+    },
+    {
+      "type": "package",
+      "value": "polymarket-trading-developer-tool",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-qh4r-g8mr-v3xp, MAL-2026-6714",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "kelly-sizing",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-vj74-3pcr-5p7j, MAL-2026-14354",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "@gfe/lx-watcher@1.5.3",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-7jmf-xqv3-ggfj, MAL-2026-14353",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "@gfe/lx-watcher@1.5.4",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-7jmf-xqv3-ggfj, MAL-2026-14353",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "saas-f-testing",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-fvrj-4h6r-8rcg, MAL-2026-12434",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "pypi:scrambleeer@0.1.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-jx7v-9c55-jw2v, MAL-2026-14350",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "pypi:scrambleeer@0.1.1",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-jx7v-9c55-jw2v, MAL-2026-14350",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "pypi:requests-crypt@0.1.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-cf52-hr54-m53p, MAL-2026-14351",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "rollup-packages-node-polyfills",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-gp6f-mxh4-x3mh, MAL-2026-12428",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "pino-deploy",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-9hw3-p3rx-59cw, MAL-2024-2871",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "express-bunker",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-w7r5-8cmj-m893, MAL-2026-10500",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "react-native-ui-message",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-w3j6-3pww-qfcw, MAL-2026-12424",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "react-hook-use-debounce-throttle-12",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-2x4w-64xc-78fv, MAL-2026-5909",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "utils-common-helpers",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-fq4g-5xjj-r935, MAL-2026-5911",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "react-fontawesome-icons",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-xvfg-jp9r-63q2, MAL-2026-12423",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "qr-code-styling-temp",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-pp2c-4x5r-7h8j, MAL-2026-4655",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "pvm-autodoc",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-9352-468r-x8fr, MAL-2026-12421",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "postcss-animate-css-vars",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-432g-6qr7-8hvh, MAL-2026-12418",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "tailwind-animate-css-plugin",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-5w98-j73p-rv7m, MAL-2026-14352",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "polymarket-bot-logger",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-v4pc-gmg8-h48w, MAL-2026-10516",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "polygon-toolkit-validator",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-67fh-9pjj-6cpw, MAL-2026-10641",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "pypi:boto4@1.0.0",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-ffh8-mpww-qp8g, MAL-2026-14349",
+      "firstSeen": "2026-08-21"
+    },
+    {
+      "type": "package",
+      "value": "pypi:boto4@1.0.2",
+      "severity": "critical",
+      "confidence": 1,
+      "source": "GHSA-ffh8-mpww-qp8g, MAL-2026-14349",
+      "firstSeen": "2026-08-21"
     }
   ]
 }

--- a/src/__tests__/campaigns.test.ts
+++ b/src/__tests__/campaigns.test.ts
@@ -4978,4 +4978,115 @@ describe("Campaign Signatures", () => {
     });
   });
 
+  // =================================================================
+  // @zalastax/nolb-* name-reservation flood (August 2026)
+  // =================================================================
+
+  describe("@zalastax/nolb-* name-reservation flood (August 2026)", () => {
+    // 4,363 advisories backfilled by GHSA on 2026-08-14 from
+    // ossf/malicious-packages, every one an all-versions range on a
+    // @zalastax/nolb-<suffix> name. Covered by ONE anchored pattern rather than
+    // 4,363 feed entries: the names are npm security holding packages (taken
+    // down, registry-verified 2026-08-22), so a bare-name rule carries no
+    // false-positive surface, and 4,363 entries would be a 34% feed growth.
+    //
+    // SURFACE THIS COVERS: the npm-scanner name check (MALICIOUS_PACKAGE_NAME)
+    // and its package.json fallback, both of which consult
+    // MALICIOUS_PACKAGE_PATTERNS. It does NOT cover the generic directory scan
+    // in scanner.ts, which matches the feed's exact names only, by design (see
+    // the comment at scanner.ts checkPackageJsonDependencies). Asserted here at
+    // the pattern level because both npm-scanner call sites sit behind a live
+    // registry fetch and neither containing function is exported.
+    const FLAGGED = [
+      "@zalastax/nolb-react-ur",
+      "@zalastax/nolb-graphqlm",
+      "@zalastax/nolb-_co_",
+      "@zalastax/nolb-bit6",
+    ];
+
+    it("matches every flagged nolb- name", () => {
+      for (const name of FLAGGED) {
+        const hit = MALICIOUS_PACKAGE_PATTERNS.some((p) => new RegExp(p).test(name));
+        expect(hit, name).toBe(true);
+      }
+    });
+
+    it("does NOT reach past the nolb- prefix or into other scopes", () => {
+      const legit = [
+        "@zalastax/some-real-package", // same scope, not the squat prefix
+        "nolb-react-ur", // unscoped lookalike
+        "@other/nolb-react-ur", // different scope
+        "@zalastax/nolb", // prefix without a suffix
+        "react-ur",
+      ];
+      for (const name of legit) {
+        const hit = MALICIOUS_PACKAGE_PATTERNS.some((p) => new RegExp(p).test(name));
+        expect(hit, name).toBe(false);
+      }
+    });
+
+    it("does NOT make the generic directory scan flag a non-nolb neighbour", async () => {
+      // The directory scan is feed-only, so this asserts the FP guard that
+      // matters for the surface a consumer runs in CI: adding this pattern must
+      // not have introduced a finding for the rest of the scope.
+      fs.writeFileSync(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({
+          name: "app",
+          version: "1.0.0",
+          dependencies: { "@zalastax/some-real-package": "1.0.0", "left-pad": "1.3.0" },
+        }),
+      );
+
+      const report = await scan({ target: tempDir, format: "text" });
+      expect(report.findings.some((f) => f.rule === "MALICIOUS_DEPENDENCY")).toBe(false);
+    });
+  });
+
+  // =================================================================
+  // Advisory-database import, 2026-08-22 batch
+  // =================================================================
+
+  describe("Advisory-database import, 2026-08-22 batch", () => {
+    // Spot-checks that the imported entries are routed to the ecosystem their
+    // advisory names. A missing feed prefix does not weaken detection, it
+    // inverts it, so the PyPI entries are asserted against the pypi namespace
+    // and the clean neighbouring version is asserted NOT to match.
+    it("pins the @postman-cse dependency-confusion versions (npm)", () => {
+      // Bare feed values are the npm namespace, so they resolve through
+      // matchBareNpmIOC(), not matchPackageIOC() - see the two-resolver note in
+      // "PyPI feed entries carry their ecosystem prefix" above.
+      const feed = getBundledFeed();
+      expect(
+        matchBareNpmIOC("@postman-cse/okta-aio-linux-arm64", "0.11.6", feed),
+        "a published malicious version must match",
+      ).toBeTruthy();
+      expect(
+        matchBareNpmIOC("@postman-cse/okta-aio-linux-arm64", "0.7.0", feed),
+        "a version the advisory never named must NOT match",
+      ).toBeNull();
+    });
+
+    it("routes the PyPI entries to the pypi namespace, not npm", () => {
+      const feed = getBundledFeed();
+      expect(matchPackageIOC("pypi", "boto4", "1.0.0", feed)).toBeTruthy();
+      expect(matchPackageIOC("pypi", "scrambleeer", "0.1.1", feed)).toBeTruthy();
+      expect(
+        matchPackageIOC("npm", "boto4", "1.0.0", feed),
+        "a pypi: entry must not match an npm package of the same name",
+      ).toBeNull();
+      expect(
+        matchPackageIOC("pypi", "boto4", "1.0.1", feed),
+        "a version between the two pinned ones must NOT match",
+      ).toBeNull();
+    });
+
+    it("keeps the all-versions npm entries reachable by bare name", () => {
+      const feed = getBundledFeed();
+      for (const name of ["kelly-sizing", "polymarket-trading-developer-tool", "saas-f-testing"]) {
+        expect(matchBareNpmIOC(name, "1.0.0", feed), name).toBeTruthy();
+      }
+    });
+  });
+
 });

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -2253,6 +2253,31 @@ export const MALICIOUS_PACKAGE_PATTERNS: string[] = [
   // and are NOT matched.
   "^(claud-code|cloude-code|cloude|crypto-locale|crypto-reader-info|detect-cache|format-defaults|hardhta|locale-loader-pro|naniod|node-native-bridge|opencraw|parse-compat|rimarf|scan-store|secp256|suport-color|veim|yarsg)$",
 
+  // @zalastax/nolb-* name-reservation flood (GitHub Advisory Database backfill,
+  // August 2026). OpenSSF malicious-packages classified this one publisher's bulk
+  // namespace-squat as CWE-506 and GHSA backfilled it on 2026-08-14: 4,363 advisories
+  // in a single import window, every one an all-versions range (`> 0`) on a name of
+  // the form @zalastax/nolb-<suffix>, all published Jan/Feb 2023.
+  //
+  // Registry-verified 2026-08-22: these are npm SECURITY HOLDING PACKAGES. 12 of a
+  // 14-name spread sample carry only a 0.0.1-security placeholder; 2 still have their
+  // original 2023 version alongside it. So the payload is largely gone and the names
+  // have no legitimate release history - the same situation as the SANDWORM_MODE set
+  // above, where holding-package status is what makes a bare-name rule safe.
+  //
+  // ONE anchored rule rather than 4,363 feed entries: that would be a 34% feed growth
+  // (12,962 -> 17,325) and about 1 MB on feed.json for one publisher's taken-down 2023
+  // squats. Every advisory in the scope carries the nolb- prefix (1,000/1,000 sampled
+  // from ossf/malicious-packages) and the rule is anchored to it, so a non-nolb
+  // @zalastax package does NOT match. A named-publisher namespace rule like the
+  // BufferZoneCorp Go rule above, not the scoped catch-all rejected below.
+  //
+  // LIMIT, on purpose: MALICIOUS_PACKAGE_PATTERNS is read by the npm-scanner name
+  // check and its package.json fallback, NOT by the generic directory scan, which
+  // matches exact feed names only. Taken-down names make that residual gap small,
+  // but it is a gap and not a claim of full coverage.
+  "^@zalastax\\/nolb-[a-z0-9._-]+$",
+
   // NOTE: there is deliberately NO scoped-package catch-all here.
   // A rule of the shape "^@(?!<allowlist>)/.*$" matched 94% of every scoped
   // package on npm, so `scg npm <any scoped package>` exited 1 with riskLevel

--- a/src/threat-intel.ts
+++ b/src/threat-intel.ts
@@ -13700,6 +13700,58 @@ const FEED_CHUNK_12: FeedIOC[] = [
   { type: "hash", value: "25ad700976873c76af785cb99b33c48db7df8b81f21d1e9e06b3676b9a9373ae", severity: "critical", confidence: 1.0, campaign: "arrayref Build-Time Dropper", source: "StepSecurity, Wiz", firstSeen: "2026-08-20" },
   { type: "hash", value: "61198155da51b838772eecf5bfaac6cbc4dcc388dccc56658fc28a8e831b34d4", severity: "critical", confidence: 1.0, campaign: "arrayref Build-Time Dropper", source: "StepSecurity, Wiz", firstSeen: "2026-08-20" },
   { type: "hash", value: "b5c1b5b0763a8809a644a8f92224653f0aca623a98eecc714d27f74b80fbe436", severity: "critical", confidence: 1.0, campaign: "arrayref Build-Time Dropper", source: "StepSecurity, Wiz", firstSeen: "2026-08-20" },
+
+  // Imported from GitHub Advisory Database (2026-08-08) - see docs/threat-feed-sources.md
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.8.10", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.8.11", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.9.0", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.9.1", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.0", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.1", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.2", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.3", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.4", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.5", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.6", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.7", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.8", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.10.9", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.11.0", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.11.1", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.11.2", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.11.3", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.11.6", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.11.5", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "@postman-cse/okta-aio-linux-arm64@0.11.4", severity: "critical", confidence: 1.0, source: "GHSA-h84r-259m-g3fg, MAL-2026-14357", firstSeen: "2026-08-22" },
+  { type: "package", value: "lumen-pages-community@9.9.9", severity: "critical", confidence: 1.0, source: "GHSA-cf4g-g969-7qvx, MAL-2026-14356", firstSeen: "2026-08-22" },
+  { type: "package", value: "fuel-react@91.0.0", severity: "critical", confidence: 1.0, source: "GHSA-77vr-cf3r-2v4w, MAL-2026-14355", firstSeen: "2026-08-22" },
+  { type: "package", value: "polymarket-trading-developer-tool", severity: "critical", confidence: 1.0, source: "GHSA-qh4r-g8mr-v3xp, MAL-2026-6714", firstSeen: "2026-08-21" },
+  { type: "package", value: "kelly-sizing", severity: "critical", confidence: 1.0, source: "GHSA-vj74-3pcr-5p7j, MAL-2026-14354", firstSeen: "2026-08-21" },
+  { type: "package", value: "@gfe/lx-watcher@1.5.3", severity: "critical", confidence: 1.0, source: "GHSA-7jmf-xqv3-ggfj, MAL-2026-14353", firstSeen: "2026-08-21" },
+  { type: "package", value: "@gfe/lx-watcher@1.5.4", severity: "critical", confidence: 1.0, source: "GHSA-7jmf-xqv3-ggfj, MAL-2026-14353", firstSeen: "2026-08-21" },
+  { type: "package", value: "saas-f-testing", severity: "critical", confidence: 1.0, source: "GHSA-fvrj-4h6r-8rcg, MAL-2026-12434", firstSeen: "2026-08-21" },
+  { type: "package", value: "pypi:scrambleeer@0.1.0", severity: "critical", confidence: 1.0, source: "GHSA-jx7v-9c55-jw2v, MAL-2026-14350", firstSeen: "2026-08-21" },
+  { type: "package", value: "pypi:scrambleeer@0.1.1", severity: "critical", confidence: 1.0, source: "GHSA-jx7v-9c55-jw2v, MAL-2026-14350", firstSeen: "2026-08-21" },
+  { type: "package", value: "pypi:requests-crypt@0.1.0", severity: "critical", confidence: 1.0, source: "GHSA-cf52-hr54-m53p, MAL-2026-14351", firstSeen: "2026-08-21" },
+  { type: "package", value: "rollup-packages-node-polyfills", severity: "critical", confidence: 1.0, source: "GHSA-gp6f-mxh4-x3mh, MAL-2026-12428", firstSeen: "2026-08-21" },
+  { type: "package", value: "pino-deploy", severity: "critical", confidence: 1.0, source: "GHSA-9hw3-p3rx-59cw, MAL-2024-2871", firstSeen: "2026-08-21" },
+  { type: "package", value: "express-bunker", severity: "critical", confidence: 1.0, source: "GHSA-w7r5-8cmj-m893, MAL-2026-10500", firstSeen: "2026-08-21" },
+  { type: "package", value: "react-native-ui-message", severity: "critical", confidence: 1.0, source: "GHSA-w3j6-3pww-qfcw, MAL-2026-12424", firstSeen: "2026-08-21" },
+];
+
+const FEED_CHUNK_13: FeedIOC[] = [
+  // Imported from GitHub Advisory Database (2026-08-08) - see docs/threat-feed-sources.md
+  { type: "package", value: "react-hook-use-debounce-throttle-12", severity: "critical", confidence: 1.0, source: "GHSA-2x4w-64xc-78fv, MAL-2026-5909", firstSeen: "2026-08-21" },
+  { type: "package", value: "utils-common-helpers", severity: "critical", confidence: 1.0, source: "GHSA-fq4g-5xjj-r935, MAL-2026-5911", firstSeen: "2026-08-21" },
+  { type: "package", value: "react-fontawesome-icons", severity: "critical", confidence: 1.0, source: "GHSA-xvfg-jp9r-63q2, MAL-2026-12423", firstSeen: "2026-08-21" },
+  { type: "package", value: "qr-code-styling-temp", severity: "critical", confidence: 1.0, source: "GHSA-pp2c-4x5r-7h8j, MAL-2026-4655", firstSeen: "2026-08-21" },
+  { type: "package", value: "pvm-autodoc", severity: "critical", confidence: 1.0, source: "GHSA-9352-468r-x8fr, MAL-2026-12421", firstSeen: "2026-08-21" },
+  { type: "package", value: "postcss-animate-css-vars", severity: "critical", confidence: 1.0, source: "GHSA-432g-6qr7-8hvh, MAL-2026-12418", firstSeen: "2026-08-21" },
+  { type: "package", value: "tailwind-animate-css-plugin", severity: "critical", confidence: 1.0, source: "GHSA-5w98-j73p-rv7m, MAL-2026-14352", firstSeen: "2026-08-21" },
+  { type: "package", value: "polymarket-bot-logger", severity: "critical", confidence: 1.0, source: "GHSA-v4pc-gmg8-h48w, MAL-2026-10516", firstSeen: "2026-08-21" },
+  { type: "package", value: "polygon-toolkit-validator", severity: "critical", confidence: 1.0, source: "GHSA-67fh-9pjj-6cpw, MAL-2026-10641", firstSeen: "2026-08-21" },
+  { type: "package", value: "pypi:boto4@1.0.0", severity: "critical", confidence: 1.0, source: "GHSA-ffh8-mpww-qp8g, MAL-2026-14349", firstSeen: "2026-08-21" },
+  { type: "package", value: "pypi:boto4@1.0.2", severity: "critical", confidence: 1.0, source: "GHSA-ffh8-mpww-qp8g, MAL-2026-14349", firstSeen: "2026-08-21" },
 ];
 
 // Composed from the chunks above. A single array literal of this size trips
@@ -13722,6 +13774,7 @@ const BUNDLED_FEED: FeedIOC[] = [
   ...FEED_CHUNK_10,
   ...FEED_CHUNK_11,
   ...FEED_CHUNK_12,
+  ...FEED_CHUNK_13,
 ];
 
 // Exported so the feed channel (feed.ts: "feed refresh") writes its download


### PR DESCRIPTION
Daily threat-intel sweep for 2026-08-22. No version bump: this is feed and rule
content for whichever release picks it up next.

## What the importer proposed, and why the diff is not 4,409 entries

The run over `2026-08-08` to `2026-08-22` mapped 6,482 IOCs, of which 4,409 were
new. It refused to exit clean: at the default `--limit 250`, 2,659 of the
remainder would age out of the `--days 14` window before any later run could
reach them.

4,363 of those 4,409 are one publisher's namespace, `@zalastax/nolb-*`,
backfilled into the GitHub Advisory Database on 2026-08-14 from
ossf/malicious-packages. All are all-versions ranges (`> 0`) on names published
in Jan/Feb 2023. The genuinely new signal in the window is the other 46.

Two registry checks decided how to handle them, and the first one on its own was
misleading. Liveness said the packages exist, are not unpublished, and predate
their advisory by three years, which reads as a live gap. Reading the version
contents corrected it: they are npm **security holding packages**. In a 14-name
spread sample across the whole set, 12 carry only a `0.0.1-security` placeholder
and 2 still have their original 2023 version alongside it.

So they are taken-down names with no legitimate release history, which is the
same situation as the SANDWORM_MODE set already in `MALICIOUS_PACKAGE_PATTERNS`,
where holding-package status is exactly what makes a bare-name rule safe. Taking
them as feed entries would have grown the bundled feed 34% (12,962 to 17,325) and
added about 1 MB to `feed.json`, shipped to every consumer, for one publisher's
2023 squats. They are covered by one anchored rule instead:

    ^@zalastax\/nolb-[a-z0-9._-]+$

Every advisory in the scope carries the `nolb-` prefix (1,000 of 1,000 sampled
from ossf/malicious-packages) and the rule is anchored to it, so a non-`nolb`
package in the same scope does not match.

One thing this deliberately does not claim: `MALICIOUS_PACKAGE_PATTERNS` is read
by the npm-scanner name check and its `package.json` fallback, not by the generic
directory scan, which matches exact feed names only by design. Taken-down names
make that residual gap small, but it is a gap. The comment in `patterns.ts` says
so rather than implying full coverage.

## The 46 imported package IOCs

Applied through the importer's own writer, so chunking, re-parse verification and
`feed.json` regeneration behave exactly as a normal `feed:import` run.

- `@postman-cse/okta-aio-linux-arm64`, 21 versions (0.8.10 through 0.11.6) -
  dependency confusion against an internal Postman scope, now an npm security
  holding package. GHSA-h84r-259m-g3fg, MAL-2026-14357.
- `@gfe/lx-watcher` 1.5.3 and 1.5.4 - GHSA-7jmf-xqv3-ggfj, MAL-2026-14353.
- PyPI: `boto4` 1.0.0/1.0.2 (GHSA-ffh8-mpww-qp8g), `scrambleeer` 0.1.0/0.1.1
  (GHSA-jx7v-9c55-jw2v), `requests-crypt` 0.1.0 (GHSA-cf52-hr54-m53p).
- Exact-version npm pins: `lumen-pages-community@9.9.9` (GHSA-cf4g-g969-7qvx),
  `fuel-react@91.0.0` (GHSA-77vr-cf3r-2v4w).
- All-versions npm names: `polymarket-trading-developer-tool`, `kelly-sizing`,
  `saas-f-testing`, `rollup-packages-node-polyfills`, `pino-deploy`,
  `express-bunker`, `react-native-ui-message`,
  `react-hook-use-debounce-throttle-12`, `utils-common-helpers`,
  `react-fontawesome-icons`, `qr-code-styling-temp`, `pvm-autodoc`,
  `postcss-animate-css-vars`, `tailwind-animate-css-plugin`,
  `polymarket-bot-logger`, `polygon-toolkit-validator`.

All 46 are corroborated by OSV (a MAL- id), so they carry confidence 1.0.

Nothing was reported unmappable: `skipped` was 0 and no bounded-range or
unsupported-ecosystem advisory needed a human decision. The window did not need
slicing; the page cap was not hit (60 pages fetched, cap 750).

## Non-package enrichment: nothing addable

Socket, Aikido, StepSecurity, safedep, OX Security and The Hacker News were
checked for write-ups newer than the v5.28.1 sweep. Every atomic indicator they
publish is already in the blocklist: the keyv/cacheable Shai-Hulud domains
(`npm-cache[.]com`, `pypi-get[.]com`, `js-mirror[.]com`), both payload hashes and
the blockchain C2 contract, the arrayref build-time dropper, WEL1DROPPER, the
Alibaba RAT cluster, Joyfill and the fake Corepack site. The one genuinely new
cluster, `@postman-cse`, had its advisory published 2026-08-22 00:44 UTC and has
no vendor write-up yet, so there is nothing to add beyond the version pins.

## Tests

Six new cases in `src/__tests__/campaigns.test.ts`:

- the `nolb-` rule matches flagged names and does not reach past the prefix, into
  the unscoped lookalike, or into another scope;
- the directory scan still returns no `MALICIOUS_DEPENDENCY` for a non-`nolb`
  neighbour in the same scope, which is the false-positive guard for the surface
  the Action actually runs;
- the `@postman-cse` version pin matches a published version and not
  `0.7.0`, which the advisory never named;
- the PyPI entries resolve in the `pypi` namespace and not as npm, and `boto4`
  1.0.1 between the two pinned versions does not match;
- the all-versions names stay reachable by bare name.

The `nolb-` rule was mutation-checked: green, then red with the pattern line
removed, then green again after restoring it.

Locally only the suites covering this change were run. CI runs the full suite on
this PR and that is the authoritative verdict.
