### PR TITLE
fix(policy): a policy-narrowed scan can no longer pass for a clean one (#168)

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.28.1 |
 | Node engines | >=22.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 118 under `src/__tests__/` |
+| Test files | 119 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,10 +11,10 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1b0b50a17bc818e59d1773fea20c421633d2e6ea1de520f92f33a0d259a17b6e",
+      "checksum": "sha256:f12f2012167ab5e4d66c1fafef5f16ffd30548bcf534f948a3287bcba922434e",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2727,
-      "summary": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump."
+      "lines": 2804,
+      "summary": "Model: claude-opus-5. Branch fix/issue-168-policy-visibility. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
@@ -41,14 +41,14 @@
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:92f74c0dbd4642a38054ab234012c679b8bbe4b21b44806cce01a217244fa39e",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:a3f5ac40cf40fa687ce694aac88db8946d763ef765d0c4cbc64ea2e3c242d49e",
+      "updated": "2026-08-22T13:37:51Z",
       "lines": 72,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:d5ba6fb28d49c8108c61da1a43e48c85805a5828578852395876c3b6ff5e8bf6",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:660c3678483ebc3b297f209d92edd692b38ecc11dbf8ffc0607c0e5943007a1c",
+      "updated": "2026-08-22T13:37:51Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Model: claude-opus-5. Branch fix/issue-168-policy-visibility. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 32959,
-    "full_read": 44621
+    "manifest_plus_core": 34314,
+    "full_read": 45976
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,83 @@
 
 ---
 
+## A policy-narrowed scan can no longer pass for a clean one (2026-08-22, unreleased)
+
+Model: claude-opus-5. Branch fix/issue-168-policy-visibility. No version bump.
+Issue: https://github.com/homeofe/supply-chain-guard/issues/168
+
+### What was actually wrong
+
+The issue's title is about the trust boundary: policy is read from the tree being
+scanned, so a proposed change can disable the rule that would flag it. That much
+is deliberate and unchanged here, because moving it is an owner decision.
+
+The defect that was fixed is the second one underneath it, and it is the reason
+the first one is dangerous rather than merely awkward: the narrowing was
+**silent**. Measured on a directory containing `eval(atob(...))`:
+
+- `rules.disable: [EVAL_ATOB]` took the scan from exit 2 with one critical to
+  exit 0 with none. `suppressedCount` reached 1, but nothing named the rule, and
+  the markdown report, which is the Action's default format and the body of the
+  pull request comment it posts by default, contained the word "suppress" zero
+  times.
+- `ignore: ["app.js"]` was quieter still. `ignore` prunes files before any rule
+  opens them, so `suppressedCount` stayed 0 and **all nine** output formats were
+  silent. Nothing distinguished that report from a genuinely clean one.
+
+The second variant is the severe one, and the issue mentions it only in passing.
+A fix that covered `rules.disable` alone would have passed its own tests while
+leaving the quieter path exactly as it was.
+
+### What changed
+
+- `ScanReport.policyEffect` carries the loaded config's effect as structured
+  metadata: config file, disabled rules, ignored globs, suppressed rules, each
+  with its written reason when one exists. Built by `describePolicyEffect()` in
+  `src/policy-engine.ts`, attached in `src/scanner.ts` next to the policy load.
+  It is `undefined` when the config narrows nothing, so its presence always means
+  something was switched off.
+- All nine formats render it: text, JSON, markdown, SARIF, SBOM, HTML, badge,
+  GitLab and JUnit. Markdown places it **above** the summary, because that is the
+  rendering a reviewer reads before deciding a green check means the change is
+  clean. SARIF carries it as a run-level notification plus
+  `invocations[0].properties`. The badge appends `(policy-narrowed)`, since
+  "clean" on a scan whose config removed a rule is the most misleading string
+  this tool can publish.
+- The v5.2.40 rule is intact and is asserted by a test: policy METADATA is
+  surfaced, suppressed FINDINGS still never enter SARIF, SBOM or GitLab.
+- `POLICY_DISABLE_NO_REASON` and `POLICY_IGNORE_NO_REASON` (medium) bring
+  `rules.disable` and `ignore` up to the audit bar `suppress` has met since v5.3.
+  Both sections now accept a reason-carrying mapping form alongside the list
+  form. Nothing is vetoed: the bare form still disables and still excludes, it is
+  simply reported as undocumented.
+- `README.md` and `action.yml` state where policy is read from and what that
+  means on a `pull_request` event. That was documented nowhere. The README also
+  corrects a `rules.disable` example written as a one-line flow sequence, a form
+  the parser reports as `POLICY_UNKNOWN_KEY` and which disables nothing.
+
+### Evidence
+
+`src/__tests__/issue-168-policy-visibility.test.ts`, 14 tests. The reproduction
+was re-run against a pristine build of the cited commit and against the fixed
+build, same fixtures, same commands: before, `ignore:` produced zero mentions in
+all nine formats; after, all nine name `app.js`, and the `rules.disable` fixture
+names `EVAL_ATOB` in all nine.
+
+Mutation proof: deleting only the `ignoredGlobs` half of `describePolicyEffect`
+leaves the `rules.disable` test green and reddens the `ignore` test, which is the
+mutation that would have caught a decorative fix.
+
+### Still open, and deliberately so
+
+The gate still exits 0 on both fixtures. Making the bypass **loud** is what this
+change does; making it **impossible** means giving the scanner a trusted policy
+source outside the scanned tree, which changes the tool's trust boundary and is
+recorded in the issue as needing the owner. `ScanOptions.policyFile` exists in
+the type and is read by nothing, which is where that work would start.
+
+---
+
 ## The required handoff gate compared main to itself on every push (2026-08-22, unreleased)
 
 Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump.

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.28.1 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 118 | src/__tests__/ file list |
+| Test files present | 119 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,39 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
   weaker and different claim than staleness being self-announcing. The README now
   states the distinction and what it costs when those pull requests are never
   merged.
+- **`README.md` and `action.yml` now state where the policy is read from.** It is
+  read from the directory being scanned and from nowhere else, which on a
+  `pull_request` event is the head of the proposing branch, so a change can ship a
+  config that narrows the scan of that same change. That property was documented
+  nowhere before. The README also lists the controls that hold when the proposer
+  is untrusted, and corrects a `rules.disable` example written as a flow sequence
+  on one line, a form the parser reports as `POLICY_UNKNOWN_KEY` and which
+  disables nothing.
+
+### Added
+
+- **Every scan report now names what the loaded policy switched off, in all nine
+  output formats** (`policyEffect` on `ScanReport`, rendered by `src/reporter.ts`
+  in text, JSON, markdown, SARIF, SBOM, HTML, badge, GitLab and JUnit). A config
+  in the scanned tree could remove the rule that would have failed the gate and
+  leave no trace a reader could find. Measured on a directory containing
+  `eval(atob(...))`: with `rules.disable: [EVAL_ATOB]` the scan went from exit 2
+  with one critical to exit 0 with none, `suppressedCount` reached 1 but never
+  named the rule, and the markdown report - the Action's default format and the
+  body of the pull request comment it posts - contained the word "suppress" zero
+  times. With `ignore: ["app.js"]` it was quieter still: `ignore` prunes files
+  before any rule opens them, so `suppressedCount` stayed 0 and every one of the
+  nine formats was silent. Both fixtures now name `EVAL_ATOB` and `app.js`
+  respectively in all nine. Policy METADATA is what is surfaced; suppressed
+  FINDINGS stay out of the machine formats, which is the separate v5.2.40 rule
+  and is unchanged.
+- **`POLICY_DISABLE_NO_REASON` and `POLICY_IGNORE_NO_REASON`** (medium), which
+  bring `rules.disable` and `ignore` up to the audit bar `suppress` has met since
+  v5.3. Both sections now accept a reason-carrying mapping form
+  (`EVAL_ATOB: why` and `"vendor/**": why`) alongside the existing list form; the
+  list form still disables and still excludes, it is simply reported as
+  undocumented. Nothing is vetoed: a narrowing without a written reason costs a
+  line in the report rather than nothing at all.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -290,9 +290,13 @@ Practically: the default gate exits non-zero on `critical` and `high` only, so *
 
 ```yaml
 rules:
-  disable: [INTERNAL_PRIVATE_IP, INTERNAL_HOSTNAME, INTERNAL_SERVICE_ENDPOINT,
-            INTERNAL_GIT_REMOTE, INTERNAL_DEV_PATH, INTERNAL_SINGLE_LABEL_URL]
+  disable:
+    INTERNAL_PRIVATE_IP: RFC1918 addresses are expected in this repository's fixtures
+    INTERNAL_HOSTNAME: internal names are already covered by a separate review
 ```
+
+The parser reads block style only; a flow sequence on one line
+(`disable: [A, B]`) is reported as `POLICY_UNKNOWN_KEY` and disables nothing.
 
 ### False-positive controls
 
@@ -431,9 +435,12 @@ Create `.supply-chain-guard.yml` in your project root to customize behavior:
 
 ```yaml
 rules:
+  # Every disabled rule needs a written reason, the same bar `suppress` has met
+  # since v5.3. The bare list form (`- HEX_ARRAY`) still disables the rule and is
+  # reported as POLICY_DISABLE_NO_REASON.
   disable:
-    - HEX_ARRAY
-    - CHARCODE_OBFUSCATION
+    HEX_ARRAY: minified vendor bundles in this repository, reviewed 2026-08
+    CHARCODE_OBFUSCATION: same bundles, same review
   severityOverrides:
     GHA_UNPINNED_ACTION: medium
 
@@ -451,10 +458,13 @@ allowlist:
     # says who publishes the code, not that every version of it is safe.
     - my-org
 
-# Skip files matched by these path globs (** / * / ?) during the scan.
+# Skip files matched by these path globs (** / * / ?) during the scan. These
+# files are never opened, so nothing about them reaches the report except the
+# policy block below. Each glob needs a written reason; the bare list form
+# (`- vendor/**`) still skips the path and is reported as POLICY_IGNORE_NO_REASON.
 ignore:
-  - vendor/**
-  - "**/*.min.js"
+  "vendor/**": third-party code, tracked by the upstream project's own scanning
+  "**/*.min.js": build output, scanned at source instead
 
 suppress:
   - rule: RELEASE_EXE_ARTIFACT
@@ -471,6 +481,37 @@ baseline:
 Findings can also be suppressed inline with a comment on the line directly
 above them: `// scg-ignore-next-line RULE reason` (JS/TS) or
 `# scg-ignore-next-line RULE` (Python/YAML/shell).
+
+### Where the policy is read from, and what that means on a pull request
+
+The policy file is read **from the directory being scanned**, and from nowhere
+else. There is no flag, environment variable or Action input that points the
+scanner at a policy outside the scan target.
+
+On a `pull_request` event the checkout materialises the **head of the proposing
+branch**, so the policy that governs the scan is the one on the branch under
+review, not the one on your default branch. A change that adds
+`.supply-chain-guard.yml` alongside the code it excuses is applying its own
+policy to itself. Anyone who can push a branch can therefore narrow the scan of
+that branch.
+
+That is a property of reading policy from the tree, and it is stated here rather
+than left to be discovered. What it is **not** is silent:
+
+- Every narrowing is named in the report, in **all nine output formats**,
+  including the markdown pull request comment the Action posts by default.
+  A scan narrowed by policy can no longer be mistaken for a clean scan in any
+  format, including `ignore:`, which removes files before any rule opens them
+  and used to leave no trace anywhere.
+- A narrowing declared without a written reason is reported as a finding
+  (`POLICY_DISABLE_NO_REASON`, `POLICY_IGNORE_NO_REASON`,
+  `POLICY_SUPPRESSION_NO_REASON`), so an undocumented exclusion costs a line in
+  the report rather than nothing.
+
+If your threat model includes an untrusted proposer, the controls that actually
+hold are outside this tool: require review on `.supply-chain-guard.yml` through
+`CODEOWNERS`, or scan a base-ref checkout in a separate job. Treat a policy file
+in a pull request diff as a change to your security gate, because it is one.
 
 ## Baseline Diffing (v4.4)
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,20 @@ branding:
   icon: "shield"
   color: "red"
 
+# POLICY SOURCE, stated because a consumer cannot see it from the inputs below.
+#
+# The scanner reads .supply-chain-guard.yml (or .yaml / .scg.yml / .scg.yaml)
+# from the DIRECTORY IT SCANS. There is no input here that points it anywhere
+# else. On a pull_request event the checkout is the HEAD of the proposing
+# branch, so the policy applied to the scan is the proposing branch's policy: a
+# change can ship a config that narrows the scan of that same change.
+#
+# It cannot do so silently. Every rule disabled, path ignored and rule
+# suppressed by the loaded config is named in the scan report in every output
+# format, including the markdown body of the pull request comment this Action
+# posts by default, and a narrowing with no written reason is reported as a
+# finding. See the "Where the policy is read from" section of the README for
+# the controls that apply when the proposer is untrusted.
 inputs:
   path:
     description: "Path to scan (defaults to repository root)"

--- a/policy-schema.json
+++ b/policy-schema.json
@@ -12,12 +12,27 @@
       "additionalProperties": false,
       "properties": {
         "disable": {
-          "description": "Rule ids to disable entirely. Disabled findings are dropped and counted as suppressed.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^[A-Z][A-Z0-9_]*$"
-          }
+          "description": "Rule ids to disable entirely. A disabled rule's findings are dropped from the report before they are counted, so every entry is named in the scan report's policy block in all nine output formats. Prefer the mapping form 'RULE_ID: <why>', which records the justification; the bare list form still works and is reported as POLICY_DISABLE_NO_REASON.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[A-Z][A-Z0-9_]*$"
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[A-Z][A-Z0-9_]*$": {
+                  "description": "Why this rule is switched off (audit trail).",
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          ]
         },
         "severityOverrides": {
           "description": "Map of rule id to the severity it should be reported with.",
@@ -81,9 +96,21 @@
       }
     },
     "ignore": {
-      "description": "Path globs (** / * / ?) whose matching files are skipped entirely by the scanner walk.",
-      "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "description": "Path globs (** / * / ?) whose matching files are skipped entirely by the scanner walk. Nothing about an ignored file reaches the report in any form, so every glob is named in the scan report's policy block in all nine output formats. Prefer the mapping form '<glob>: <why>', which records the justification; the bare list form still works and is reported as POLICY_IGNORE_NO_REASON.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "description": "Why this path is not scanned (audit trail).",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
     },
     "internalDisclosure": {
       "description": "Deny-list for the internal-disclosure rule family (INTERNAL_*). The built-in shape rules need none of this; this section is for names only your project knows. A list of internal hostnames committed to a public repository is itself the leak, so prefer hashedTerms (publishable) or externalFile (never published) over patterns.",

--- a/src/__tests__/issue-168-policy-visibility.test.ts
+++ b/src/__tests__/issue-168-policy-visibility.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Issue 168: a policy config in the scanned tree could remove the rule that
+ * would have failed the gate, and leave no trace a reader could find.
+ * https://github.com/homeofe/supply-chain-guard/issues/168
+ *
+ * Two independent silences were measured on the commit the issue cites:
+ *
+ *   rules.disable: [EVAL_ATOB]   critical 1 -> 0, exit 2 -> 0.
+ *                                suppressedCount reached 1, but nothing named
+ *                                the rule, and the markdown format - the
+ *                                Action default and the body of its pull
+ *                                request comment - said nothing at all.
+ *   ignore: ["app.js"]           critical 1 -> 0, exit 2 -> 0.
+ *                                suppressedCount stayed 0, because `ignore`
+ *                                prunes files before any rule opens them, so
+ *                                all nine output formats were silent.
+ *
+ * These tests hold the fix for both halves. The `ignore` half is the one that
+ * matters most: it is strictly quieter than `rules.disable`, and a fix that
+ * covers only `rules.disable` would pass a suite that omitted it while leaving
+ * the more severe variant exactly as silent as before.
+ *
+ * NOT tested here, because it is deliberately unchanged: policy is still read
+ * from the scanned tree, so the gate still exits 0 on these fixtures. Making
+ * that loud is what this change does; making it impossible is a trust-boundary
+ * decision recorded in the issue.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { scan } from "../scanner.js";
+import { formatReport } from "../reporter.js";
+import { describePolicyEffect, loadPolicyConfig, applyPolicy } from "../policy-engine.js";
+import type { Finding, ScanReport } from "../types.js";
+
+/** The payload every fixture trips: a critical EVAL_ATOB finding. */
+const PAYLOAD = "function boot(p) { return eval(atob(p)); }\nmodule.exports = { boot };\n";
+
+/** Every format the CLI and the Action can emit. */
+const ALL_FORMATS = [
+  "text",
+  "json",
+  "markdown",
+  "sarif",
+  "sbom",
+  "html",
+  "badge",
+  "gitlab",
+  "junit",
+] as const;
+
+describe("issue 168: a policy-narrowed scan is never indistinguishable from a clean one", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "scg-issue168-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /** Write the payload plus a policy config, and scan the result. */
+  async function scanWithPolicy(configYaml: string): Promise<ScanReport> {
+    fs.writeFileSync(path.join(tempDir, "app.js"), PAYLOAD);
+    fs.writeFileSync(path.join(tempDir, ".supply-chain-guard.yml"), configYaml);
+    return scan({ target: tempDir, format: "json", noHistory: true });
+  }
+
+  // ── The bypass itself is still real, which is what makes the rest matter ──
+
+  it("still removes the critical finding, so the report state is the only warning left", async () => {
+    fs.writeFileSync(path.join(tempDir, "app.js"), PAYLOAD);
+    const control = await scan({ target: tempDir, format: "json", noHistory: true });
+    expect(control.summary.critical).toBe(1);
+    expect(control.findings.map((f) => f.rule)).toContain("EVAL_ATOB");
+    // No config, so no policy block: its presence always means something was
+    // switched off, never "a config file happened to exist".
+    expect(control.policyEffect).toBeUndefined();
+
+    const disabled = await scanWithPolicy("rules:\n  disable:\n    - EVAL_ATOB\n");
+    expect(disabled.summary.critical).toBe(0);
+    expect(disabled.findings.map((f) => f.rule)).not.toContain("EVAL_ATOB");
+  });
+
+  // ── Report state: both halves ─────────────────────────────────────────────
+
+  it("names the disabled rule in the report, where only a count used to be", async () => {
+    const report = await scanWithPolicy("rules:\n  disable:\n    - EVAL_ATOB\n");
+
+    // Delete `policyEffect,` from the returned object in src/scanner.ts to redden this.
+    expect(report.policyEffect).toBeDefined();
+    expect(report.policyEffect?.configFile).toBe(".supply-chain-guard.yml");
+    expect(report.policyEffect?.disabledRules).toEqual([{ id: "EVAL_ATOB" }]);
+    expect(report.policyEffect?.ignoredGlobs).toEqual([]);
+  });
+
+  it("names the ignored glob, which never reached suppressedCount at all", async () => {
+    const report = await scanWithPolicy('ignore:\n  - "app.js"\n');
+
+    // The measurement that makes this the severe half: the count a reader
+    // might have pulled on is still zero, because the file was never opened.
+    expect(report.suppressedCount).toBeUndefined();
+    expect(report.summary.critical).toBe(0);
+
+    // Delete the `ignoredGlobs` line from describePolicyEffect to redden this.
+    expect(report.policyEffect?.ignoredGlobs).toEqual([{ id: "app.js" }]);
+    expect(report.policyEffect?.disabledRules).toEqual([]);
+  });
+
+  it("carries the written reason when the config supplies one, and no reason when it does not", async () => {
+    const withReason = await scanWithPolicy(
+      "rules:\n  disable:\n    EVAL_ATOB: vendored bundle, reviewed 2026-08\n",
+    );
+    expect(withReason.policyEffect?.disabledRules).toEqual([
+      { id: "EVAL_ATOB", reason: "vendored bundle, reviewed 2026-08" },
+    ]);
+    // The mapping form must still DISABLE, not merely document.
+    expect(withReason.summary.critical).toBe(0);
+
+    const withoutReason = await scanWithPolicy("rules:\n  disable:\n    - EVAL_ATOB\n");
+    expect(withoutReason.policyEffect?.disabledRules[0].reason).toBeUndefined();
+  });
+
+  it("does not present the suppress placeholder reason as a written justification", () => {
+    // The parser fills every suppress entry with a placeholder before a real
+    // `reason:` line can overwrite it. Reporting that placeholder to a reader
+    // would make an unaudited suppression read as an audited one.
+    fs.writeFileSync(
+      path.join(tempDir, ".supply-chain-guard.yml"),
+      "suppress:\n  - rule: EVAL_ATOB\n",
+    );
+    const policy = loadPolicyConfig(tempDir);
+    expect(policy?.suppress?.[0].reason).toBe("suppressed by policy");
+    expect(describePolicyEffect(policy!)?.suppressedRules).toEqual([{ id: "EVAL_ATOB" }]);
+  });
+
+  // ── Every output format, which is the claim the issue actually makes ──────
+
+  it("names the disabled rule in ALL NINE output formats", async () => {
+    const report = await scanWithPolicy("rules:\n  disable:\n    - EVAL_ATOB\n");
+
+    for (const format of ALL_FORMATS) {
+      const rendered = formatReport(report, format);
+      if (format === "badge") {
+        // A shield carries one short string; the qualifier is what fits.
+        expect(rendered, format).toContain("policy-narrowed");
+      } else {
+        expect(rendered, format).toContain("EVAL_ATOB");
+        expect(rendered.toLowerCase(), format).toContain("policy");
+      }
+    }
+  });
+
+  it("names the ignored path in ALL NINE output formats", async () => {
+    // THE MUTATION THAT CATCHES A DECORATIVE FIX. Remove only the `ignore`
+    // half of the policy metadata and leave `rules.disable` intact: the test
+    // above stays green and this one goes red. If both stay green, the fix has
+    // the same blind spot the original code had.
+    const report = await scanWithPolicy('ignore:\n  - "app.js"\n');
+
+    for (const format of ALL_FORMATS) {
+      const rendered = formatReport(report, format);
+      if (format === "badge") {
+        expect(rendered, format).toContain("policy-narrowed");
+      } else {
+        expect(rendered, format).toContain("app.js");
+        expect(rendered.toLowerCase(), format).toContain("policy");
+      }
+    }
+  });
+
+  it("puts the disabled rule in the markdown body a pull request reviewer reads", async () => {
+    // Asserted on the rendered string rather than on report state, because the
+    // markdown report IS the Action's default pull request comment, and it was
+    // the format with zero mentions of the word "suppress" before this change.
+    const report = await scanWithPolicy("rules:\n  disable:\n    - EVAL_ATOB\n");
+    const markdown = formatReport(report, "markdown");
+
+    expect(markdown).toContain("Policy in effect");
+    expect(markdown).toContain("EVAL_ATOB");
+    // Above the summary, so it cannot be scrolled past.
+    expect(markdown.indexOf("Policy in effect")).toBeLessThan(markdown.indexOf("### Summary"));
+  });
+
+  it("puts the policy effect in SARIF, where GitHub code scanning reads it", async () => {
+    const report = await scanWithPolicy('ignore:\n  - "app.js"\n');
+    const sarif = JSON.parse(formatReport(report, "sarif")) as {
+      runs: Array<{
+        invocations?: Array<{
+          executionSuccessful: boolean;
+          toolExecutionNotifications: Array<{ message: { text: string } }>;
+          properties?: { policyEffect?: { ignoredGlobs: Array<{ id: string }> } };
+        }>;
+      }>;
+    };
+
+    const invocation = sarif.runs[0].invocations?.[0];
+    expect(invocation).toBeDefined();
+    // A policy-narrowed scan still EXECUTED successfully; only partial coverage
+    // sets this false, and that distinction must survive the new notification.
+    expect(invocation?.executionSuccessful).toBe(true);
+    expect(invocation?.toolExecutionNotifications[0].message.text).toContain("app.js");
+    expect(invocation?.properties?.policyEffect?.ignoredGlobs).toEqual([{ id: "app.js" }]);
+  });
+
+  // ── Option C: a narrowing without a written reason is a finding ───────────
+
+  it("reports a bare rules.disable entry as POLICY_DISABLE_NO_REASON", async () => {
+    const bare = await scanWithPolicy("rules:\n  disable:\n    - EVAL_ATOB\n");
+    expect(bare.findings.map((f) => f.rule)).toContain("POLICY_DISABLE_NO_REASON");
+
+    const documented = await scanWithPolicy(
+      "rules:\n  disable:\n    EVAL_ATOB: vendored bundle, reviewed 2026-08\n",
+    );
+    expect(documented.findings.map((f) => f.rule)).not.toContain("POLICY_DISABLE_NO_REASON");
+  });
+
+  it("reports a bare ignore entry as POLICY_IGNORE_NO_REASON", async () => {
+    const bare = await scanWithPolicy('ignore:\n  - "app.js"\n');
+    expect(bare.findings.map((f) => f.rule)).toContain("POLICY_IGNORE_NO_REASON");
+
+    const documented = await scanWithPolicy(
+      'ignore:\n  "app.js": generated bundle, scanned at source instead\n',
+    );
+    expect(documented.findings.map((f) => f.rule)).not.toContain("POLICY_IGNORE_NO_REASON");
+    // The documented form must still EXCLUDE the file, or the reason would be
+    // buying an exemption the config no longer gets.
+    expect(documented.summary.critical).toBe(0);
+    expect(documented.policyEffect?.ignoredGlobs).toEqual([
+      { id: "app.js", reason: "generated bundle, scanned at source instead" },
+    ]);
+  });
+
+  it("holds rules.disable to the same bar suppress has met since v5.3", async () => {
+    // The contrast the issue leads with: suppress demanded a reason and warned
+    // without one; rules.disable demanded nothing while removing findings more
+    // completely. Both halves are asserted from the same fixture so neither can
+    // pass because of the other.
+    const report = await scanWithPolicy(
+      "rules:\n  disable:\n    - EVAL_ATOB\nsuppress:\n  - rule: HEX_ARRAY\n",
+    );
+    const rules = report.findings.map((f) => f.rule);
+    expect(rules).toContain("POLICY_DISABLE_NO_REASON");
+    expect(rules).toContain("POLICY_SUPPRESSION_NO_REASON");
+  });
+
+  // ── The v5.2.40 rule this fix must not break ──────────────────────────────
+
+  it("keeps suppressed FINDINGS out of machine output while surfacing policy METADATA", () => {
+    const suppressed: Finding = {
+      rule: "SUPPRESSED_RULE",
+      description: "policy-suppressed body text",
+      severity: "high",
+      file: "b.js",
+      recommendation: "fix",
+      suppressed: true,
+    };
+    const report: ScanReport = {
+      tool: "supply-chain-guard v5.28.1",
+      timestamp: "2026-08-22T10:00:00.000Z",
+      target: "fixture",
+      scanType: "directory",
+      durationMs: 1,
+      findings: [suppressed],
+      summary: { totalFiles: 1, filesScanned: 1, critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+      score: 0,
+      riskLevel: "clean",
+      recommendations: [],
+      policyEffect: {
+        configFile: ".supply-chain-guard.yml",
+        disabledRules: [],
+        ignoredGlobs: [],
+        suppressedRules: [{ id: "SUPPRESSED_RULE", reason: "reviewed tradeoff" }],
+      },
+    };
+
+    for (const format of ["sarif", "sbom", "gitlab"] as const) {
+      const rendered = formatReport(report, format);
+      // The policy block names the rule...
+      expect(rendered, format).toContain("SUPPRESSED_RULE");
+      // ...but the suppressed finding's own body never enters the document.
+      expect(rendered, format).not.toContain("policy-suppressed body text");
+    }
+  });
+
+  // ── The parser change, isolated from the scanner ──────────────────────────
+
+  it("accepts both the list and the mapping form for disable and ignore", () => {
+    fs.writeFileSync(
+      path.join(tempDir, ".supply-chain-guard.yml"),
+      [
+        "rules:",
+        "  disable:",
+        "    - HEX_ARRAY",
+        "    EVAL_ATOB: reviewed, vendored",
+        "ignore:",
+        '  - "dist/**"',
+        '  "vendor/**": upstream code',
+        "",
+      ].join("\n"),
+    );
+    const policy = loadPolicyConfig(tempDir);
+
+    expect(policy?.rules?.disable).toEqual(["HEX_ARRAY", "EVAL_ATOB"]);
+    expect(policy?.rules?.disableReasons).toEqual({ EVAL_ATOB: "reviewed, vendored" });
+    expect(policy?.ignore).toEqual(["dist/**", "vendor/**"]);
+    expect(policy?.ignoreReasons).toEqual({ "vendor/**": "upstream code" });
+
+    // Both forms must actually disable, not merely parse.
+    const findings: Finding[] = [
+      { rule: "HEX_ARRAY", description: "a", severity: "medium", recommendation: "fix" },
+      { rule: "EVAL_ATOB", description: "b", severity: "critical", recommendation: "fix" },
+    ];
+    const applied = applyPolicy(findings, policy!);
+    expect(applied.findings.filter((f) => !f.rule.startsWith("POLICY_"))).toHaveLength(0);
+
+    // Exactly one no-reason warning: the bare list entry in each section.
+    const warned = (policy?.warnings ?? []).map((w) => w.rule);
+    expect(warned.filter((r) => r === "POLICY_DISABLE_NO_REASON")).toHaveLength(1);
+    expect(warned.filter((r) => r === "POLICY_IGNORE_NO_REASON")).toHaveLength(1);
+  });
+});

--- a/src/__tests__/policy-engine.test.ts
+++ b/src/__tests__/policy-engine.test.ts
@@ -337,6 +337,29 @@ describe("Policy Engine", () => {
       expect(config!.suppress?.[0]).toMatchObject({ rule: "EVAL_ATOB", path: "vendor/**" });
       // Quoted glob must have its quotes stripped so it actually matches.
       expect(matchGlob(config!.ignore![1], "src/app.min.js")).toBe(true);
+      // v5.29 (issue 168): the bare list form still works and still excludes
+      // the path; it just cannot be audited, so each entry is reported. The
+      // suppress entry carries a reason and is therefore not reported.
+      expect((config!.warnings ?? []).map((w) => w.rule)).toEqual([
+        "POLICY_IGNORE_NO_REASON",
+        "POLICY_IGNORE_NO_REASON",
+      ]);
+    });
+
+    it("parses the reason-carrying mapping form for ignore without warning", () => {
+      fs.writeFileSync(path.join(tmpDir, ".supply-chain-guard.yml"), [
+        "ignore:",
+        "  vendor/**: upstream code, scanned by its own project",
+        '  "**/*.min.js": build output, scanned at source instead',
+      ].join("\n"));
+
+      const config = loadPolicyConfig(tmpDir);
+      expect(config!.ignore).toEqual(["vendor/**", "**/*.min.js"]);
+      expect(config!.ignoreReasons).toEqual({
+        "vendor/**": "upstream code, scanned by its own project",
+        "**/*.min.js": "build output, scanned at source instead",
+      });
+      expect(matchGlob(config!.ignore![1], "src/app.min.js")).toBe(true);
       expect(config!.warnings).toBeUndefined();
     });
   });
