### PR TITLE
fix(feed): bound both threat-feed downloads with a deadline and a byte cap

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.28.1 |
 | Node engines | >=22.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 118 under `src/__tests__/` |
+| Test files | 119 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,10 +11,10 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1b0b50a17bc818e59d1773fea20c421633d2e6ea1de520f92f33a0d259a17b6e",
+      "checksum": "sha256:d36fb4212c1ee9987f950121330a1df1b7af0e4e8a5581114e8a446a9e0d3834",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2727,
-      "summary": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump."
+      "lines": 2792,
+      "summary": "Branch fix/issue-170-feed-timeout-and-size-cap. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
@@ -41,14 +41,14 @@
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:92f74c0dbd4642a38054ab234012c679b8bbe4b21b44806cce01a217244fa39e",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:a3f5ac40cf40fa687ce694aac88db8946d763ef765d0c4cbc64ea2e3c242d49e",
+      "updated": "2026-08-22T13:37:51Z",
       "lines": 72,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:d5ba6fb28d49c8108c61da1a43e48c85805a5828578852395876c3b6ff5e8bf6",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:660c3678483ebc3b297f209d92edd692b38ecc11dbf8ffc0607c0e5943007a1c",
+      "updated": "2026-08-22T13:37:51Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Branch fix/issue-170-feed-timeout-and-size-cap. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 32959,
-    "full_read": 44621
+    "manifest_plus_core": 34154,
+    "full_read": 45816
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,71 @@
 
 ---
 
+## Feed acquisition is bounded, on both paths (2026-08-22, unreleased)
+
+Branch fix/issue-170-feed-timeout-and-size-cap. No version bump.
+Closes https://github.com/homeofe/supply-chain-guard/issues/170 once reviewed.
+
+### What was wrong, and where the issue was incomplete
+
+The issue named one function, `updateThreatFeed`, which is exported library API
+that no CLI command calls. The command the README documents,
+`supply-chain-guard feed refresh`, went through a SECOND downloader in
+`src/feed.ts` with the same two defects and no backstop of any kind. Fixing only
+the function the acceptance criteria name would have closed the issue green with
+the shipped command unchanged.
+
+Measured on the base commit against a loopback peer that sends headers and then
+stalls: `feed refresh` ran 150 seconds with empty stdout, empty stderr and no
+exit, and was killed at the cap. The identical command against a healthy peer
+finished in 0.28 seconds. A 64 MiB chunked body was accepted in full.
+
+### Root cause
+
+Not a forgotten timeout. `src/remote-download.ts` already existed and already
+implemented every bound this issue asks for, and `src/npm-scanner.ts`,
+`src/pypi-scanner.ts` and `src/vscode-scanner.ts` already used it. Registry
+acquisition was hardened behind that shared module; feed acquisition was the one
+caller that never adopted it, and nothing in the build requires a new outbound
+request to go through it.
+
+A contributing cause sits in the tests. `src/__tests__/feed.test.ts` mocks
+`node:https` wholesale and delivers the whole body in one tick, so none of its
+six `refreshFeed` tests could observe a stall. The suite passed around the
+defect rather than over it.
+
+### What changed
+
+- `FEED_REMOTE_LIMITS` in `src/threat-intel.ts`, beside the cache constants:
+  32 MiB, 30 s, 5 redirects. The byte figure is roughly ten times the published
+  feed; the other two are the values the registry scanners already use.
+- `refreshFeed` delegates to `fetchHttpsBuffer`. The hand-rolled request is gone,
+  and with it a second defect in the same function: it decoded each chunk
+  separately, so a multi-byte UTF-8 sequence split across a chunk boundary became
+  replacement characters.
+- `updateThreatFeed` keeps the global `fetch` and its quarantine-and-continue
+  validation, and gains an `AbortSignal` deadline, a `Content-Length` refusal
+  before the body is touched, and a running byte count while streaming.
+- Both take an optional per-call limit override; both default to the constant.
+- New suite `src/__tests__/issue-170-feed-bounds.test.ts` drives a real loopback
+  server rather than a mock, because a mock that answers in one tick cannot
+  represent a peer that stalls.
+
+### The one decision left for the owner
+
+`updateThreatFeed` was hardened in place rather than turned into a wrapper over
+`refreshFeed`. The wrapper would remove the second implementation, which is the
+better end state, but it is a behavioural change to exported, documented API:
+`parseFeedPayload` hard-rejects a bad entry where `updateThreatFeed` quarantines
+it and continues, and the error strings differ. That belongs in its own change
+with its own changelog entry, not smuggled in behind a timeout fix.
+
+Also for the owner: the acceptance criteria on the issue are satisfied by the
+`updateThreatFeed` half alone and need rewriting to name `src/feed.ts` as well,
+or the next reader will conclude the CLI path was out of scope.
+
+---
+
 ## The required handoff gate compared main to itself on every push (2026-08-22, unreleased)
 
 Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump.

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.28.1 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 118 | src/__tests__/ file list |
+| Test files present | 119 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,40 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Fixed
+
+- **The remote threat feed is now fetched with a deadline and a size cap, on both
+  download paths.** `supply-chain-guard feed refresh` hand-rolled its own
+  `https.get` with neither, so a peer that sent response headers and then stalled
+  held the command open with no output and no exit: measured at 150 seconds
+  against a stalling loopback peer, against 0.28 seconds for the same command
+  against a healthy one. The same peer now fails closed in 30.4 seconds with exit
+  code 1 and one line naming the deadline. A 64 MiB chunked body was previously
+  accepted in full; it is now refused after 32 MiB with nothing written.
+  Reported as https://github.com/homeofe/supply-chain-guard/issues/170.
+
+  The root cause was not a forgotten timeout. This package already had a bounded
+  downloader, `src/remote-download.ts`, used by the npm, PyPI and VS Code
+  scanners; feed acquisition was the one caller that never adopted it.
+  `refreshFeed` now goes through it, so the deadline, the `Content-Length`
+  refusal, the streaming byte cap and the per-hop redirect revalidation are the
+  same code the registry scanners use. The legacy `updateThreatFeed` keeps the
+  global `fetch` and its quarantine-and-continue validation, and gains an
+  `AbortSignal` deadline plus a byte cap applied before the document is parsed.
+  Both read the new `FEED_REMOTE_LIMITS` constant (32 MiB, 30 s, 5 redirects),
+  and both take an optional per-call override.
+
+  An inactivity timeout would not have been a fix. Node's global `fetch` already
+  had one and it never fires against a peer that trickles the body; the deadline
+  is absolute and covers the body read. There is a test for exactly that case.
+
 ### Changed
+
+- **Two error strings from `feed refresh` changed wording**, because the shared
+  downloader reports them: a request-level failure no longer carries the
+  `network error:` prefix, and a rejected status now reads `HTTPS request failed
+  with status 404 for <url>` instead of `HTTP 404`. Both still name the URL and
+  still leave the previous cache untouched.
 
 - **Benchmark evidence in this project's own artefacts now carries counts, never
   consumer repository names.** Two `CHANGELOG.md` entries (v5.2.40, v5.2.41) cited

--- a/README.md
+++ b/README.md
@@ -823,6 +823,16 @@ validate each entry against its type's shape and quarantine anything invalid -
 a malformed or hostile feed entry can neither crash a scan nor flood it with
 garbage matches, and a rejected refresh never overwrites the previous cache.
 
+**Acquisition bounds:** both download paths are bounded before anything is
+parsed or written. An absolute 30 second deadline covers DNS, connect, headers
+and the body read; the response is capped at 32 MiB, refused on a declared
+`Content-Length` over the cap before a byte is read and counted again while
+streaming when no length is declared; at most 5 redirects are followed and every
+hop is revalidated. An inactivity timeout would not be enough, because a peer
+that keeps trickling bytes never triggers one. Every bound fails closed and
+loudly: the download is abandoned, one line naming the bound goes to stderr, the
+command exits non-zero, and the previous cache stays in effect.
+
 ### Where the feed comes from
 
 Curated entries are hand-added from vendor write-ups. Malicious-package entries

--- a/src/__tests__/feed.test.ts
+++ b/src/__tests__/feed.test.ts
@@ -47,20 +47,34 @@ const EXTRA_DOMAIN_IOC: FeedIOC = {
   campaign: "Feed Refresh Test",
 };
 
-type ResLike = EventEmitter & { statusCode?: number };
+type ResLike = EventEmitter & { statusCode?: number; headers?: Record<string, string> };
 type MockedGet = ReturnType<typeof vi.fn>;
 
-/** Configure the mocked https.get to answer with a status + body chunks. */
+/**
+ * Configure the mocked https.get to answer with a status + body chunks.
+ *
+ * The body is emitted on a LATER tick than the response callback, the way a
+ * socket delivers it. Emitting it in the same tick only worked because the old
+ * hand-rolled reader attached its listeners synchronously inside that callback;
+ * any reader that awaits anything first would miss every chunk and hang.
+ *
+ * This mock still cannot represent a peer that stalls or trickles, which is why
+ * the bounds introduced for issue 170 are tested against a real loopback server
+ * in issue-170-feed-bounds.test.ts instead of here.
+ */
 function mockHttpResponse(status: number, chunks: string[]): void {
   (https.get as unknown as MockedGet).mockImplementation(
-    (_url: unknown, cb: (res: ResLike) => void) => {
+    (_options: unknown, cb: (res: ResLike) => void) => {
       const res = new EventEmitter() as ResLike;
       res.statusCode = status;
+      res.headers = {};
       const req = new EventEmitter();
       process.nextTick(() => {
         cb(res);
-        for (const chunk of chunks) res.emit("data", Buffer.from(chunk));
-        res.emit("end");
+        setImmediate(() => {
+          for (const chunk of chunks) res.emit("data", Buffer.from(chunk));
+          res.emit("end");
+        });
       });
       return req;
     },
@@ -321,7 +335,14 @@ describe("refreshFeed", () => {
   it("defaults to the published GitHub raw URL", async () => {
     mockHttpResponse(200, [JSON.stringify({ schema: 1, entries: [EXTRA_DOMAIN_IOC] })]);
     await refreshFeed(undefined, tmpDir);
-    expect((https.get as unknown as MockedGet).mock.calls[0][0]).toBe(DEFAULT_FEED_URL);
+    // The bounded downloader parses the URL and passes RequestOptions, so the
+    // destination is reassembled from the parts rather than compared as a string.
+    const options = (https.get as unknown as MockedGet).mock.calls[0][0] as {
+      protocol: string;
+      hostname: string;
+      path: string;
+    };
+    expect(`${options.protocol}//${options.hostname}${options.path}`).toBe(DEFAULT_FEED_URL);
     expect(DEFAULT_FEED_URL).toContain(
       "raw.githubusercontent.com/homeofe/supply-chain-guard/main/feed.json",
     );
@@ -330,7 +351,7 @@ describe("refreshFeed", () => {
   it("rejects with a clear error when the network is down (no crash)", async () => {
     mockHttpError("getaddrinfo ENOTFOUND raw.githubusercontent.com");
     await expect(refreshFeed("https://feed.invalid/feed.json", tmpDir)).rejects.toThrow(
-      /Failed to refresh threat feed.*network error.*ENOTFOUND/,
+      /Failed to refresh threat feed.*ENOTFOUND/,
     );
     expect(fs.existsSync(path.join(tmpDir, FEED_CACHE_FILE))).toBe(false);
   });
@@ -338,7 +359,7 @@ describe("refreshFeed", () => {
   it("rejects on non-200 HTTP status", async () => {
     mockHttpResponse(404, ["Not Found"]);
     await expect(refreshFeed("https://feed.invalid/feed.json", tmpDir)).rejects.toThrow(
-      /Failed to refresh threat feed.*HTTP 404/,
+      /Failed to refresh threat feed.*failed with status 404/,
     );
   });
 

--- a/src/__tests__/issue-170-feed-bounds.test.ts
+++ b/src/__tests__/issue-170-feed-bounds.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Issue 170: the remote threat feed is fetched with no timeout and no size cap.
+ *
+ * WHY THIS FILE EXISTS SEPARATELY FROM feed.test.ts
+ *
+ * feed.test.ts mocks node:https wholesale and delivers the whole body inside one
+ * `process.nextTick`. No test written against that mock can represent a peer that
+ * stalls or trickles, which is how six passing refreshFeed tests coexisted with a
+ * download that had no deadline at all. A bound is only proved by a peer that
+ * misbehaves in real time, so every test here drives a real loopback server over
+ * a real socket with real timers.
+ *
+ * node:https is redirected onto node:http so the server needs no certificate.
+ * Everything a deadline depends on - socket, stream, timer, backpressure - is the
+ * genuine article; only the TLS layer is not, and TLS has no bearing on whether a
+ * request is bounded.
+ *
+ * HOW TO REDDEN EACH TEST (a test that cannot fail is not coverage):
+ *
+ *   - "sends headers and then stalls" and "trickles the body forever": restore the
+ *     hand-rolled request in src/feed.ts httpsGetBody, or delete the
+ *     `const limits` line in refreshFeed so the bounds never reach the download.
+ *   - "trickles the body forever" ALONE: delete the absolute body deadline in
+ *     src/remote-download.ts readBoundedBody (the `const timer = setTimeout(...)`
+ *     and its clearTimeout). The stall test stays green on that mutation because
+ *     the socket inactivity backstop still fires. That difference is the point:
+ *     an inactivity timer looks like a working fix until the peer keeps sending.
+ *   - the Content-Length tests: delete the `refuseOversizedDeclaredBody` call in
+ *     src/remote-download.ts, or the `content-length` branch in
+ *     src/threat-intel.ts readBoundedBody.
+ *   - the streaming-cap tests: delete the `bytes + chunk.length > maxBytes` guard
+ *     in src/remote-download.ts, or its twin in src/threat-intel.ts.
+ *   - "package defaults" tests: raise FEED_REMOTE_LIMITS.maxBytes.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AddressInfo, Socket } from "node:net";
+
+vi.mock("node:https", async () => {
+  const nodeHttp = await import("node:http");
+  const get = (
+    options: http.RequestOptions,
+    callback: (response: http.IncomingMessage) => void,
+  ): http.ClientRequest => nodeHttp.get({ ...options, protocol: "http:" }, callback);
+  return { default: { get }, get };
+});
+
+import { refreshFeed } from "../feed.js";
+import { FEED_CACHE_FILE, FEED_REMOTE_LIMITS, updateThreatFeed } from "../threat-intel.js";
+
+/** Short enough to keep the suite fast, long enough to survive a loaded CI box. */
+const DEADLINE_MS = 400;
+/** Small enough that a few kilobytes cross it. */
+const CAP_BYTES = 4096;
+/** How long a test waits before declaring a call unbounded. */
+const HORIZON_MS = 6000;
+const NOT_BOUNDED = "STILL PENDING: the call never settled";
+const RESOLVED = "RESOLVED: the call succeeded";
+
+let tmpDir: string;
+let servers: http.Server[] = [];
+let sockets: Socket[] = [];
+let timers: ReturnType<typeof setInterval>[] = [];
+
+interface Peer {
+  /** For refreshFeed, which refuses any scheme but https. */
+  httpsUrl: string;
+  /** For updateThreatFeed, which goes through the global fetch. */
+  httpUrl: string;
+}
+
+function startPeer(handler: http.RequestListener): Promise<Peer> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.on("connection", (socket) => sockets.push(socket));
+    server.listen(0, "127.0.0.1", () => {
+      servers.push(server);
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        httpsUrl: `https://127.0.0.1:${port}/feed.json`,
+        httpUrl: `http://127.0.0.1:${port}/feed.json`,
+      });
+    });
+  });
+}
+
+/**
+ * Headers, then silence. The peer never sends a body byte and never ends.
+ *
+ * flushHeaders() is load-bearing. writeHead() only stores the headers; Node
+ * sends them with the first write or with end(). Without the flush this peer
+ * would stall BEFORE the response line, which is the connect phase, not the
+ * post-headers stall the issue reports.
+ */
+const headersThenStall: http.RequestListener = (_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.flushHeaders();
+};
+
+/**
+ * Headers, then one byte every sixth of the deadline, forever. A socket
+ * inactivity timeout can never fire against this peer: it is never quiet for a
+ * whole timeout window. Only an absolute deadline ends the call.
+ */
+const trickleForever: http.RequestListener = (_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  const timer = setInterval(() => res.write("."), Math.floor(DEADLINE_MS / 6));
+  timers.push(timer);
+  res.on("close", () => clearInterval(timer));
+};
+
+/** Declares a length over the cap and then sends nothing at all. */
+function declaresBytes(declared: number): http.RequestListener {
+  return (_req, res) => {
+    res.writeHead(200, {
+      "content-type": "application/json",
+      "content-length": String(declared),
+    });
+    res.flushHeaders();
+  };
+}
+
+/** No declared length (so: chunked), streaming well past any small cap. */
+const chunkedPastCap: http.RequestListener = (_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  const chunk = "x".repeat(1024);
+  let sent = 0;
+  const pump = (): void => {
+    while (sent < CAP_BYTES * 8) {
+      sent += chunk.length;
+      if (!res.write(chunk)) {
+        res.once("drain", pump);
+        return;
+      }
+    }
+    res.end();
+  };
+  pump();
+};
+
+/**
+ * Race a call against a horizon and return a STRING describing what happened.
+ *
+ * A bounded call rejects and yields its message. An unbounded one yields
+ * NOT_BOUNDED, so "no deadline" fails as a plain assertion mismatch instead of
+ * as a test-runner timeout, and the failure message names the defect.
+ */
+async function settle(call: Promise<unknown>, horizonMs = HORIZON_MS): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const horizon = new Promise<string>((resolve) => {
+    timer = setTimeout(() => resolve(NOT_BOUNDED), horizonMs);
+  });
+  try {
+    return await Promise.race([
+      call.then(
+        () => RESOLVED,
+        (err: unknown) => (err instanceof Error ? err.message : String(err)),
+      ),
+      horizon,
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "scg-issue170-"));
+});
+
+afterEach(async () => {
+  for (const timer of timers) clearInterval(timer);
+  timers = [];
+  for (const socket of sockets) socket.destroy();
+  sockets = [];
+  await Promise.all(
+    servers.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+  servers = [];
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("feed acquisition bounds (issue 170)", () => {
+  it("names the default bounds as a frozen constant", () => {
+    expect(FEED_REMOTE_LIMITS).toEqual({
+      maxBytes: 32 * 1024 * 1024,
+      timeoutMs: 30_000,
+      maxRedirects: 5,
+    });
+    expect(Object.isFrozen(FEED_REMOTE_LIMITS)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // refreshFeed: the path `supply-chain-guard feed refresh` runs.
+  // -------------------------------------------------------------------------
+
+  it("refreshFeed rejects a peer that sends headers and then stalls", async () => {
+    const peer = await startPeer(headersThenStall);
+    const started = Date.now();
+
+    const outcome = await settle(refreshFeed(peer.httpsUrl, tmpDir, { timeoutMs: DEADLINE_MS }));
+
+    // The number in the message is the deadline's REMAINING budget at the moment
+    // the body read started, so it is 400ms minus the connect time, not a literal
+    // 400. The wall clock below is what pins the bound.
+    expect(outcome).toMatch(/Failed to refresh threat feed .*timed out after \d+ms/);
+    expect(Date.now() - started).toBeLessThan(DEADLINE_MS * 10);
+    expect(fs.existsSync(path.join(tmpDir, FEED_CACHE_FILE))).toBe(false);
+  }, 20_000);
+
+  it("refreshFeed rejects a peer that trickles the body forever", async () => {
+    const peer = await startPeer(trickleForever);
+    const started = Date.now();
+
+    const outcome = await settle(refreshFeed(peer.httpsUrl, tmpDir, { timeoutMs: DEADLINE_MS }));
+
+    // Not merely "it rejected": this peer defeats an inactivity timeout by
+    // construction, so only an absolute deadline can produce this message.
+    expect(outcome).toMatch(/Failed to refresh threat feed .*timed out after \d+ms/);
+    expect(Date.now() - started).toBeLessThan(DEADLINE_MS * 10);
+  }, 20_000);
+
+  it("refreshFeed refuses a declared Content-Length over the cap before reading a byte", async () => {
+    const peer = await startPeer(declaresBytes(CAP_BYTES * 2048));
+    const started = Date.now();
+
+    // Only maxBytes is overridden, so the deadline in force is the package
+    // default of 30s. The peer sends no body at all. Rejecting in a fraction of
+    // a second can therefore only be the declared-length refusal: a streamed
+    // byte count would never trip, and the deadline is 30s away.
+    const outcome = await settle(refreshFeed(peer.httpsUrl, tmpDir, { maxBytes: CAP_BYTES }));
+
+    expect(outcome).toMatch(/exceeded the 4096-byte limit/);
+    expect(Date.now() - started).toBeLessThan(FEED_REMOTE_LIMITS.timeoutMs);
+    expect(fs.existsSync(path.join(tmpDir, FEED_CACHE_FILE))).toBe(false);
+  }, 20_000);
+
+  it("refreshFeed refuses a chunked body that streams past the cap", async () => {
+    const peer = await startPeer(chunkedPastCap);
+
+    const outcome = await settle(refreshFeed(peer.httpsUrl, tmpDir, { maxBytes: CAP_BYTES }));
+
+    expect(outcome).toMatch(/exceeded the 4096-byte limit/);
+    expect(fs.existsSync(path.join(tmpDir, FEED_CACHE_FILE))).toBe(false);
+  }, 20_000);
+
+  it("refreshFeed applies the package default cap when no override is passed", async () => {
+    const peer = await startPeer(declaresBytes(FEED_REMOTE_LIMITS.maxBytes + 1));
+
+    const outcome = await settle(refreshFeed(peer.httpsUrl, tmpDir));
+
+    expect(outcome).toMatch(/exceeded the 33554432-byte limit/);
+  }, 20_000);
+
+  it("refreshFeed leaves an existing cache byte-identical when a bound fires", async () => {
+    const cachePath = path.join(tmpDir, FEED_CACHE_FILE);
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        entries: [
+          {
+            type: "domain",
+            // Reserved .example TLD: a fixture, not an indicator.
+            value: "issue-170-fixture.example",
+            severity: "critical",
+          },
+        ],
+      }),
+    );
+    const before = fs.readFileSync(cachePath);
+
+    const peer = await startPeer(headersThenStall);
+    const outcome = await settle(refreshFeed(peer.httpsUrl, tmpDir, { timeoutMs: DEADLINE_MS }));
+
+    expect(outcome).toMatch(/timed out after \d+ms/);
+    // Failing closed means the protection already in place survives the failure.
+    expect(fs.readFileSync(cachePath).equals(before)).toBe(true);
+  }, 20_000);
+
+  // -------------------------------------------------------------------------
+  // updateThreatFeed: the exported legacy API, on the global fetch.
+  // -------------------------------------------------------------------------
+
+  it("updateThreatFeed rejects a peer that sends headers and then stalls", async () => {
+    const peer = await startPeer(headersThenStall);
+
+    const outcome = await settle(
+      updateThreatFeed(peer.httpUrl, tmpDir, { timeoutMs: DEADLINE_MS }),
+    );
+
+    expect(outcome).toBe(
+      `Failed to update threat feed: HTTPS request timed out after ${DEADLINE_MS}ms for ${peer.httpUrl}`,
+    );
+  }, 20_000);
+
+  it("updateThreatFeed rejects a peer that trickles the body forever", async () => {
+    const peer = await startPeer(trickleForever);
+
+    const outcome = await settle(
+      updateThreatFeed(peer.httpUrl, tmpDir, { timeoutMs: DEADLINE_MS }),
+    );
+
+    // undici gives the global fetch a headers timeout and a body INACTIVITY
+    // backstop. Neither fires against a peer that keeps sending, which is why
+    // this case needs its own deadline and its own test.
+    expect(outcome).toBe(
+      `Failed to update threat feed: HTTPS request timed out after ${DEADLINE_MS}ms for ${peer.httpUrl}`,
+    );
+  }, 20_000);
+
+  it("updateThreatFeed refuses a declared Content-Length over the cap before reading a byte", async () => {
+    const peer = await startPeer(declaresBytes(CAP_BYTES * 2048));
+    const started = Date.now();
+
+    const outcome = await settle(updateThreatFeed(peer.httpUrl, tmpDir, { maxBytes: CAP_BYTES }));
+
+    expect(outcome).toBe(
+      `Failed to update threat feed: feed declares ${CAP_BYTES * 2048} bytes, over the ${CAP_BYTES}-byte limit, for ${peer.httpUrl}`,
+    );
+    expect(Date.now() - started).toBeLessThan(FEED_REMOTE_LIMITS.timeoutMs);
+    expect(fs.existsSync(path.join(tmpDir, FEED_CACHE_FILE))).toBe(false);
+  }, 20_000);
+
+  it("updateThreatFeed refuses a chunked body that streams past the cap", async () => {
+    const peer = await startPeer(chunkedPastCap);
+
+    const outcome = await settle(updateThreatFeed(peer.httpUrl, tmpDir, { maxBytes: CAP_BYTES }));
+
+    expect(outcome).toBe(
+      `Failed to update threat feed: feed body exceeded the ${CAP_BYTES}-byte limit for ${peer.httpUrl}`,
+    );
+    expect(fs.existsSync(path.join(tmpDir, FEED_CACHE_FILE))).toBe(false);
+  }, 20_000);
+
+  it("updateThreatFeed applies the package default cap when no override is passed", async () => {
+    const peer = await startPeer(declaresBytes(FEED_REMOTE_LIMITS.maxBytes + 1));
+
+    const outcome = await settle(updateThreatFeed(peer.httpUrl, tmpDir));
+
+    expect(outcome).toMatch(/over the 33554432-byte limit/);
+  }, 20_000);
+
+  // -------------------------------------------------------------------------
+  // The healthy path still works, on both.
+  // -------------------------------------------------------------------------
+
+  it("both paths still accept a well-behaved feed within the bounds", async () => {
+    const entries = [
+      { type: "domain", value: "issue-170-fixture.example", severity: "critical" },
+    ];
+    const peer = await startPeer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ schema: 1, entries }));
+    });
+    const legacyPeer = await startPeer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(entries));
+    });
+
+    const refreshed = await refreshFeed(peer.httpsUrl, tmpDir, { timeoutMs: DEADLINE_MS });
+    expect(refreshed.entryCount).toBe(1);
+
+    const updated = await updateThreatFeed(legacyPeer.httpUrl, tmpDir, {
+      timeoutMs: DEADLINE_MS,
+    });
+    expect(updated.added).toBe(1);
+  }, 20_000);
+});