@@ -450,7 +473,10 @@ describe("Policy Engine", () => {
       const config = loadConfig([
         "rules:",
         "  disable:",
-        "    - HEX_ARRAY",
+        // v5.29 (issue 168): a valid config documents what it switches off.
+        // The bare list form still disables the rule and is reported as
+        // POLICY_DISABLE_NO_REASON, which is asserted separately below.
+        "    HEX_ARRAY: minified vendor bundles, reviewed",
         "  severityOverrides:",
         "    GHA_UNPINNED_ACTION: medium",
         "allowlist:",
@@ -467,8 +493,23 @@ describe("Policy Engine", () => {
         "  file: .scg-baseline.json",
       ]);
       expect(config.warnings).toBeUndefined();
+      expect(config.rules?.disable).toEqual(["HEX_ARRAY"]);
+      expect(config.rules?.disableReasons).toEqual({
+        HEX_ARRAY: "minified vendor bundles, reviewed",
+      });
       const result = applyPolicy([makeFinding("EVAL_ATOB", "critical")], config);
       expect(result.findings.some((f) => f.rule.startsWith("POLICY_"))).toBe(false);
+    });
+
+    it("reports an undocumented rules.disable entry, the audit gap suppress never had", () => {
+      const config = loadConfig(["rules:", "  disable:", "    - HEX_ARRAY"]);
+      expect((config.warnings ?? []).map((w) => w.rule)).toEqual([
+        "POLICY_DISABLE_NO_REASON",
+      ]);
+      // The rule is still disabled: the warning is an audit trail, not a veto.
+      const result = applyPolicy([makeFinding("HEX_ARRAY", "critical")], config);
+      expect(result.findings.some((f) => f.rule === "HEX_ARRAY")).toBe(false);
+      expect(result.findings.some((f) => f.rule === "POLICY_DISABLE_NO_REASON")).toBe(true);
     });
 
     it("should tolerate a leading yaml-language-server schema comment", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export { analyzePublishingAnomalies, evaluateVersionDrift, checkRegistryVersionD
 export { scanReleaseArtifacts } from "./release-scanner.js";
 export { correlateFindings } from "./correlation-engine.js";
 export { calculateTrustBreakdown } from "./trust-breakdown.js";
-export { loadPolicyConfig, applyPolicy, applyBaseline, saveBaseline } from "./policy-engine.js";
+export { loadPolicyConfig, applyPolicy, applyBaseline, describePolicyEffect, saveBaseline } from "./policy-engine.js";
 export { detectTrustSignals } from "./trust-signals.js";
 export { loadThreatIntel, updateThreatFeed, checkThreatIntel, matchPackageIOC, getBundledFeed } from "./threat-intel.js";
 export { feedStats, refreshFeed, parseFeedPayload, DEFAULT_FEED_URL } from "./feed.js";
@@ -132,6 +132,8 @@ export type {
   SolanaTransaction,
   PatternEntry,
   PolicyConfig,
+  PolicyEffect,
+  PolicyEffectEntry,
   InternalDisclosurePolicy,
   WatchlistEntry,
   WatchlistConfig,

--- a/src/policy-engine.ts
+++ b/src/policy-engine.ts
@@ -8,7 +8,14 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { Finding, PolicyConfig, PolicyWarning, Severity } from "./types.js";
+import type {
+  Finding,
+  PolicyConfig,
+  PolicyEffect,
+  PolicyEffectEntry,
+  PolicyWarning,
+  Severity,
+} from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Minimal glob matcher (no dependency; commander stays the only runtime dep)
@@ -70,6 +77,19 @@ const CONFIG_FILENAMES = [
 /**
  * Load policy config from the project directory.
  * Returns null if no config file found.
+ *
+ * TRUST BOUNDARY, stated here because the call site cannot state it: `dir` is
+ * the directory being SCANNED. Policy and artifact are therefore the same
+ * input, so on a pull_request event the config that governs the scan is the
+ * one on the proposing branch. That is a deliberate, documented property (see
+ * the "Where policy is read from" section of README.md and the `policy-source`
+ * note in action.yml), not an oversight, and changing it is an owner decision
+ * tracked in https://github.com/homeofe/supply-chain-guard/issues/168.
+ *
+ * What is NOT deliberate, and what this module now prevents, is the change
+ * being SILENT: every narrowing the config performs is recorded by
+ * describePolicyEffect() and rendered in every output format, and a narrowing
+ * declared without a written reason is reported as a finding.
  */
 export function loadPolicyConfig(dir: string): PolicyConfig | null {
   for (const filename of CONFIG_FILENAMES) {
@@ -79,6 +99,7 @@ export function loadPolicyConfig(dir: string): PolicyConfig | null {
     try {
       const content = fs.readFileSync(configPath, "utf-8");
       const config = parseYamlConfig(content);
+      config.sourceFile = filename;
       // Attach the config file name so warnings-turned-findings point at it
       if (config.warnings) {
         for (const warning of config.warnings) warning.file = filename;
@@ -116,6 +137,14 @@ const HASHED_TERM_PATTERN = /^(?:sha256:)?[0-9a-f]{64}$/i;
 
 /** Keys allowed inside a suppress entry */
 const SUPPRESS_ENTRY_KEYS = new Set(["rule", "reason", "path"]);
+
+/**
+ * Filled in for a suppress entry until a real `reason:` line overwrites it.
+ * Named rather than inlined because describePolicyEffect() has to tell a
+ * placeholder apart from a written justification: reporting this string to a
+ * reader as the reason a finding vanished would be worse than reporting none.
+ */
+const SUPPRESS_PLACEHOLDER_REASON = "suppressed by policy";
 
 /** Rule ids are SCREAMING_SNAKE_CASE (e.g. EVAL_ATOB, GHA_UNPINNED_ACTION) */
 const RULE_ID_PATTERN = /^[A-Z][A-Z0-9_]*$/;
@@ -192,6 +221,17 @@ function parseYamlConfig(content: string): PolicyConfig {
 
     // Sub-sections
     if (indent === 2 && trimmed.endsWith(":")) {
+      // `ignore:` takes globs, not sub-keys. A mapping key with an empty value
+      // ("dist/**:") is the reason-carrying form written without its reason, so
+      // record the glob and report the missing justification rather than
+      // reporting an "unknown key" the user never intended to write.
+      if (currentSection === "ignore") {
+        const glob = stripQuotes(trimmed.slice(0, -1));
+        config.ignore ??= [];
+        config.ignore.push(glob);
+        currentSubSection = "";
+        continue;
+      }
       currentSubSection = trimmed.slice(0, -1);
       if (sectionKnown && !KNOWN_SECTIONS[currentSection].includes(currentSubSection)) {
         if (currentSection === "suppress" && currentSubSection === "- rule") {
@@ -300,7 +340,7 @@ function parseYamlConfig(content: string): PolicyConfig {
           }
           config.suppress.push({
             rule: ruleId,
-            reason: "suppressed by policy",
+            reason: SUPPRESS_PLACEHOLDER_REASON,
           });
           reasonProvided.push(false);
         } else {
@@ -340,6 +380,29 @@ function parseYamlConfig(content: string): PolicyConfig {
         // so is what lets a missing salt be reported rather than look clean.
         config.internalDisclosure ??= {};
         config.internalDisclosure.hashSalted = /^(?:true|yes|1)$/i.test(stripQuotes(val));
+      } else if (currentSection === "rules" && currentSubSection === "disable") {
+        // Mapping form: `EVAL_ATOB: why this rule is off`. The list form
+        // (`- EVAL_ATOB`) stays supported and is handled with the other list
+        // items above; this branch is what lets a disable carry the same audit
+        // trail `suppress` has required since v5.3.
+        config.rules ??= {};
+        config.rules.disable ??= [];
+        config.rules.disable.push(k);
+        const reason = stripQuotes(val);
+        if (reason !== "") {
+          config.rules.disableReasons ??= {};
+          config.rules.disableReasons[k] = reason;
+        }
+      } else if (currentSection === "ignore" && currentSubSection === "") {
+        // Mapping form: `"dist/**": why these files are not scanned`.
+        const glob = stripQuotes(k);
+        config.ignore ??= [];
+        config.ignore.push(glob);
+        const reason = stripQuotes(val);
+        if (reason !== "") {
+          config.ignoreReasons ??= {};
+          config.ignoreReasons[glob] = reason;
+        }
       } else if (currentSection === "suppress" && SUPPRESS_ENTRY_KEYS.has(k)) {
         // Handle suppress reason/path on inline entries. ("rule:" continuation
         // lines are tolerated; entries are created by the "- rule:" item.)
@@ -374,6 +437,28 @@ function parseYamlConfig(content: string): PolicyConfig {
     }
   });
 
+  // v5.29 (issue 168): `rules.disable` and `ignore` are held to the same audit
+  // bar. Both remove findings from the report more completely than `suppress`
+  // does - `disable` drops them before they are counted, `ignore` prunes the
+  // files before any rule looks at them - so neither may be the one narrowing
+  // that needs no written justification.
+  for (const ruleId of config.rules?.disable ?? []) {
+    if (!config.rules?.disableReasons?.[ruleId]) {
+      warnings.push({
+        rule: "POLICY_DISABLE_NO_REASON",
+        message: `rules.disable entry "${ruleId}" has no reason; write it as "${ruleId}: <why>" so the disabled rule carries an audit trail`,
+      });
+    }
+  }
+  for (const glob of config.ignore ?? []) {
+    if (!config.ignoreReasons?.[glob]) {
+      warnings.push({
+        rule: "POLICY_IGNORE_NO_REASON",
+        message: `ignore entry "${glob}" has no reason; write it as "${glob}: <why>" so the unscanned path carries an audit trail`,
+      });
+    }
+  }
+
   if (warnings.length > 0) config.warnings = warnings;
   return config;
 }
@@ -402,6 +487,22 @@ const POLICY_WARNING_META: Record<
       "Policy suppression has no reason. Suppressions without a documented justification cannot be audited and tend to outlive the tradeoff that motivated them.",
     recommendation:
       "Add a \"reason:\" line to every suppress entry in .supply-chain-guard.yml.",
+  },
+  POLICY_DISABLE_NO_REASON: {
+    severity: "medium",
+    confidence: 1.0,
+    description:
+      "A rule is disabled with no documented reason. rules.disable removes that rule's findings from the report entirely - more completely than a suppression, which is at least recorded as suppressed - so an undocumented entry is an unaudited decision to stop looking, and it outlives whoever made it.",
+    recommendation:
+      "Write the entry as \"RULE_ID: <why>\" under rules.disable in .supply-chain-guard.yml. The bare list form (\"- RULE_ID\") still works and still disables the rule; it just cannot be audited.",
+  },
+  POLICY_IGNORE_NO_REASON: {
+    severity: "medium",
+    confidence: 1.0,
+    description:
+      "A path is excluded from the scan with no documented reason. ignore: prunes matching files before any rule opens them, so nothing about the excluded code reaches the report in any form - not a finding, not a suppression, not a count. An undocumented exclusion is the quietest way a scan can be narrowed.",
+    recommendation:
+      "Write the entry as \"<glob>: <why>\" under ignore: in .supply-chain-guard.yml. The bare list form (\"- <glob>\") still works and still excludes the path; it just cannot be audited.",
   },
   POLICY_MALFORMED_RULE_ID: {
     severity: "medium",
@@ -435,6 +536,48 @@ function policyWarningToFinding(warning: PolicyWarning): Finding {
     recommendation: meta.recommendation,
     confidence: meta.confidence,
     category: "config",
+  };
+}
+
+/**
+ * Describe what a loaded policy config removes from a scan (v5.29, issue 168).
+ *
+ * Returns undefined when the config narrows nothing, so a policy block present
+ * in a report always means something was turned off, and its absence is not an
+ * ambiguous "either nothing was disabled or nobody rendered it".
+ *
+ * Reasons come out only when they were actually written. A suppress entry the
+ * parser filled with SUPPRESS_PLACEHOLDER_REASON reports no reason at all,
+ * because presenting the placeholder as a justification would make an
+ * unaudited suppression read as an audited one.
+ */
+export function describePolicyEffect(policy: PolicyConfig): PolicyEffect | undefined {
+  const entry = (id: string, reason: string | undefined): PolicyEffectEntry =>
+    reason !== undefined && reason !== "" ? { id, reason } : { id };
+
+  const disabledRules = (policy.rules?.disable ?? []).map((id) =>
+    entry(id, policy.rules?.disableReasons?.[id]),
+  );
+  const ignoredGlobs = (policy.ignore ?? []).map((glob) =>
+    entry(glob, policy.ignoreReasons?.[glob]),
+  );
+  const suppressedRules = (policy.suppress ?? []).map((s) =>
+    entry(s.rule, s.reason === SUPPRESS_PLACEHOLDER_REASON ? undefined : s.reason),
+  );
+
+  if (
+    disabledRules.length === 0 &&
+    ignoredGlobs.length === 0 &&
+    suppressedRules.length === 0
+  ) {
+    return undefined;
+  }
+
+  return {
+    configFile: policy.sourceFile ?? CONFIG_FILENAMES[0],
+    disabledRules,
+    ignoredGlobs,
+    suppressedRules,
   };
 }
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -5,10 +5,62 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { Finding, ScanReport, Severity } from "./types.js";
+import type {
+  Finding,
+  PolicyEffect,
+  PolicyEffectEntry,
+  ScanReport,
+  Severity,
+} from "./types.js";
 
 const PARTIAL_SCAN_WARNING =
   "Scan incomplete: one or more configured checks or files could not be fully evaluated. No clean verdict can be established until coverage gaps are resolved.";
+
+/**
+ * v5.29 (issue 168). One sentence, rendered identically by all nine formats,
+ * so a reader who has met it in the CLI recognises it in a pull request
+ * comment, in SARIF, or in a GitLab report.
+ *
+ * The wording is the point. A narrowed scan and a clean scan produce the same
+ * empty finding list, and until this block existed nothing in markdown, SARIF,
+ * SBOM, GitLab, JUnit, HTML or the badge distinguished them. The `ignore:` form
+ * did not even increment suppressedCount, because it prunes files before any
+ * rule opens them, so the text format had nothing to print either.
+ */
+const POLICY_EFFECT_HEADLINE =
+  "Policy narrowed this scan. The rules and paths below produced no findings because the loaded config switched them off, not because the code was examined and found clean.";
+
+/** "EVAL_ATOB (no reason given)" or "EVAL_ATOB (reason as written)". */
+function policyEntryText(entry: PolicyEffectEntry): string {
+  return entry.reason ? `${entry.id} (${entry.reason})` : `${entry.id} (no reason given)`;
+}
+
+/**
+ * The non-empty groups, ordered by how completely each one hides code:
+ * `ignore` never opens the file, `rules.disable` drops the finding before it
+ * is counted, `suppress` at least records that something was removed.
+ */
+function policyEffectGroups(
+  effect: PolicyEffect,
+): Array<{ label: string; entries: PolicyEffectEntry[] }> {
+  return [
+    { label: "Paths not scanned (ignore)", entries: effect.ignoredGlobs },
+    { label: "Rules disabled (rules.disable)", entries: effect.disabledRules },
+    { label: "Rules suppressed (suppress)", entries: effect.suppressedRules },
+  ].filter((group) => group.entries.length > 0);
+}
+
+/**
+ * Single-line rendering for the formats that carry a string rather than a
+ * block: the SARIF notification, the GitLab scan message, the SBOM property
+ * and the JUnit testsuite property.
+ */
+function policyEffectLine(effect: PolicyEffect): string {
+  const parts = policyEffectGroups(effect).map(
+    (group) => `${group.label}: ${group.entries.map(policyEntryText).join(", ")}`,
+  );
+  return `${POLICY_EFFECT_HEADLINE} Config: ${effect.configFile}. ${parts.join(". ")}.`;
+}
 
 /** Default CLI gate semantics for a collection of findings. */
 export function getFindingsExitCode(
@@ -300,6 +352,24 @@ function formatText(report: ScanReport): string {
     lines.push("");
   }
 
+  // ── POLICY IN EFFECT ───────────────────────────────────────────────────────
+  // Deliberately outside the box: an entry carries a free-text reason of any
+  // length, and a wrapped reason must never be truncated to keep a border
+  // aligned. The whole purpose of this block is that nothing it names is lost.
+  if (report.policyEffect) {
+    const effect = report.policyEffect;
+    lines.push(`${BOLD}POLICY IN EFFECT${RESET}  ${DIM}${effect.configFile}${RESET}`);
+    for (const line of wrapText(POLICY_EFFECT_HEADLINE, W)) lines.push(line);
+    lines.push("");
+    for (const group of policyEffectGroups(effect)) {
+      lines.push(`  ${BOLD}${group.label}${RESET}`);
+      for (const entry of group.entries) {
+        lines.push(`    - ${policyEntryText(entry)}`);
+      }
+    }
+    lines.push("");
+  }
+
   // ── FINDINGS DETAIL ────────────────────────────────────────────────────────
   if (report.findings.length > 0) {
     const sorted = [...report.findings].sort(
@@ -508,6 +578,32 @@ function formatMarkdown(report: ScanReport): string {
   }
   lines.push("");
 
+  // Policy in effect (v5.29, issue 168). Placed ABOVE the summary on purpose:
+  // markdown is the Action's default format and the body of its pull request
+  // comment, so this is the one rendering a human reviewer actually reads
+  // before deciding a green check means the change is clean.
+  if (report.policyEffect) {
+    const effect = report.policyEffect;
+    lines.push("### ⚠️ Policy in effect");
+    lines.push("");
+    // The headline and the group labels are this module's own constants and are
+    // emitted verbatim. Everything that came out of the config file - rule ids,
+    // globs, reasons - goes through the escapers, because a policy file in a
+    // scanned tree is attacker-controlled input like any other scanned content.
+    lines.push(`> ${POLICY_EFFECT_HEADLINE}`);
+    lines.push(">");
+    lines.push(`> Loaded from \`${mdInlineCode(effect.configFile)}\` in the scanned tree.`);
+    lines.push("");
+    for (const group of policyEffectGroups(effect)) {
+      lines.push(`- **${group.label}:**`);
+      for (const entry of group.entries) {
+        const reason = entry.reason ? mdText(entry.reason) : "_no reason given_";
+        lines.push(`  - \`${mdInlineCode(entry.id)}\` ${reason}`);
+      }
+    }
+    lines.push("");
+  }
+
   // Summary
   lines.push("### Summary");
   lines.push("");
@@ -651,6 +747,39 @@ function formatSarif(report: ScanReport): string {
     results.push(result);
   }
 
+  // Run-level notifications. Partial coverage stays FIRST: it was the only
+  // notification before v5.29 and consumers index it positionally.
+  const notifications: Array<Record<string, unknown>> = [];
+  if (report.partialScan) {
+    notifications.push({
+      level: "warning",
+      message: { text: PARTIAL_SCAN_WARNING },
+    });
+  }
+  if (report.policyEffect) {
+    notifications.push({
+      level: "warning",
+      message: { text: policyEffectLine(report.policyEffect) },
+    });
+  }
+
+  // The v5.2.40 rule still holds: suppressed FINDINGS never enter machine
+  // output. What goes in here is policy METADATA - which rules and paths the
+  // config removed - which is the opposite of leaking a suppressed result and
+  // is the only way a SARIF consumer can tell a narrowed scan from a clean one.
+  const invocations =
+    notifications.length > 0
+      ? [
+          {
+            executionSuccessful: !report.partialScan,
+            toolExecutionNotifications: notifications,
+            ...(report.policyEffect
+              ? { properties: { policyEffect: report.policyEffect } }
+              : {}),
+          },
+        ]
+      : undefined;
+
   const sarif = {
     $schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
     version: "2.1.0" as const,
@@ -664,21 +793,7 @@ function formatSarif(report: ScanReport): string {
             rules,
           },
         },
-        ...(report.partialScan
-          ? {
-              invocations: [
-                {
-                  executionSuccessful: false,
-                  toolExecutionNotifications: [
-                    {
-                      level: "warning",
-                      message: { text: PARTIAL_SCAN_WARNING },
-                    },
-                  ],
-                },
-              ],
-            }
-          : {}),
+        ...(invocations ? { invocations } : {}),
         results,
       },
     ],
@@ -711,6 +826,20 @@ function formatSbom(report: ScanReport): string {
     name: "supply-chain-guard:scan-status",
     value: "partial",
   };
+  // CycloneDX metadata.properties is a name/value list, which is exactly the
+  // slot for "this document describes a deliberately narrowed scan" (v5.29).
+  const policyEffectProperties = report.policyEffect
+    ? [
+        {
+          name: "supply-chain-guard:policy-config",
+          value: report.policyEffect.configFile,
+        },
+        {
+          name: "supply-chain-guard:policy-effect",
+          value: policyEffectLine(report.policyEffect),
+        },
+      ]
+    : [];
 
   // v4.9: use the proper CycloneDX 1.6 document if available
   if (report.sbomDocument) {
@@ -720,11 +849,15 @@ function formatSbom(report: ScanReport): string {
     // Attach scan findings as vulnerabilities to the real SBOM
     const withVulns = {
       ...report.sbomDocument,
-      ...(report.partialScan
+      ...(report.partialScan || policyEffectProperties.length > 0
         ? {
             metadata: {
               ...metadata,
-              properties: [...(metadata.properties ?? []), partialScanProperty],
+              properties: [
+                ...(metadata.properties ?? []),
+                ...(report.partialScan ? [partialScanProperty] : []),
+                ...policyEffectProperties,
+              ],
             },
           }
         : {}),
@@ -764,7 +897,14 @@ function formatSbom(report: ScanReport): string {
         name: report.target,
         "bom-ref": "target",
       },
-      ...(report.partialScan ? { properties: [partialScanProperty] } : {}),
+      ...(report.partialScan || policyEffectProperties.length > 0
+        ? {
+            properties: [
+              ...(report.partialScan ? [partialScanProperty] : []),
+              ...policyEffectProperties,
+            ],
+          }
+        : {}),
     },
     components: [] as unknown[],
     vulnerabilities: report.findings.filter((f) => !f.suppressed).map((finding, idx) => ({
@@ -817,6 +957,14 @@ function formatBadge(report: ScanReport): string {
   } else {
     message = "clean";
     color = "brightgreen";
+  }
+  // v5.29 (issue 168): the badge is the most compressed reading of a report,
+  // and "clean" on a scan whose config removed a rule is the single most
+  // misleading string this tool can publish. The suffix is additive, so it
+  // qualifies a critical count exactly as it qualifies a clean one, and it can
+  // never make the badge look calmer than the gate it represents.
+  if (report.policyEffect) {
+    message = `${message} (policy-narrowed)`;
   }
   return JSON.stringify({
     schemaVersion: 1,
@@ -927,6 +1075,18 @@ function formatGitlab(report: ScanReport): string {
       start_time: gitlabTime(startMs),
       end_time: gitlabTime(startMs + (report.durationMs ?? 0)),
       status: report.partialScan ? ("failure" as const) : ("success" as const),
+      // scan.messages is the schema's own slot for analyzer-level notices
+      // (security-report-schemas v15.2.4: items require {level, value}, level in
+      // info|warn|fatal). A custom key would also validate, since the scan object
+      // does not set additionalProperties:false, but only this one is rendered by
+      // the GitLab security UI, and rendering is the entire point here.
+      ...(report.policyEffect
+        ? {
+            messages: [
+              { level: "warn" as const, value: policyEffectLine(report.policyEffect) },
+            ],
+          }
+        : {}),
     },
     vulnerabilities,
   };
@@ -971,6 +1131,19 @@ function formatJunit(report: ScanReport): string {
   lines.push(
     `<testsuite name="supply-chain-guard" tests="${testCount}" failures="${failureCount}" errors="${errorCount}" time="${timeSeconds}">`,
   );
+
+  // Run metadata belongs in <properties>, which every JUnit consumer renders
+  // and which leaves the tests/failures/errors counts untouched (v5.29).
+  if (report.policyEffect) {
+    lines.push("  <properties>");
+    lines.push(
+      `    <property name="supply-chain-guard:policy-config" value="${xmlEscape(report.policyEffect.configFile)}"/>`,
+    );
+    lines.push(
+      `    <property name="supply-chain-guard:policy-effect" value="${xmlEscape(policyEffectLine(report.policyEffect))}"/>`,
+    );
+    lines.push("  </properties>");
+  }
 
   if (report.partialScan) {
     lines.push('  <testcase name="SCAN_INCOMPLETE" classname="supply-chain-guard">');
@@ -1067,6 +1240,8 @@ header .meta{display:flex;gap:24px;flex-wrap:wrap;font-size:14px;opacity:0.85}
 .score-label{font-size:14px;color:#64748b}
 .score-level{font-size:20px;font-weight:600;text-transform:uppercase;color:${scoreColor}}
 .partial-warning{background:#fffbeb;border:1px solid #f59e0b;color:#92400e;padding:16px 20px;border-radius:10px;margin-bottom:24px}
+.policy-warning{background:#fffbeb;border:1px solid #f59e0b;color:#92400e;padding:16px 20px;border-radius:10px;margin-bottom:24px}
+.policy-warning ul{margin:8px 0 0 20px}
 .summary{display:flex;gap:12px;flex-wrap:wrap;margin-bottom:24px}
 .summary .chip{padding:8px 16px;border-radius:8px;font-weight:600;font-size:14px}
 .card{background:#fff;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,0.1);padding:24px;margin-bottom:24px}
@@ -1098,6 +1273,7 @@ footer{text-align:center;padding:24px;color:#94a3b8;font-size:13px}
   </header>
 
   ${report.partialScan ? `<div class="partial-warning"><strong>Scan incomplete.</strong> Coverage gaps prevented a complete verdict. Resolve skipped or unreadable files before treating this result as clean.</div>` : ""}
+  ${report.policyEffect ? `<div class="policy-warning"><strong>Policy in effect.</strong> ${escapeHtml(POLICY_EFFECT_HEADLINE)} Loaded from <code>${escapeHtml(report.policyEffect.configFile)}</code>.${policyEffectGroups(report.policyEffect).map((group) => `<ul><li>${escapeHtml(group.label)}: ${group.entries.map((entry) => escapeHtml(policyEntryText(entry))).join(", ")}</li></ul>`).join("")}</div>` : ""}
 
   <div class="score-card">
     <div>

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -78,7 +78,7 @@ import { analyzeInstallHooks, extractInstallScripts } from "./install-hook-scann
 import { analyzeDependencyRisks } from "./dependency-risk-analyzer.js";
 import { correlateFindings } from "./correlation-engine.js";
 import { calculateTrustBreakdown } from "./trust-breakdown.js";
-import { loadPolicyConfig, applyPolicy, applyBaseline, applyInlineSuppressions, matchGlob } from "./policy-engine.js";
+import { loadPolicyConfig, applyPolicy, applyBaseline, applyInlineSuppressions, describePolicyEffect, matchGlob } from "./policy-engine.js";
 import { detectTrustSignals } from "./trust-signals.js";
 import { loadThreatIntel, checkThreatIntel, isInertThreatFeedFile } from "./threat-intel.js";
 import { calculateRiskDimensions } from "./risk-engine.js";
@@ -299,6 +299,11 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
   // same object is reused for the suppression passes further down.
   const policy = loadPolicyConfig(scanDir);
   const ignoreGlobs = policy?.ignore ?? [];
+  // v5.29 (issue 168): record WHAT the config turns off, not just how many
+  // findings it removed. `ignore:` never reached suppressedCount at all, since
+  // it prunes files here, before any rule runs; a scan narrowed that way used
+  // to be indistinguishable from a clean one in every output format.
+  const policyEffect = policy ? describePolicyEffect(policy) : undefined;
 
   // Collect files (v4.5: diff mode filters to changed files only). Coverage
   // failures are held separately so policy.ignore can remove out-of-scope
@@ -829,6 +834,7 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
     incidents: correlation.incidents.length > 0 ? correlation.incidents : undefined,
     trustBreakdown,
     suppressedCount: suppressedCount > 0 ? suppressedCount : undefined,
+    policyEffect,
     partialScan: partialScan || undefined,
     riskDimensions: calculateRiskDimensions(filteredFindings),
     remediations: generateRemediations(filteredFindings),

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,11 @@ export interface ScanReport {
   trustBreakdown?: TrustBreakdown;
   /** Number of findings suppressed by policy/baseline (v4.4) */
   suppressedCount?: number;
+  /**
+   * What the loaded policy config turned off for this scan (v5.29).
+   * Present only when the config actually narrowed the scan.
+   */
+  policyEffect?: PolicyEffect;
   /** Whether scan completed fully (v4.4) */
   partialScan?: boolean;
   /** Threat timeline for forensics (v4.5) */
@@ -292,6 +297,13 @@ export interface ThreatIntelSource {
 export interface PolicyConfig {
   rules?: {
     disable?: string[];
+    /**
+     * Written justification per disabled rule id, from the mapping form
+     * `disable: { RULE_ID: "why" }` (v5.29). A rule id present in `disable`
+     * but absent here was declared without a reason, which is reported as
+     * POLICY_DISABLE_NO_REASON.
+     */
+    disableReasons?: Record<string, string>;
     severityOverrides?: Record<string, Severity>;
   };
   allowlist?: {
@@ -310,10 +322,22 @@ export interface PolicyConfig {
   };
   /** Path globs whose matching files are skipped by the scanner walk (v5.13). */
   ignore?: string[];
+  /**
+   * Written justification per ignore glob, from the mapping form
+   * `ignore: { "dist/**": "why" }` (v5.29). A glob present in `ignore` but
+   * absent here was declared without a reason: POLICY_IGNORE_NO_REASON.
+   */
+  ignoreReasons?: Record<string, string>;
   /** Internal-disclosure deny-list (see InternalDisclosurePolicy). */
   internalDisclosure?: InternalDisclosurePolicy;
   /** Validation problems collected while parsing (v5.3, fail-closed config validation) */
   warnings?: PolicyWarning[];
+  /**
+   * Basename of the config file this policy was parsed from, e.g.
+   * ".supply-chain-guard.yml" (set by loadPolicyConfig, v5.29). Reported so a
+   * reader can find the file that narrowed the scan.
+   */
+  sourceFile?: string;
 }
 
 /**
@@ -363,7 +387,9 @@ export type PolicyWarningRule =
   | "POLICY_UNKNOWN_KEY"
   | "POLICY_SUPPRESSION_NO_REASON"
   | "POLICY_MALFORMED_RULE_ID"
-  | "POLICY_INVALID_INTERNAL_TERM";
+  | "POLICY_INVALID_INTERNAL_TERM"
+  | "POLICY_DISABLE_NO_REASON"
+  | "POLICY_IGNORE_NO_REASON";
 
 /**
  * A problem found while parsing .supply-chain-guard.yml (v5.3).
@@ -381,6 +407,43 @@ export interface PolicyWarning {
   line?: number;
   /** Config file name, e.g. ".supply-chain-guard.yml" (set by loadPolicyConfig) */
   file?: string;
+}
+
+/**
+ * One thing a policy config switched off: a rule id, or a path glob, with the
+ * written justification when the config supplied one (v5.29).
+ */
+export interface PolicyEffectEntry {
+  /** Rule id, or path glob for `ignoredGlobs` */
+  id: string;
+  /** Written justification from the config; absent when none was given */
+  reason?: string;
+}
+
+/**
+ * The effective policy for a scan: what the loaded config removed from the
+ * result, named rather than counted (v5.29, issue 168).
+ *
+ * `suppressedCount` alone could not answer the only question that matters when
+ * a report comes back clean: WHAT was turned off. A count of 1 reads the same
+ * whether a noisy informational rule or the critical rule that would have
+ * failed the gate was disabled, and the `ignore:` form produced no count at
+ * all because it prunes files before any rule runs. Every output format
+ * renders this block, so a narrowed scan can no longer be mistaken for a clean
+ * one in whichever format the reader happens to be looking at.
+ *
+ * This carries policy METADATA only. Suppressed FINDINGS stay out of the
+ * machine formats, which is the separate and still-standing v5.2.40 rule.
+ */
+export interface PolicyEffect {
+  /** Config file the policy was read from, e.g. ".supply-chain-guard.yml" */
+  configFile: string;
+  /** Rule ids switched off by `rules.disable`: their findings never appear */
+  disabledRules: PolicyEffectEntry[];
+  /** Path globs under `ignore:`: matching files are never opened */
+  ignoredGlobs: PolicyEffectEntry[];
+  /** Rule ids named by `suppress` entries */
+  suppressedRules: PolicyEffectEntry[];
 }
 
 export interface ScanSummary {


### PR DESCRIPTION
# fix(policy): a policy-narrowed scan can no longer pass for a clean one (#168)

Resolves #168.

## Summary

When a `.supply-chain-guard.yml` in the scanned repository disables a rule (e.g. `EVAL_ATOB`) or ignores a path (e.g. `app.js`), the scan no longer silently passes as a clean report.

1. **Policy effect disclosure:** The scan report captures `policyEffect` (`configFile`, `disabledRules`, `ignoredGlobs`, `suppressedRules`) and surfaces it loudly across all nine formats: text, markdown, JSON, SARIF, SBOM, HTML, badge, GitLab, and JUnit.
2. **Policy warnings:** Disabling rules or ignoring paths without a documented reason raises `POLICY_DISABLE_NO_REASON` and `POLICY_IGNORE_NO_REASON` (medium severity).
3. **Badge qualification:** A scan whose policy narrows rules or paths renders `(policy-narrowed)` on the badge.

## Acceptance criteria

- [x] 1. Policy loading strategy resolved: policy is loaded from the scanned tree with full policy effect disclosure (`policyEffect`) surfaced across all 9 report formats, and `action.yml` explicitly documents this operating boundary.
- [x] 2. A fixture whose config disables a rule that the same fixture trips no longer produces a silent clean report; the mechanism is exercised by tests that fail if removed.
- [x] 3. The scan report surfaces the set of rules disabled by the loaded policy, not only the suppressed count, in all nine formats (including `ignore:`).
- [x] 4. `action.yml` documents whether the policy is read from the head or the base of a pull request.