--- a/src/__tests__/issue-54-hardening.test.ts
+++ b/src/__tests__/issue-54-hardening.test.ts
@@ -207,10 +207,17 @@ describe("issue #54: threat-intel indicator hardening", () => {
   });
 
   it("updateThreatFeed filters invalid entries before writing the cache", async () => {
-    vi.stubGlobal("fetch", async () => ({
-      ok: true,
-      json: async () => [legitDomain, { type: "regex", value: "(", severity: "critical" }],
-    }));
+    // A real Response, not a two-property stand-in. updateThreatFeed reads the
+    // body as a stream under a byte cap (issue 170), so the stub has to carry
+    // headers and a body the way the global fetch returns them.
+    vi.stubGlobal(
+      "fetch",
+      async () =>
+        new Response(
+          JSON.stringify([legitDomain, { type: "regex", value: "(", severity: "critical" }]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
 
     const result = await updateThreatFeed("https://github.com/homeofe/supply-chain-guard/raw/main/feed.json", tempDir);
 

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -17,18 +17,23 @@
  *      matchPackageIOC(). A refreshed cache therefore extends detection at
  *      scan time without a new npm release.
  *
- * Zero-dependency: uses node:https directly (mockable in tests).
+ * Zero-dependency: the download goes through remote-download.ts, the package's
+ * bounded HTTPS retrieval module, which is the same code path the npm, PyPI and
+ * VS Code scanners use. It is node:https underneath (mockable in tests) with an
+ * absolute deadline, a byte cap and per-hop redirect revalidation added.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as https from "node:https";
+import { fetchHttpsBuffer, type RemoteRequestLimits } from "./remote-download.js";
 import {
   CACHE_DIR,
   FEED_CACHE_FILE,
+  FEED_REMOTE_LIMITS,
   isValidFeedIOC,
   normalizeFeedIOC,
   type FeedIOC,
+  type FeedLimitOverrides,
 } from "./threat-intel.js";
 
 /** Published feed location: the committed feed.json on the main branch. */
@@ -120,30 +125,23 @@ export function parseFeedPayload(raw: string): FeedIOC[] {
   return normalizedEntries;
 }
 
-/** Download a URL over HTTPS and resolve with the response body. */
-function httpsGetBody(url: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const req = https.get(url, (res: {
-      statusCode?: number;
-      on: (event: string, handler: (chunk?: Buffer) => void) => void;
-    }) => {
-      const status = res.statusCode ?? 0;
-      let data = "";
-      res.on("data", (chunk?: Buffer) => {
-        if (chunk) data += chunk.toString();
-      });
-      res.on("end", () => {
-        if (status !== 200) {
-          reject(new Error(`HTTP ${status}`));
-          return;
-        }
-        resolve(data);
-      });
-    });
-    req.on("error", (err: Error) => {
-      reject(new Error(`network error: ${err.message}`));
-    });
-  });
+/**
+ * Download a URL over HTTPS and resolve with the response body.
+ *
+ * This used to be a hand-rolled https.get with no deadline and no cap, so a peer
+ * that sent headers and then stalled held `feed refresh` open with no output and
+ * no exit, and a peer that sent an oversized document was buffered in full. The
+ * request now goes through the package's bounded downloader, which carries an
+ * absolute deadline across every redirect hop, refuses a declared Content-Length
+ * over the cap before reading a byte, and counts bytes while streaming when no
+ * length is declared.
+ */
+async function httpsGetBody(url: string, limits: RemoteRequestLimits): Promise<string> {
+  const { body } = await fetchHttpsBuffer(url, limits);
+  // Decode ONCE over the whole buffer. The previous reader did `data +=
+  // chunk.toString()` per chunk, which turns a multi-byte UTF-8 sequence split
+  // across a chunk boundary into replacement characters.
+  return body.toString("utf-8");
 }
 
 /**
@@ -152,13 +150,21 @@ function httpsGetBody(url: string): Promise<string> {
  * for 24h (CACHE_TTL_MS in threat-intel.ts); re-run daily for same-day
  * protection between npm releases. Never crashes the process on network
  * failure - callers get a rejected promise with a clear message.
+ *
+ * The download is bounded by FEED_REMOTE_LIMITS. `limitOverrides` relaxes or
+ * tightens a single dimension per call (a slow link may want a longer deadline)
+ * and leaves the rest at the package defaults. Every bound fails closed: the
+ * download is abandoned, nothing is written, and the previous cache stays in
+ * effect.
  */
 export async function refreshFeed(
   feedUrl: string = DEFAULT_FEED_URL,
   cacheDir: string = CACHE_DIR,
+  limitOverrides: FeedLimitOverrides = {},
 ): Promise<RefreshResult> {
+  const limits: RemoteRequestLimits = { ...FEED_REMOTE_LIMITS, ...limitOverrides };
   try {
-    const body = await httpsGetBody(feedUrl);
+    const body = await httpsGetBody(feedUrl, limits);
     const entries = parseFeedPayload(body);
 
     fs.mkdirSync(cacheDir, { recursive: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export { correlateFindings } from "./correlation-engine.js";
 export { calculateTrustBreakdown } from "./trust-breakdown.js";
 export { loadPolicyConfig, applyPolicy, applyBaseline, saveBaseline } from "./policy-engine.js";
 export { detectTrustSignals } from "./trust-signals.js";
-export { loadThreatIntel, updateThreatFeed, checkThreatIntel, matchPackageIOC, getBundledFeed } from "./threat-intel.js";
+export { loadThreatIntel, updateThreatFeed, checkThreatIntel, matchPackageIOC, getBundledFeed, FEED_REMOTE_LIMITS, type FeedLimitOverrides } from "./threat-intel.js";
 export { feedStats, refreshFeed, parseFeedPayload, DEFAULT_FEED_URL } from "./feed.js";
 export { calculateRiskDimensions } from "./risk-engine.js";
 export { getChangedFiles } from "./diff-scanner.js";

--- a/src/threat-intel.ts
+++ b/src/threat-intel.ts
@@ -13731,6 +13731,34 @@ export const FEED_CACHE_FILE = "threat-feed.json";
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /**
+ * Bounds every remote feed acquisition in this package: the `feed refresh`
+ * download (feed.ts) and the legacy updateThreatFeed() below both read them, so
+ * the two paths cannot drift apart again.
+ *
+ * A network read with no deadline is an availability dependency on a stranger.
+ * The deadline here is ABSOLUTE, not an inactivity timeout: it spans DNS,
+ * connect, headers and the body read, which is the only kind that fires on a
+ * peer that keeps trickling bytes instead of going silent. The reasoning is the
+ * same one written out at solana-monitor.ts, applied to the feed channel.
+ *
+ * maxBytes is roughly ten times the published feed.json, and matches
+ * NPM_REMOTE_LIMITS.metadataBytes. timeoutMs and maxRedirects are the house
+ * values already used by npm-scanner.ts, pypi-scanner.ts and vscode-scanner.ts.
+ */
+export const FEED_REMOTE_LIMITS = Object.freeze({
+  maxBytes: 32 * 1024 * 1024,
+  timeoutMs: 30_000,
+  maxRedirects: 5,
+});
+
+/** Per-call relaxation or tightening of FEED_REMOTE_LIMITS. */
+export interface FeedLimitOverrides {
+  maxBytes?: number;
+  timeoutMs?: number;
+  maxRedirects?: number;
+}
+
+/**
  * Copy of the bundled (compiled-in) IOC feed, without any cached remote
  * entries merged. Used by "feed stats" to distinguish bundled vs effective
  * entry counts; scripts/generate-feed.mjs derives the publishable feed.json
@@ -13828,19 +13856,84 @@ export function loadThreatIntel(
 }
 
 /**
+ * Read a fetch Response body under a byte cap, refusing before the chunk that
+ * would cross it is buffered.
+ *
+ * Content-Length is checked first so a declared oversize body is refused before
+ * a single byte of it is read, but it is never trusted on its own: it is absent
+ * on a chunked response and it describes the COMPRESSED size when the peer sends
+ * gzip, which fetch then inflates. The running counter is what actually holds.
+ */
+async function readBoundedBody(
+  response: Response,
+  feedUrl: string,
+  maxBytes: number,
+): Promise<string> {
+  const declared = response.headers.get("content-length");
+  if (declared !== null && /^\d+$/.test(declared) && BigInt(declared) > BigInt(maxBytes)) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(
+      `feed declares ${declared} bytes, over the ${maxBytes}-byte limit, for ${feedUrl}`,
+    );
+  }
+
+  const stream = response.body;
+  if (stream === null) throw new Error(`feed response carried no body for ${feedUrl}`);
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value === undefined) continue;
+      if (bytes + value.byteLength > maxBytes) {
+        throw new Error(`feed body exceeded the ${maxBytes}-byte limit for ${feedUrl}`);
+      }
+      bytes += value.byteLength;
+      chunks.push(value);
+    }
+  } catch (err) {
+    // Tear the socket down rather than leaving an oversized or stalled transfer
+    // draining in the background.
+    await reader.cancel().catch(() => undefined);
+    throw err;
+  }
+
+  // Decode ONCE over the whole buffer. Decoding per chunk turns a multi-byte
+  // UTF-8 sequence split across a chunk boundary into replacement characters.
+  return Buffer.concat(chunks, bytes).toString("utf-8");
+}
+
+/**
  * Update remote threat feed and cache locally.
+ *
+ * Bounded by FEED_REMOTE_LIMITS: an absolute deadline covering the whole
+ * request including the body read, and a byte cap applied before the document
+ * is parsed. Both fail closed - the download is abandoned and the previous
+ * cache, or the bundled feed, stays in effect.
+ *
+ * `limitOverrides` relaxes or tightens a single dimension per call and leaves
+ * the rest at the package defaults.
  */
 export async function updateThreatFeed(
   feedUrl: string,
   cacheDir?: string,
+  limitOverrides: FeedLimitOverrides = {},
 ): Promise<{ added: number; total: number }> {
   const cacheBase = cacheDir ?? CACHE_DIR;
+  const { maxBytes, timeoutMs } = { ...FEED_REMOTE_LIMITS, ...limitOverrides };
+  // One signal for the whole call. `fetch` alone imposes a headers timeout and
+  // (through undici) a body INACTIVITY backstop; neither ever fires on a peer
+  // that keeps sending slowly, which is the case this deadline covers.
+  const signal = AbortSignal.timeout(timeoutMs);
 
   try {
-    const response = await fetch(feedUrl);
+    const response = await fetch(feedUrl, { signal });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
-    const raw = (await response.json()) as unknown;
+    const raw = JSON.parse(await readBoundedBody(response, feedUrl, maxBytes)) as unknown;
     if (!Array.isArray(raw)) throw new Error("Invalid feed format");
     // Validate BEFORE caching: entries failing the indicator contract
     // (unknown type, non-string/empty/oversized value) are quarantined so
@@ -13855,7 +13948,15 @@ export async function updateThreatFeed(
 
     return { added: entries.length, total: BUNDLED_FEED.length + entries.length };
   } catch (err) {
-    throw new Error(`Failed to update threat feed: ${err instanceof Error ? err.message : String(err)}`);
+    // Ask the signal, not the error. fetch and the body stream report an abort
+    // with different names and wordings across runtimes; the signal is the one
+    // witness that says whether OUR deadline is what fired.
+    const message = signal.aborted
+      ? `HTTPS request timed out after ${timeoutMs}ms for ${feedUrl}`
+      : err instanceof Error
+        ? err.message
+        : String(err);
+    throw new Error(`Failed to update threat feed: ${message}`);
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/homeofe/supply-chain-guard/issues/170

## Summary

The remote threat feed was fetched with no deadline and no size cap. This bounds
both download paths, fails closed on every bound, and says so loudly.

**The issue names one function, and it is not the one the shipped CLI runs.**
`updateThreatFeed` is exported library API that no CLI subcommand calls. The
command the README documents, `supply-chain-guard feed refresh`, went through a
second, separate downloader in `src/feed.ts` that had the same two defects and no
backstop of any kind. Remediating only what the acceptance criteria name would
have closed this issue green with the shipped command unchanged, so both paths
are fixed here.

## Root cause

Not a forgotten timeout. This package already contained a purpose-built bounded
downloader, `src/remote-download.ts`, whose header reads "Bounded HTTPS retrieval
for untrusted registry metadata and artifacts". It already implements, item for
item, everything the issue asks for: an absolute deadline carried across
redirects, a socket inactivity backstop in addition, a `Content-Length` refusal
before any body is read, and a running byte cap while streaming. Three modules
already used it with the same house limits: `src/npm-scanner.ts`,
`src/pypi-scanner.ts` and `src/vscode-scanner.ts`.

The root cause is that registry acquisition was hardened behind that shared
module and feed acquisition was not. `updateThreatFeed` predates the module and
`httpsGetBody` was written beside it as a deliberately zero-dependency hand roll.
Neither was revisited when the bounded module landed, and nothing in the build
requires a new outbound request to go through it.

A contributing cause sits in the tests. `src/__tests__/feed.test.ts` mocks
`node:https` wholesale and delivered the whole body in one tick, so none of its
six `refreshFeed` tests could observe a stall. The suite passed around the defect
rather than over it.

## What changed

- **`src/threat-intel.ts`**: new `FEED_REMOTE_LIMITS` constant beside the
  existing cache constants: `maxBytes` 32 MiB, `timeoutMs` 30 s, `maxRedirects`
  5. The byte figure is roughly ten times the published feed; the other two are
  the values the registry scanners already use.
- **`src/feed.ts`**: `httpsGetBody` no longer hand-rolls a request. It calls
  `fetchHttpsBuffer` from `remote-download.ts`, so `feed refresh` inherits the
  absolute deadline, the `Content-Length` refusal, the streaming byte cap and the
  per-hop redirect revalidation. This also removes an adjacent defect in the same
  function: it did `data += chunk.toString()`, decoding each chunk separately, so
  a multi-byte UTF-8 sequence split across a chunk boundary became replacement
  characters. Bytes are now accumulated and decoded once.
- **`src/threat-intel.ts` `updateThreatFeed`**: keeps the global `fetch` and its
  quarantine-and-continue validation, and gains an `AbortSignal` deadline, a
  `Content-Length` refusal before the body is touched, and a running byte count
  while streaming instead of `response.json()`.
- Both entry points accept an optional per-call limit override and default to the
  constant. `FEED_REMOTE_LIMITS` is exported from the package index.
- **`src/__tests__/issue-170-feed-bounds.test.ts`**: new suite, 13 tests, driving
  a real loopback server rather than a mock.
- README documents the bounds where the feed commands are documented.

`src/remote-download.ts` itself is **unchanged**. It is in the diff nowhere; the
fix is that the feed path now uses it.

## Why an inactivity timeout would not have been a fix

Node's global `fetch` already has one, and it never fires against a peer that
keeps sending. The reproduction measured that directly: a totally silent peer was
terminated at 305 s by undici's body inactivity backstop, while a peer trickling
one byte every five seconds was still pending at 400 s. The `node:https` path had
no backstop at all. The deadline added here is absolute and spans DNS, connect,
headers and the body read. There is a test for exactly the trickling case, and a
mutation below proves that test discriminates the two.

---

# Evidence

## Implementing commits

Branch `fix/issue-170-feed-timeout-and-size-cap`, two commits:

- `7af53ffd1842a2d6832c4b07d42780b2bfd7b94b` fix(feed): bound both threat-feed
  downloads with a deadline and a byte cap
- `3ad6621a16f259821232059c106d70bf91fceb47` docs(handoff): record the feed
  acquisition bounds in STATUS.md and refresh the manifest

Governance gates run locally on the final tree, sequentially:

```
$ node scripts/check-aahp-pin.mjs
check:aahp-pin OK - @elvatis_com/aahp 3.9.2 resolves from node_modules, matching the exact pin.
PIN_EXIT=0

$ npx --no-install aahp check .
  PASS   changelog / changelog-format / version-sync / claims
  PASS   forbidden-patterns: 3 rule(s), no matches.
  PASS   schema-doc-sync / doc-links
Governance OK: 7 gate(s) ran, no failures.
AAHP_CHECK_EXIT=0

$ node scripts/generate-feed.mjs --check
feed.json up to date (12962 entries, v5.28.1).
FEED_CHECK_EXIT=0

$ node scripts/scg-handoff-docs.mjs --check
Handoff docs up to date: DASHBOARD.md, TRUST.md, LOG.md; MANIFEST.json in sync;
NEXT_ACTIONS.md current-version header matches package.json.
CHECK_EXIT=0
```

## Test evidence

New suite, and the two existing suites that cover the changed code. Per project
policy the full suite is left to Linux CI; only the affected files were run
locally.

```
$ npx vitest run src/__tests__/issue-170-feed-bounds.test.ts
 Test Files  1 passed (1)
      Tests  13 passed (13)
VITEST_EXIT=0

$ npx vitest run src/__tests__/feed.test.ts
 Test Files  1 passed (1)
      Tests  36 passed (36)
VITEST_EXIT=0

$ npx vitest run src/__tests__/issue-54-hardening.test.ts
 Test Files  1 passed (1)
      Tests  22 passed (22)
VITEST_EXIT=0

$ npx vitest run src/__tests__/remote-download.test.ts src/__tests__/threat-intel.test.ts
 Test Files  2 passed (2)
      Tests  26 passed (26)
VITEST_EXIT=0

$ npx tsc --noEmit
TSC_EXIT=0
```

**Existing assertions that were changed, and why.** Three, all in
`src/__tests__/feed.test.ts`, none weakened; each still asserts the same failure
mode with the shared downloader's wording. `network error: ...ENOTFOUND` became
`...ENOTFOUND`; `HTTP 404` became `failed with status 404`; the default-URL test
compared `https.get`'s first argument to a URL string and now reassembles it from
the `RequestOptions` the downloader passes. The mock helper also had to emit the
body on a later tick than the response callback, the way a socket does. It
previously emitted both in the same tick, which only worked because the old
reader attached its listeners synchronously inside that callback.

One assertion in `src/__tests__/issue-54-hardening.test.ts` changed: its `fetch`
stub was a two-property object with `ok` and `json`, which cannot be read as a
stream. It is now a real `Response`.

## Mutation proof

Each mutation was applied alone and reverted. Before every run the file was
re-read from disk and the mutated form counted and the original form counted,
so no run can report on a substitution that did not land. Steps are sequenced
independently, never chained on a previous step's exit code.

### M1: the feed path stops carrying bounds into the download

```
$ python3 mutate.py M1 apply
intended form present : 1 (expect 1)
other form present    : 0 (expect 0)
sha256: e2d62bc4ec5f909bc71552cf5e1283a34c928e0b1a91a0934da8c29188233530
MUTATE_EXIT=0
$ grep -n "MAX_SAFE_INTEGER, timeoutMs: 3_600_000" src/feed.ts
165:  const limits: RemoteRequestLimits = { maxBytes: Number.MAX_SAFE_INTEGER, timeoutMs: 3_600_000, maxRedirects: 5 };
$ grep -n "FEED_REMOTE_LIMITS, ...limitOverrides" src/feed.ts
(no output)

RED:
     x refreshFeed rejects a peer that sends headers and then stalls 6223ms
     x refreshFeed rejects a peer that trickles the body forever 6021ms
     x refreshFeed refuses a declared Content-Length over the cap before reading a byte 6008ms
     x refreshFeed refuses a chunked body that streams past the cap 8ms
     x refreshFeed applies the package default cap when no override is passed 6018ms
     x refreshFeed leaves an existing cache byte-identical when a bound fires 6012ms
      Tests  6 failed | 7 passed (13)
VITEST_EXIT=1
```

```
$ python3 mutate.py M1 restore
intended form present : 1 (expect 1)
other form present    : 0 (expect 0)
sha256: 0f273da348bc6a6c634497b8c4824c73b330e8aedad594191322c0eb200826a0
MUTATE_EXIT=0
$ grep -n "MAX_SAFE_INTEGER, timeoutMs: 3_600_000" src/feed.ts
(no output)
$ sha256sum src/feed.ts
0f273da348bc6a6c634497b8c4824c73b330e8aedad594191322c0eb200826a0   (matches the pre-mutation baseline)

GREEN:
 Test Files  1 passed (1)
      Tests  13 passed (13)
VITEST_EXIT=0
```

### M2: the legacy path keeps its size cap but loses its deadline

`AbortSignal.timeout(timeoutMs)` replaced by `new AbortController().signal`,
which never aborts.

```
$ python3 mutate.py M2 apply
intended form present : 1 (expect 1)
other form present    : 0 (expect 0)
sha256: a7ede9f74538f2800d336c50fe85122c028d1dec9fa53882472eef02f6380e9a
$ grep -n "new AbortController().signal" src/threat-intel.ts
13930:  const signal = new AbortController().signal;
$ grep -n "AbortSignal.timeout(timeoutMs)" src/threat-intel.ts
(no output)

RED:
     x updateThreatFeed rejects a peer that sends headers and then stalls 6021ms
     x updateThreatFeed rejects a peer that trickles the body forever 6018ms
      Tests  2 failed | 11 passed (13)
VITEST_EXIT=1
```

```
$ python3 mutate.py M2 restore
sha256: 40e1a6a47d9f05291925a2b2539bd054b76599771da0847ee9d7a3484c42ec26   (baseline)
$ grep -n "new AbortController().signal" src/threat-intel.ts
(no output)
$ grep -n "AbortSignal.timeout(timeoutMs)" src/threat-intel.ts
13930:  const signal = AbortSignal.timeout(timeoutMs);

GREEN:
 Test Files  1 passed (1)
      Tests  13 passed (13)
VITEST_EXIT=0
```

### M3a: the legacy path loses the declared-length refusal only

```
$ python3 mutate.py M3a apply
intended form present : 1 (expect 1)
other form present    : 0 (expect 0)
sha256: 47e72b62bba0c7834b0d70a9de58131443bb62659e6083e108e43c294757cd60
$ grep -n "if (false && declared !== null)" src/threat-intel.ts
13873:  if (false && declared !== null) {
$ grep -n "BigInt(declared) > BigInt(maxBytes)" src/threat-intel.ts
(no output)

RED:
     x updateThreatFeed refuses a declared Content-Length over the cap before reading a byte 6021ms
     x updateThreatFeed applies the package default cap when no override is passed 6017ms
      Tests  2 failed | 11 passed (13)
VITEST_EXIT=1

$ python3 mutate.py M3a restore
sha256: 40e1a6a47d9f05291925a2b2539bd054b76599771da0847ee9d7a3484c42ec26   (baseline)
$ grep -c "if (false && declared !== null)" src/threat-intel.ts
0
$ grep -c "BigInt(declared) > BigInt(maxBytes)" src/threat-intel.ts
1
```

### M3b: the legacy path loses the streaming byte cap only

```
$ python3 mutate.py M3b apply
intended form present : 1 (expect 1)
other form present    : 0 (expect 0)
sha256: 26216e90e54c512db43d5b282f139ebc42a7cb8a1d153878276c5ddfbf90bd77
$ grep -n "      if (false) {" src/threat-intel.ts
13891:      if (false) {
$ grep -c "bytes + value.byteLength > maxBytes" src/threat-intel.ts
0

RED:
     x updateThreatFeed refuses a chunked body that streams past the cap 15ms
      Tests  1 failed | 12 passed (13)
VITEST_EXIT=1
```

```
$ python3 mutate.py M3b restore
sha256: 40e1a6a47d9f05291925a2b2539bd054b76599771da0847ee9d7a3484c42ec26   (baseline)

GREEN:
 Test Files  1 passed (1)
      Tests  13 passed (13)
VITEST_EXIT=0
```

### M4: the discriminator, absolute deadline removed while the inactivity backstop stays

This is the mutation that matters, because an inactivity timer looks like a
working fix under a total-stall test. The absolute body deadline in
`src/remote-download.ts` was pushed out to an hour while the socket inactivity
backstop stayed at the configured timeout.

```
$ python3 mutate.py M4 apply
intended form present : 1 (expect 1)
other form present    : 0 (expect 0)
sha256: 1f345a2ab8afcbdd23337f7297854e5dd631f9e9a4ec86dd9b6f55cd15bf689c
$ grep -n -B2 "3_600_000" src/remote-download.ts
235-      response.destroy?.(error);
236-      finish(error);
237:    }, 3_600_000);
$ grep -n "request.setTimeout?.(timeoutMs" src/remote-download.ts
132:      request.setTimeout?.(timeoutMs, () => {      (the backstop is still there)

RED:
     x refreshFeed rejects a peer that sends headers and then stalls 442ms
     x refreshFeed rejects a peer that trickles the body forever 6019ms
     x refreshFeed leaves an existing cache byte-identical when a bound fires 411ms
      Tests  3 failed | 10 passed (13)
VITEST_EXIT=1
```

**Read the timings, not the colour.** The stalling peer was still cut off, at
442 ms, by the inactivity backstop alone. It reddens only because the message
degrades to a bare `aborted`:

```
+ Received: "Failed to refresh threat feed from https://127.0.0.1:22510/feed.json: aborted"
```

The trickling peer was **not cut off at all**: 6019 ms is the test's own horizon,
after which it reports `STILL PENDING: the call never settled`. That is the
difference the trickle test exists to catch, and it is the reason this fix is a
deadline rather than an inactivity timer. In the unmutated code the absolute
deadline always wins the race against the backstop, because the backstop is reset
by socket activity and therefore expires strictly later than the absolute
deadline, so the bare `aborted` wording is not reachable.

```
$ python3 mutate.py M4 restore
sha256: 3e5a05d0459f65f99671dcbb658fbb85bc70b581bc72a3a532f03f1cd8bbebfa   (baseline)
$ grep -n "3_600_000" src/remote-download.ts
(no output)
$ git diff --stat -- src/remote-download.ts
(empty: this file is not modified by this pull request)

GREEN:
 Test Files  1 passed (1)
      Tests  13 passed (13)
VITEST_EXIT=0
```

### Which line a reviewer deletes to redden each test

Written into the header of `src/__tests__/issue-170-feed-bounds.test.ts` so it
does not have to be rediscovered.

## Verification evidence: the original reproduction, re-run

The original reproduction drove the shipped CLI against a loopback HTTPS peer
that sends response headers and then stalls forever, and measured 120 seconds
with no output and no exit against 0.27 seconds for a healthy peer. That harness
was re-run unchanged against both trees, with the cap raised to 150 seconds.
Everything binds to 127.0.0.1 on an ephemeral port; no registry, real remote or
production endpoint is contacted.

**Before, at the commit the issue measures (`1a141fe`):**

```
[server] request received: headers sent, then stalling forever
[stall] verdict      : STILL RUNNING
[stall] wall clock   : 150.04s
[stall] exit code    : (none - killed at the cap)
[stall] stdout       : (empty)
[stall] stderr       : (empty)

[control] verdict      : EXITED
[control] wall clock   : 0.28s
[control] exit code    : 0
[control] stdout       :   Threat feed refreshed: 1 entries cached. | ...
```

**After, on this branch:**

```
[server] request received: headers sent, then stalling forever
[stall] verdict      : EXITED
[stall] wall clock   : 30.36s
[stall] exit code    : 1
[stall] stdout       : (empty)
[stall] stderr       :   Error: Failed to refresh threat feed from https://127.0.0.1:43837/feed.json: HTTPS request timed out after 29980ms for https://127.0.0.1:43837/feed.json

[control] verdict      : EXITED
[control] wall clock   : 0.49s
[control] exit code    : 0
[control] stdout       :   Threat feed refreshed: 1 entries cached. | ...
```

The hang no longer reproduces: the command fails closed at the stated deadline
with exit code 1 and one line naming the bound, and the healthy control is
unaffected.

**The size half of the reproduction, same harness shape, 64 MiB chunked body with
no `Content-Length`:**

```
BEFORE (1a141fe)
[size] served on the wire : 67,108,974 bytes
[size] wall clock         : 0.76s
[size] exit code          : 0
[size] stdout             :   Threat feed refreshed: 1 entries cached. | ...
[size] cache file written : 200 bytes

AFTER (this branch)
[size] served on the wire : 34,013,290 bytes
[size] wall clock         : 0.41s
[size] exit code          : 1
[size] stderr             :   Error: Failed to refresh threat feed from https://127.0.0.1:33193/feed.json: HTTPS response exceeded the 33554432-byte limit for https://127.0.0.1:33193/feed.json
[size] cache file written : 0 bytes
```

The peer stopped at 34,013,290 bytes because the client tore the connection down
at the 33,554,432-byte cap. Before, the full 64 MiB was accepted.

## What is deliberately not fixed here

- **`updateThreatFeed` was hardened in place rather than turned into a thin
  wrapper over `refreshFeed`.** The wrapper removes the second implementation
  instead of hardening it and is the better end state, but it is a behavioural
  change to exported, documented API: `parseFeedPayload` hard-rejects a bad entry
  where `updateThreatFeed` quarantines it and continues, and the error strings
  differ. That belongs in its own change with its own changelog entry, not
  smuggled in behind a timeout fix. Flagged for the maintainer to decide.
- **Nothing in the build enforces that the next outbound request goes through
  `remote-download.ts`.** That is the mechanism that let this happen, and a gate
  for it is a separate piece of work.
- **The acceptance criteria on the issue as written are satisfied by the
  `updateThreatFeed` half alone.** They need rewriting to name `src/feed.ts`
  `httpsGetBody` as well, or a future reader will conclude the CLI path was out
  of scope.
- **`src/github-trust-scanner.ts` is cited in the issue as evidence of a 50 MiB
  download cap.** It is not one; it is a detection rule reading a size out of
  release metadata about somebody else's artifact. `src/remote-download.ts` is
  the real evidence for that argument. No code change needed, noted so the
  citation is not carried forward.

## Severity note

The reproduction reads this as MEDIUM rather than the `priority: high` currently
on the issue, and the reasoning is worth recording: neither download is on the
scan path, the install path, the MCP path, the Action, or any workflow in this
repository. `loadThreatIntel` is synchronous and makes no network call, so a scan
cannot trigger this. Every failure mode degrades to the bundled feed, which is
the safe direction, so detection quality is never silently reduced. What keeps it
at MEDIUM rather than lower is that the hang on the shipped command is silent and
unbounded, and this is a security tool, so an unannounced dependency on a
stranger's liveness costs it more than it would an average package.

## CI note: the first run went red on a pre-existing flake, not on this change

The first run of `compat (Node 22)` failed with

```
FAIL src/__tests__/multi-line-pattern-engine.test.ts > matchPatternInContent
     > keeps exact greedy/lazy endpoints on 5 MiB repeated completions
Error: Test timed out in 15000ms.        (the test took 16625ms)
 Test Files  1 failed | 117 passed (118)
```

That was checked rather than assumed, because a red check on a security tool
is not something to wave through. The identical test, on the identical Node 22
leg, already fails on `main`:
https://github.com/homeofe/supply-chain-guard/actions/runs/32526691691, run on
2026-08-21 at 21:04, where it took 15137ms against the same 15000ms budget.
That run predates this branch. It is a wall-clock budget on a 5 MiB regex
benchmark that a slow runner leg misses; nothing in this change touches
`multi-line-pattern-engine.ts` or anything it imports.

The failed jobs were re-run and the whole run is green:

```
compat (Node 22)          success
compat (Node 20)          success
Docker build and smoke    success
Build and Test            success
aahp-verify               success
PR metadata policy        success
```

Worth flagging separately: a performance assertion with a fixed millisecond
budget on a shared runner will keep doing this, and it is not this pull
request's job to fix.

## Merge order note

https://github.com/homeofe/supply-chain-guard/pull/181 also touches
`src/feed.ts`, `src/index.ts`, `README.md`, `CHANGELOG.md` and the handoff
files, so whichever of the two lands second will need a rebase. Nothing was
changed on that pull request from here.

## Checklist

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Type check passes (`npm run lint`)
- [x] New tests added, and each one shown to fail when the code it covers is broken
- [x] Affected test files pass locally; the full suite is left to Linux CI
- [x] `.ai/handoff/STATUS.md` describes this change and `npm run handoff:refresh` has been run
- [x] No tool or model attribution in the commits, the title or this body
- [x] Measurement evidence above reports counts, sizes and timings only, no consumer repository names
