### PR TITLE
fix(governance): the em-dash rule scanned a file set that held none of them

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.28.1 |
 | Node engines | >=22.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 118 under `src/__tests__/` |
+| Test files | 119 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -132,15 +132,15 @@ This generated journal lists every release derived from CHANGELOG.md, newest fir
 | v5.2.6 | 2026-05-08 | Threat intel: CanisterSprawl, BufferZoneCorp, MacSync, EtherRAT (May 2026) |
 | v5.2.5 | 2026-05-01 | Threat intel: Mini Shai-Hulud / TeamPCP supply chain worm (April 2026) |
 | v5.2.4 | 2026-04-30 | Threat intel: DPRK @validate-sdk/v2 + LofyGang / LofyStealer (April 2026) |
-| v5.2.3 | 2026-04-26 | Documentation catch-up  bumps version strings in src/cli.ts, src/reporter.ts (text header, SARIF, SBOM, HTML footer)... |
-| v5.2.2 | 2026-04-26 | Solana monitor: rate-limit-aware RPC client  closes [#21](https://github.com/homeofe/supply-chain-guard/issues/21). |
+| v5.2.3 | 2026-04-26 | Documentation catch-up - bumps version strings in src/cli.ts, src/reporter.ts (text header, SARIF, SBOM, HTML footer)... |
+| v5.2.2 | 2026-04-26 | Solana monitor: rate-limit-aware RPC client - closes [#21](https://github.com/homeofe/supply-chain-guard/issues/21). |
 | v5.2.1 | 2026-04-26 | Threat intel: Checkmarx KICS / Bitwarden CLI supply-chain breach (April 2026) |
-| v5.2.0 | 2026-04-08 | Self-Scan Clean + Text Wrapping  the scanner no longer flags its own source code. Scanning supply-chain-guard itself... |
+| v5.2.0 | 2026-04-08 | Self-Scan Clean + Text Wrapping - the scanner no longer flags its own source code. Scanning supply-chain-guard itself... |
 | v5.1.1 | 2026-04-07 | CI and test fixes |
-| v5.1.0 | 2026-04-07 | Comprehensive ASCII CLI output  complete redesign of the default text reporter. |
-| v5.0.1 | 2026-04-07 | False positive fixes  second pass after live workspace testing revealed additional FPs. |
-| v5.0.0 | 2026-04-07 | Context-Aware False Positive Elimination  workspace-wide scan of 100k+ LOC across 15 projects identified 14 systemati... |
-| v4.9.0 | 2026-04-07 | New: SBOM Generator  reads package-lock.json (v2+) to generate CycloneDX 1.6 SBOMs with real components[] (name, vers... |
+| v5.1.0 | 2026-04-07 | Comprehensive ASCII CLI output - complete redesign of the default text reporter. |
+| v5.0.1 | 2026-04-07 | False positive fixes - second pass after live workspace testing revealed additional FPs. |
+| v5.0.0 | 2026-04-07 | Context-Aware False Positive Elimination - workspace-wide scan of 100k+ LOC across 15 projects identified 14 systemat... |
+| v4.9.0 | 2026-04-07 | New: SBOM Generator - reads package-lock.json (v2+) to generate CycloneDX 1.6 SBOMs with real components[] (name, ver... |
 | v4.8.0 | 2026-04-04 | New: Continuous Risk Monitor -- persistent risk history, trend detection (spikes, stagnation, increasing) |
 | v4.7.0 | 2026-04-04 | New: Attack Graph Engine -- models relationships between repos, packages, workflows, secrets, IOCs as directed graphs... |
 | v4.6.0 | 2026-04-04 | New: Remediation Engine -- concrete, prioritized fix steps for every finding |

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,10 +11,10 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1b0b50a17bc818e59d1773fea20c421633d2e6ea1de520f92f33a0d259a17b6e",
+      "checksum": "sha256:6488b0cab2ca8e2404d24d7fb091524458f9f47e585ff6cdcf88b325a139ef54",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2727,
-      "summary": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump."
+      "lines": 2803,
+      "summary": "Model: claude-opus-5. Branch fix/em-dash-rule-scope. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
@@ -23,8 +23,8 @@
       "summary": "Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
-      "checksum": "sha256:931be02f873b962f89ee315b82902c481d1e8517cb624ad48a61aa43ce10b31a",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:e252fc47df0aa168016d38515a438b5799940181146e839553dfd3f06ce04180",
+      "updated": "2026-08-22T15:30:33Z",
       "lines": 156,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -41,14 +41,14 @@
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:92f74c0dbd4642a38054ab234012c679b8bbe4b21b44806cce01a217244fa39e",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:a3f5ac40cf40fa687ce694aac88db8946d763ef765d0c4cbc64ea2e3c242d49e",
+      "updated": "2026-08-22T15:30:33Z",
       "lines": 72,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:d5ba6fb28d49c8108c61da1a43e48c85805a5828578852395876c3b6ff5e8bf6",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:660c3678483ebc3b297f209d92edd692b38ecc11dbf8ffc0607c0e5943007a1c",
+      "updated": "2026-08-22T15:30:33Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Model: claude-opus-5. Branch fix/em-dash-rule-scope. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 32959,
-    "full_read": 44621
+    "manifest_plus_core": 34383,
+    "full_read": 46054
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,82 @@
 
 ---
 
+## The em-dash rule was enforced on a set of files that held none of them (2026-08-22, unreleased)
+
+Model: claude-opus-5. Branch fix/em-dash-rule-scope. No version bump.
+
+An audit reported 77 em dashes across 17 files "with no check enforcing the
+rule". Half of that was wrong in a way worth keeping: a check did exist, it ran
+on every pull request, and it sat inside a required status check. It was green,
+truthfully, because the `em-dash` rule's `include` list named six pathspecs and
+those six matched none of the 17 files. The gate answered the question it was
+asked. Nobody had noticed the question had drifted away from the rule.
+
+### What was actually wrong
+
+Three things, in the order they matter.
+
+1. **Opt-in scope fails open.** Every file created after the rule was written
+   was outside it by default, silently. The `include` list is now the single
+   pathspec `*`, so a file is covered the moment git tracks it and the only way
+   out is a reviewed entry.
+2. **A config line read like a mechanism and was not one.** `exclude` held
+   `CHANGELOG.md`, which every reader took for the reason the changelog went
+   unchecked. It was inert: a non-empty `include` REPLACES the gate's default
+   file set, so `CHANGELOG.md` was never in scope for `exclude` to remove.
+   Deleting that line alone changed nothing, which was verified before it was
+   removed.
+3. **The only written statement of the rule was the gate's own `message`
+   field**, and it said "banned in docs". Under that wording the 49 source
+   occurrences were not violations at all. `CONTRIBUTING.md` now carries the
+   scope, and the two narrower scopes that were rejected, with the reason for
+   each.
+
+### The scope decision, and why the other two were rejected
+
+Documentation only was rejected because the one occurrence with measurable reach
+outside this project was not in documentation: it is in `src/slsa-verifier.ts`,
+in the sentence a scan prints for a project with no build script, and it lands
+in the SARIF report adopters upload to GitHub code scanning. Documentation plus
+emitted strings was rejected because no gate can express it, so the rule would
+have gone back to being a review convention, which is the state that let the 77
+accumulate. Every tracked file was chosen because it is the only one of the
+three a gate can decide.
+
+### The second gate, and what it deliberately is not
+
+`scripts/check-em-dash-scope.mjs` runs inside `check:aahp`, before the AAHP
+gates. It never reads file content and never searches for U+2014. There is still
+exactly one em-dash rule and it lives in `aahp.config.json`. The script answers
+the question that rule cannot ask about itself: does its scope still cover the
+repository? It exits 1 when a tracked file is uncovered and unexplained, and 2
+when it cannot determine the answer at all, which includes a pathspec that
+matches nothing and an `exclude` entry that subtracts nothing.
+
+Two files are exempt, each with its reason in `SCOPE_EXCEPTIONS`: the binary
+demo GIF, because a chance byte sequence in compressed image data is not prose,
+and the handoff archive, because its own header declares its entries preserved
+verbatim. Both hold zero occurrences today, so both preserve rather than
+suppress.
+
+### Assumption recorded, so it is not re-derived
+
+The handoff-archive exemption rests on an inference, not on a written policy:
+the file states it is append-only with older entries "preserved below verbatim",
+and that is read as a reason not to rewrite them. The inference is written next
+to the exemption. Anyone who disagrees deletes the `SCOPE_EXCEPTIONS` entry and
+the matching `exclude` line together, and the file is simply covered.
+
+### Open for the owner
+
+Nothing blocks this change. One item is deliberately left out of it: the AAHP
+CLI gate reads each file inside `try { readFileSync } catch { continue }`, so a
+file it cannot read is skipped in silence rather than failing. That is the same
+fail-open class, it ships to every consumer of the governance CLI, and it is not
+this repository's file to fix. It belongs upstream as its own piece of work.
+
+---
+
 ## The required handoff gate compared main to itself on every push (2026-08-22, unreleased)
 
 Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump.

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.28.1 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 118 | src/__tests__/ file list |
+| Test files present | 119 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ### Changed
 
+- **The `em-dash` governance rule now covers every tracked file, and a second
+  gate keeps it that way.** The rule's `include` list named six pathspecs, and
+  those six matched none of the 17 files that carried an em dash, so
+  `forbidden-patterns` reported `no matches` and exited 0 on every pull request
+  while 77 occurrences sat in the tree, 28 of them in `CHANGELOG.md`. Scope is
+  now the single pathspec `*`, which makes it opt-out: a new file is covered the
+  moment git tracks it. All 77 occurrences are corrected, every one a
+  space-delimited em dash replaced by a hyphen with no wording changed,
+  including the eleven inside strings the CLI prints and the one that reached
+  the SARIF report adopters upload to GitHub code scanning.
+  `scripts/check-em-dash-scope.mjs`, run by `check:aahp` and therefore inside
+  the required `Build and Test` check, fails the build if the include list is
+  narrowed that way again, if an `exclude` entry subtracts nothing (the state
+  the inert `CHANGELOG.md` entry was in), or if an exemption loses its written
+  reason. It never reads file content: `aahp.config.json` remains the only
+  em-dash rule. The scope decision and the two narrower options that were
+  rejected are recorded in `CONTRIBUTING.md`. Reported in
+  <https://github.com/homeofe/supply-chain-guard/issues/178>.
 - **Benchmark evidence in this project's own artefacts now carries counts, never
   consumer repository names.** Two `CHANGELOG.md` entries (v5.2.40, v5.2.41) cited
   a private repository and an internal issue number as the provenance of a security
@@ -3525,15 +3543,15 @@ Two fresh May 2026 supply-chain campaigns are now signatured.
 
 Two fresh April 2026 supply-chain campaigns are now signatured.
 
-- **DPRK AI-inserted npm malware** — `@validate-sdk/v2` was inserted into a victim project as a dependency by the Claude Opus LLM during a social-engineering operation attributed to North Korean actors. New rule `DPRK_VALIDATE_SDK` in `src/patterns.ts` plus a `MALICIOUS_PACKAGE_PATTERNS` entry, a bundled threat-intel `package` IOC, and a recommendation to audit AI-suggested dependencies.
-- **LofyGang / LofyStealer (aka GrabBot)** — Brazilian crew resurfaces after three years targeting Minecraft players with a new infostealer disguised as Minecraft hacks. New rules `LOFYSTEALER_MARKER` and `LOFYGANG_MINECRAFT_LURE` in `src/patterns.ts`, plus threat-intel `package` IOCs for the family aliases.
+- **DPRK AI-inserted npm malware** - `@validate-sdk/v2` was inserted into a victim project as a dependency by the Claude Opus LLM during a social-engineering operation attributed to North Korean actors. New rule `DPRK_VALIDATE_SDK` in `src/patterns.ts` plus a `MALICIOUS_PACKAGE_PATTERNS` entry, a bundled threat-intel `package` IOC, and a recommendation to audit AI-suggested dependencies.
+- **LofyGang / LofyStealer (aka GrabBot)** - Brazilian crew resurfaces after three years targeting Minecraft players with a new infostealer disguised as Minecraft hacks. New rules `LOFYSTEALER_MARKER` and `LOFYGANG_MINECRAFT_LURE` in `src/patterns.ts`, plus threat-intel `package` IOCs for the family aliases.
 - 5 new tests in `src/__tests__/campaigns.test.ts`.
 
 ## [5.2.3] - 2026-04-26
-**Documentation catch-up** — bumps version strings in `src/cli.ts`, `src/reporter.ts` (text header, SARIF, SBOM, HTML footer) that were stuck at `5.2.0` / `5.1.0` since the v5.2.1 and v5.2.2 releases. No behavior change.
+**Documentation catch-up** - bumps version strings in `src/cli.ts`, `src/reporter.ts` (text header, SARIF, SBOM, HTML footer) that were stuck at `5.2.0` / `5.1.0` since the v5.2.1 and v5.2.2 releases. No behavior change.
 
 ## [5.2.2] - 2026-04-26
-**Solana monitor: rate-limit-aware RPC client** — closes [#21](https://github.com/homeofe/supply-chain-guard/issues/21).
+**Solana monitor: rate-limit-aware RPC client** - closes [#21](https://github.com/homeofe/supply-chain-guard/issues/21).
 
 The public Solana RPC (`api[.]mainnet-beta[.]solana[.]com`) returns HTTP 429 and JSON-RPC error `-32005` when its per-IP quota is exceeded. Previously the monitor surfaced these as fatal poll errors and skipped the interval. Now `solanaRpc()` retries with exponential backoff and recovers automatically.
 
@@ -3552,18 +3570,18 @@ A single threat actor (claiming "TeamPCP") compromised both the Checkmarx KICS D
 - **C2 IPs**: `94[.]154[.]172[.]43`, `91[.]195[.]240[.]123`
 - **Compromised package**: `@bitwarden/cli@2026.4.0`
 - **New campaign rules** in `src/patterns.ts`:
-  - `CHECKMARX_SHAI_HULUD_V3` — matches the `Shai-Hulud: The Third Coming` exfil marker string
-  - `CHECKMARX_MCP_ADDON` — matches the `mcpAddon.js` loader filename
-  - `BITWARDEN_CLI_LOADER` — matches `bw_setup.js` / `bw1.js` loader/payload pair
+  - `CHECKMARX_SHAI_HULUD_V3` - matches the `Shai-Hulud: The Third Coming` exfil marker string
+  - `CHECKMARX_MCP_ADDON` - matches the `mcpAddon.js` loader filename
+  - `BITWARDEN_CLI_LOADER` - matches `bw_setup.js` / `bw1.js` loader/payload pair
 - 4 new tests in `src/__tests__/campaigns.test.ts`
 
 ## [5.2.0] - 2026-04-08
-**Self-Scan Clean + Text Wrapping** — the scanner no longer flags its own source code. Scanning `supply-chain-guard` itself drops from 100/critical (243 critical + 137 high) to clean.
+**Self-Scan Clean + Text Wrapping** - the scanner no longer flags its own source code. Scanning `supply-chain-guard` itself drops from 100/critical (243 critical + 137 high) to clean.
 
 **Scanner source exclusion** (`src/scanner.ts`):
 - New shared `SCANNER_SOURCE_FILE` and `TEST_FILE_REGEX` constants replace duplicated inline regexes
-- `checkIOCBlocklist()` and `checkThreatIntel()` now skip scanner definition files and test files — eliminates ~50 IOC/threat-intel self-matches
-- `checkMultiLineProtestware()` skips scanner source and test files — eliminates proximity false positives
+- `checkIOCBlocklist()` and `checkThreatIntel()` now skip scanner definition files and test files - eliminates ~50 IOC/threat-intel self-matches
+- `checkMultiLineProtestware()` skips scanner source and test files - eliminates proximity false positives
 
 **Pattern-level guards** (`src/patterns.ts`):
 - `notTestFile: true` added to all ~120 pattern rules (was only on 1). Test files with malware samples are no longer flagged
@@ -3576,11 +3594,11 @@ A single threat actor (claiming "TeamPCP") compromised both the Checkmarx KICS D
 
 ## [5.1.1] - 2026-04-07
 **CI and test fixes**
-- CI workflow: add GitHub Release creation step — after npm publish, automatically creates a GitHub Release with changelog notes extracted from README.md
+- CI workflow: add GitHub Release creation step - after npm publish, automatically creates a GitHub Release with changelog notes extracted from README.md
 - `reporter.test.ts`: fix 3 text-format assertions that checked old output patterns (`"scan report"`, `"52/100"`, `"None"`) broken by the v5.1.0 ASCII output redesign
 
 ## [5.1.0] - 2026-04-07
-**Comprehensive ASCII CLI output** — complete redesign of the default text reporter.
+**Comprehensive ASCII CLI output** - complete redesign of the default text reporter.
 - Double-line banner header (`╔╗`) with tool name and version
 - Risk score with 36-char visual gauge bar, color-coded by severity level
 - Findings summary as a severity histogram with proportional `█░` bars scaled to highest count
@@ -3590,20 +3608,20 @@ A single threat actor (claiming "TeamPCP") compromised both the Checkmarx KICS D
 - Fixed stale hardcoded `4.8.0`/`4.9.0` version strings in SARIF, SBOM metadata, and HTML footer
 
 ## [5.0.1] - 2026-04-07
-**False positive fixes — second pass** after live workspace testing revealed additional FPs.
+**False positive fixes - second pass** after live workspace testing revealed additional FPs.
 - `PROXY_HANDLER_TRAP`: `notFilePattern` extended to cover non-minified vendor files in `/static/js/`, `/vendor/`, `/public/js/`, `/assets/js/` directories (e.g. `tailwindcss.js`)
-- `SHAI_HULUD_WORM` / `SHAI_HULUD_CRED_STEAL`: switched from `notFilePattern(yml)` to `onlyExtensions` for source code only — eliminates FPs on `.md`, `.json`, and other doc/config files
-- `README_LURE` rules: `onlyFilePattern` tightened to filename-based match (README/CHANGELOG/DESCRIPTION/CONTRIBUTING) instead of any `*.md` file — eliminates FPs on `docs/*.md`
+- `SHAI_HULUD_WORM` / `SHAI_HULUD_CRED_STEAL`: switched from `notFilePattern(yml)` to `onlyExtensions` for source code only - eliminates FPs on `.md`, `.json`, and other doc/config files
+- `README_LURE` rules: `onlyFilePattern` tightened to filename-based match (README/CHANGELOG/DESCRIPTION/CONTRIBUTING) instead of any `*.md` file - eliminates FPs on `docs/*.md`
 - `DROPPER_TEMP_EXEC`: pattern tightened from `save.*\.exe` to `saveFile\(` to avoid matching variable names
 - `PROTESTWARE_PROXIMITY`: destructive token detection now requires actual function calls (`fs.rm*\s*\(`) rather than any line containing `child_process`
 
 ## [5.0.0] - 2026-04-07
-**Context-Aware False Positive Elimination** — workspace-wide scan of 100k+ LOC across 15 projects identified 14 systematic FP categories. v5.0.0 eliminates all of them without weakening real detection.
+**Context-Aware False Positive Elimination** - workspace-wide scan of 100k+ LOC across 15 projects identified 14 systematic FP categories. v5.0.0 eliminates all of them without weakening real detection.
 
 **New PatternEntry context fields** (`src/types.ts`):
-- `onlyFilePattern?: RegExp` — only apply pattern to files whose path matches (e.g. README/docs only)
-- `notFilePattern?: RegExp` — skip files whose path matches (e.g. `.min.js`, `.yml`)
-- `notTestFile?: boolean` — skip test/spec/fixture/conftest files
+- `onlyFilePattern?: RegExp` - only apply pattern to files whose path matches (e.g. README/docs only)
+- `notFilePattern?: RegExp` - skip files whose path matches (e.g. `.min.js`, `.yml`)
+- `notTestFile?: boolean` - skip test/spec/fixture/conftest files
 
 **Rule-level fixes** (`src/patterns.ts`):
 - `README_LURE_CRACK` / `README_LURE_LEAKED` / `README_LURE_URGENCY`: `onlyFilePattern` → README/CHANGELOG/`.md` files only. Source files like `.ts` no longer trigger these
@@ -3617,33 +3635,33 @@ A single threat actor (claiming "TeamPCP") compromised both the Checkmarx KICS D
 **Scanner fixes** (`src/scanner.ts`):
 - `.claude/` directory excluded from scanning (eliminates 7× duplicate findings from Claude Code worktrees)
 - `CRITICAL_FINDING_NO_OWNER` and `RISK_STAGNATION_HIGH` excluded from risk score calculation (meta-governance findings caused circular score inflation)
-- `relativePath` normalized to forward slashes — cross-platform consistency in all finding `file` fields
+- `relativePath` normalized to forward slashes - cross-platform consistency in all finding `file` fields
 - `checkBeaconMinerPatterns` now respects `notFilePattern`/`onlyFilePattern`/`notTestFile` like `checkFilePatterns`
 - Binary detection path splitting fixed for cross-platform compatibility
 
 **Continuous monitor fix** (`src/continuous-monitor.ts`):
 - `RISK_STAGNATION_HIGH` requires ≥5 history entries before firing (avoids false alarms on new projects)
 
-**SCANNABLE_EXTENSIONS**: `.md` added — README/CHANGELOG files now scanned for lure patterns via `checkFilePatterns`
+**SCANNABLE_EXTENSIONS**: `.md` added - README/CHANGELOG files now scanned for lure patterns via `checkFilePatterns`
 
 - 22 new context-aware tests (629 total)
 - Expected score reduction: projects scoring 100/critical due to FPs → ≤20/low with no actual malware
 
 ## [4.9.0] - 2026-04-07
-- **New: SBOM Generator** — reads `package-lock.json` (v2+) to generate CycloneDX 1.6 SBOMs with real `components[]` (name, version, PURL, hashes, licenses). Falls back to `package.json` direct deps. VEX statements for suppressed findings. Use `--sbom-output <file>` to write separately.
-- **New: SLSA Verifier** — detects SLSA provenance level (0–3) per project. Checks for sigstore/cosign signing, `slsa-github-generator` usage, hermetic build evidence, provenance attestation files. New rules: `SLSA_LEVEL_0`, `SLSA_NO_PROVENANCE`, `SLSA_UNSIGNED_ARTIFACTS`.
-- **New: GitHub Actions PPE Patterns** — `GHA_PPE_PULL_TARGET` (critical), `GHA_SCRIPT_INJECTION` (critical), `GHA_OIDC_WRITE_PERM`, `GHA_CACHE_POISONING`, `GHA_ARTIFACT_DOWNLOAD`, `GHA_SELF_MODIFY`. Known malicious SHA blocklist (tj-actions Sep 2025, reviewdog).
-- **New: Dependency Confusion Enhancements** — `DEP_HALLUCINATED_PACKAGE` (AI-hallucinated npm/PyPI names), `DEP_FRESH_PUBLISH` (version < 24h old), `DEP_SCOPED_PUBLIC` (internal-looking scoped package on public registry), `scanPypiDependencyConfusion()` for `requirements.txt`/`pyproject.toml`.
-- **False Positive Reduction** — scanning a 100k+ LOC production codebase went from 819 findings/critical to 17 findings/high:
+- **New: SBOM Generator** - reads `package-lock.json` (v2+) to generate CycloneDX 1.6 SBOMs with real `components[]` (name, version, PURL, hashes, licenses). Falls back to `package.json` direct deps. VEX statements for suppressed findings. Use `--sbom-output <file>` to write separately.
+- **New: SLSA Verifier** - detects SLSA provenance level (0–3) per project. Checks for sigstore/cosign signing, `slsa-github-generator` usage, hermetic build evidence, provenance attestation files. New rules: `SLSA_LEVEL_0`, `SLSA_NO_PROVENANCE`, `SLSA_UNSIGNED_ARTIFACTS`.
+- **New: GitHub Actions PPE Patterns** - `GHA_PPE_PULL_TARGET` (critical), `GHA_SCRIPT_INJECTION` (critical), `GHA_OIDC_WRITE_PERM`, `GHA_CACHE_POISONING`, `GHA_ARTIFACT_DOWNLOAD`, `GHA_SELF_MODIFY`. Known malicious SHA blocklist (tj-actions Sep 2025, reviewdog).
+- **New: Dependency Confusion Enhancements** - `DEP_HALLUCINATED_PACKAGE` (AI-hallucinated npm/PyPI names), `DEP_FRESH_PUBLISH` (version < 24h old), `DEP_SCOPED_PUBLIC` (internal-looking scoped package on public registry), `scanPypiDependencyConfusion()` for `requirements.txt`/`pyproject.toml`.
+- **False Positive Reduction** - scanning a 100k+ LOC production codebase went from 819 findings/critical to 17 findings/high:
   - `LOCKFILE_ORPHANED_DEPENDENCY`: 794 individual findings → 1 aggregated summary (npm v7 flat lockfile fix)
   - `TYPOSQUAT_LEVENSHTEIN`: pre-check against popular-packages set; min name length ≥4; short popular packages (ws/pg/nx) excluded from comparison; bcryptjs/swr/tsx/zod added to whitelist
   - `SVG_SCRIPT_INJECTION`: restricted to `.svg` files only (new `onlyExtensions` field on PatternEntry)
   - `IMPORT_EXPRESSION`: backtick without `${...}` expression no longer triggers; severity high→medium
   - `BEACON_INTERVAL_FETCH`: severity high→medium (React polling false positive)
   - `DEAD_DROP_DNS_TXT` / `C2_DOH_RESOLVER`: severity high→medium (false positives in security tooling)
-  - `GHA_ENV_EXFIL`: pattern tightened — only fires when secrets/env passed as curl data/header
+  - `GHA_ENV_EXFIL`: pattern tightened - only fires when secrets/env passed as curl data/header
   - `WORKFLOW_SECRET_TO_UPLOAD_PATH`: severity high→medium, confidence 0.7→0.6
-  - `SECRETS_SSH_KEY_READ`: pattern requires specific key filenames (`id_rsa`, `id_ed25519` etc.) — no longer fires on `cat >> ~/.ssh/known_hosts` CI setup
+  - `SECRETS_SSH_KEY_READ`: pattern requires specific key filenames (`id_rsa`, `id_ed25519` etc.) - no longer fires on `cat >> ~/.ssh/known_hosts` CI setup
 - **Score Calculation**: per-rule deduplication (each unique rule contributes once to score) + weights medium 8→5, low 3→2
 - 45 new tests (607 total)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,68 @@ names, because that list, in a public config file, would itself be the
 disclosure it exists to prevent. A consumer named without that prefix will not
 trip it, so the rule above is the real control and the gate is the backstop.
 
+### No em dashes in tracked files
+
+The em dash (U+2014) is banned. Write a hyphen `-` or a colon `:` instead. The
+en dash (U+2013) is deliberately **not** covered: it has a job of its own in
+numeric ranges such as SLSA levels, this repository uses it that way, and
+banning it too would be a separate decision needing its own argument. Recorded
+here so the next audit reads it as a choice rather than an oversight.
+
+**Scope: every tracked file**, not only documentation. A comment, a `describe()`
+title and a string the CLI prints are all covered, and a new file is covered the
+moment git tracks it.
+
+Three scopes were weighed on 2026-08-22 before that one was chosen
+(<https://github.com/homeofe/supply-chain-guard/issues/178>):
+
+1. **Documentation only**, which is what the rule's own wording used to say.
+   Rejected: the single occurrence with measurable reach outside this project
+   was not in documentation. It was in `src/slsa-verifier.ts`, inside the
+   sentence a scan prints for a project with no build script, which also lands
+   in the SARIF report adopters upload to GitHub code scanning.
+2. **Documentation plus the strings the tool prints.** Rejected: no gate can
+   express it. "This string literal is emitted and that one is not" is not a
+   property a regex over tracked files can decide, so the rule would have gone
+   straight back to being a review convention, which is the state that let 77
+   occurrences accumulate.
+3. **Every tracked file.** Chosen. It is the only one of the three a gate can
+   decide, it needs no per-file judgement, and it fails safe: scope is opt-out,
+   so nothing falls outside it merely by being new.
+
+Enforcement is two halves, both inside `npm run build` and therefore inside the
+required `Build and Test` check:
+
+| half | where | what it decides |
+| --- | --- | --- |
+| the content rule | the `em-dash` entry of `forbiddenPatterns` in `aahp.config.json` | no in-scope file contains U+2014 |
+| the scope rule | `scripts/check-em-dash-scope.mjs`, run by `check:aahp` just before the gates | no tracked file has left the content rule's scope without a written reason |
+
+The second half exists because the first cannot see its own blind spot. Until
+2026-08-22 the content gate reported `no matches` and exited 0 on every pull
+request while the repository held 77 em dashes across 17 files: its `include`
+list named six pathspecs, those six matched none of the 17 files, and so the
+answer was both truthful and useless. The scope checker fails the build if the
+include list is narrowed that way again. It never reads file content and never
+searches for U+2014. There is one em-dash rule and it lives in
+`aahp.config.json`.
+
+**To exempt a file, both halves must agree**: add the pathspec to the rule's
+`exclude` array in `aahp.config.json`, and add it to `SCOPE_EXCEPTIONS` in
+`scripts/check-em-dash-scope.mjs` with a reason a stranger auditing this project
+can evaluate. Either edit alone fails the build. There are two exemptions today,
+the binary demo GIF and the verbatim handoff archive, and each carries its
+reason in that file.
+
+The scope checker refuses in two distinct ways, both non-zero so CI fails either
+way: **exit 1** when a tracked file is uncovered and unexplained, **exit 2** when
+it cannot determine the answer at all, which includes a pathspec matching
+nothing and an `exclude` entry that subtracts nothing. The second is not
+hypothetical. `exclude` used to contain `CHANGELOG.md`, which read like the
+reason the changelog went unchecked and was inert, because a non-empty `include`
+replaces the gate's default file set rather than adding to it, so there was
+nothing for `exclude` to remove.
+
 ### Code Style
 
 - TypeScript strict mode

--- a/aahp.config.json
+++ b/aahp.config.json
@@ -142,17 +142,12 @@
       "id": "em-dash",
       "pattern": "\\u2014",
       "flags": "g",
-      "message": "em dash (U+2014) is banned in docs; use a hyphen '-' or colon ':' (SCG hard rule)",
+      "message": "em dash (U+2014) is banned in EVERY tracked file; use a hyphen '-' or a colon ':' (see the 'No em dashes in tracked files' section of CONTRIBUTING.md, which states the scope and the options weighed before it was chosen). The include list is the single pathspec '*' on purpose: scope is opt-OUT, so a file added tomorrow is covered the moment it is tracked. It was opt-IN until 2026-08-22, and the six pathspecs listed then happened to miss all 77 occurrences that existed in the repository, so this gate reported 'no matches' truthfully while the rule went unenforced (https://github.com/homeofe/supply-chain-guard/issues/178). Every entry in 'exclude' must carry a written reason in scripts/check-em-dash-scope.mjs; that script fails the build if an exclusion loses its justification, if an exclusion subtracts nothing (the state 'CHANGELOG.md' was in here, where it read like the reason the changelog was unchecked and was in fact inert), or if 'include' is ever narrowed so that a tracked file leaves scope in silence. The reasons live in that script and not here because the AAHP config schema sets additionalProperties:false on a forbiddenPatterns rule, so this object cannot carry a per-exclusion reason field.",
       "include": [
-        "README.md",
-        "CONTRIBUTING.md",
-        "SECURITY.md",
-        "CODE_OF_CONDUCT.md",
-        "docs/*.md",
-        ".ai/handoff/*.md"
+        "*"
       ],
       "exclude": [
-        "CHANGELOG.md",
+        "assets/demo.gif",
         ".ai/handoff/LOG-ARCHIVE.md"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "lint": "tsc --noEmit",
-    "check:aahp": "node scripts/check-aahp-pin.mjs && npx --no-install aahp check .",
+    "check:aahp": "node scripts/check-aahp-pin.mjs && node scripts/check-em-dash-scope.mjs && npx --no-install aahp check .",
     "check:handoff": "node scripts/scg-handoff-docs.mjs --check",
     "handoff:refresh": "node scripts/scg-handoff-docs.mjs",
     "feed:generate": "node scripts/generate-feed.mjs",

--- a/scripts/check-em-dash-scope.mjs
+++ b/scripts/check-em-dash-scope.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Preflight for `check:aahp`: every tracked file is inside the `em-dash` rule's
+ * scope, or has a written reason for not being.
+ *
+ * WHAT THIS IS NOT
+ * ----------------
+ * This is NOT a second em-dash checker. It never reads the content of a tracked
+ * file and never searches for U+2014. Searching is the job of the AAHP
+ * `forbidden-patterns` gate, which runs immediately after this script inside
+ * `check:aahp`, and `aahp.config.json` stays the single source of truth for the
+ * rule. This script answers the one question that gate cannot answer about
+ * itself: does the set of files it looks at still cover the repository?
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * https://github.com/homeofe/supply-chain-guard/issues/178. On 2026-08-22 the
+ * repository held 77 em dashes across 17 files while `forbidden-patterns`
+ * reported "no matches" and exited 0, on every pull request, inside a required
+ * status check. Nothing was broken and nothing was lying. The rule's `include`
+ * list named six pathspecs, and those six happened to match none of the 17
+ * files, so "no matches" was the truthful answer to the question the rule
+ * actually asked. A rule whose scope can shrink to nothing while its gate stays
+ * green is not enforced, it is only observed.
+ *
+ * Two properties of that failure are worth naming, because both are invisible
+ * from inside the gate:
+ *
+ *   1. An OPT-IN scope fails open. Every file added after the rule was written
+ *      was outside it by default, silently, forever. The scope is now the single
+ *      pathspec "*", so a new file is covered the moment it is tracked and the
+ *      only way out is an entry below, in a diff a reviewer reads.
+ *   2. A config line can read like a mechanism without being one. `exclude` held
+ *      "CHANGELOG.md", which every reader took for the reason the changelog went
+ *      unchecked. It was inert: the gate replaces its default file set with
+ *      `include` when `include` is non-empty, so CHANGELOG.md was never in scope
+ *      for `exclude` to remove. Deleting that line alone changed nothing. This
+ *      script refuses to answer at all if an `exclude` entry subtracts nothing.
+ *
+ * EXIT CODES
+ * ----------
+ *   0  every tracked file is in scope, or is listed below with a reason.
+ *   1  policy gap: a tracked file is outside the rule's scope and no reason is
+ *      recorded for it. This is the state issue 178 found, expressed as a
+ *      number instead of as prose.
+ *   2  the question cannot be answered: no git work tree, config missing or
+ *      unparseable, the `em-dash` rule absent, a pathspec that matches nothing,
+ *      an `exclude` entry that subtracts nothing, or an exception with no
+ *      reason. Kept separate from 1 because "I found a violation" and "I could
+ *      not determine whether there is one" are different facts, and collapsing
+ *      the second into 0 is the failure mode that made this class invisible in
+ *      the first place. Both are non-zero, so CI fails either way.
+ *
+ * Why 1 and 2 and not other numbers: the AAHP gates and `check-aahp-pin.mjs`
+ * already use 1 for a policy failure, so 1 keeps that meaning here; 2 is the
+ * next value, and nothing in the Node or npm exit-code conventions claims it.
+ * No other code is ever returned.
+ *
+ * Files are enumerated with `git ls-files` through execFileSync with an argument
+ * array and NO shell, which is both how the AAHP gate enumerates them (so the
+ * two agree on pathspec semantics by construction) and the reason a pathspec
+ * string from the config cannot become a shell metacharacter.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+const EXIT_OK = 0;
+const EXIT_GAP = 1;
+const EXIT_INDETERMINATE = 2;
+
+const RULE_ID = "em-dash";
+
+/**
+ * Tracked files that are deliberately outside the `em-dash` rule's scope.
+ *
+ * One entry per exclusion, each a git pathspec and a reason a stranger auditing
+ * this repository can evaluate. An entry with no reason, an entry matching no
+ * tracked file, and an entry matching only files that ARE in scope are all
+ * refused with exit 2, so this table cannot drift away from what the config
+ * does. `aahp.config.json` cannot hold these reasons itself: the AAHP config
+ * schema sets additionalProperties:false on a forbiddenPatterns rule, so the
+ * rule object has no field to put them in.
+ *
+ * No minimum length is imposed on a reason. Any threshold would be arbitrary and
+ * is satisfied by padding; what makes a reason real is that a human reads it in
+ * the pull request that adds it. The check is only that one exists.
+ */
+const SCOPE_EXCEPTIONS = [
+  {
+    pathspec: "assets/demo.gif",
+    reason:
+      "Binary. The gate decodes each in-scope file as UTF-8 and matches line by line, so the byte sequence E2 80 94 occurring by chance inside compressed image data would be reported as an em dash in prose. Measured at the time of writing: this file contains that sequence zero times, so the exclusion is precautionary and suppresses no known occurrence. It is the only tracked file that is not text.",
+  },
+  {
+    pathspec: ".ai/handoff/LOG-ARCHIVE.md",
+    reason:
+      "Inherited exclusion, retained rather than newly decided. The file's own header declares it append-only and states that entries predating the 2026-07-18 rotation are 'preserved below verbatim', so a gate that requires editing archived text would contradict the contract the file states about itself. Assumption being relied on, recorded here because it is an inference from that header and not from a written policy: verbatim preservation is the reason for the carve-out. It holds zero occurrences today, so this preserves history rather than hiding a violation, and anyone who disagrees can delete this entry and the matching `exclude` line together and the gate will simply cover the file.",
+  },
+];
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Report that the question cannot be answered, and stop. Never returns. */
+function indeterminate(lines) {
+  console.error(`check:em-dash-scope INDETERMINATE (exit ${EXIT_INDETERMINATE}):`);
+  for (const line of [].concat(lines)) console.error(`  ${line}`);
+  process.exit(EXIT_INDETERMINATE);
+}
+
+/** Tracked paths matching `specs`; all tracked paths when `specs` is empty. */
+function lsFiles(specs) {
+  const out = execFileSync("git", ["-C", repo, "ls-files", "-z", "--", ...specs], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out.split("\0").filter(Boolean);
+}
+
+try {
+  const inside = execFileSync("git", ["-C", repo, "rev-parse", "--is-inside-work-tree"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  if (inside !== "true") throw new Error(`git reported is-inside-work-tree=${inside}`);
+} catch (err) {
+  indeterminate([
+    `not inside a git work tree at ${repo}: ${err.message}`,
+    "`git ls-files` would enumerate zero files and every check below would pass vacuously.",
+    "In CI, run actions/checkout before this script.",
+  ]);
+}
+
+let config;
+const configPath = path.join(repo, "aahp.config.json");
+try {
+  config = JSON.parse(readFileSync(configPath, "utf8"));
+} catch (err) {
+  indeterminate([`cannot read or parse ${configPath}: ${err.message}`]);
+}
+
+const rules = Array.isArray(config.forbiddenPatterns) ? config.forbiddenPatterns : [];
+const rule = rules.find((r) => r && r.id === RULE_ID);
+if (!rule) {
+  indeterminate([
+    `no forbiddenPatterns rule with id "${RULE_ID}" in ${configPath}.`,
+    "The rule this script exists to keep honest is gone; deleting it must not look like success.",
+  ]);
+}
+
+// An absent or empty `include` is NOT equivalent to "everything". The AAHP gate
+// falls back to its own DEFAULT_INCLUDE, a list of common text extensions that
+// does not contain *.ts, so the scope would silently become something this
+// repository never chose and the fallback would move whenever the pinned CLI
+// moves. Demand an explicit list.
+const includeSpecs = rule.include;
+if (!Array.isArray(includeSpecs) || includeSpecs.length === 0 || includeSpecs.some((s) => typeof s !== "string")) {
+  indeterminate([
+    `the "${RULE_ID}" rule has no explicit non-empty include list of strings.`,
+    "Without one the gate falls back to the pinned CLI's own default file set, which excludes *.ts",
+    "and can change with a dependency bump. State the scope here instead.",
+  ]);
+}
+
+const excludeSpecs = Array.isArray(rule.exclude) ? rule.exclude : [];
+if (excludeSpecs.some((s) => typeof s !== "string")) {
+  indeterminate([`the "${RULE_ID}" rule has a non-string entry in its exclude list.`]);
+}
+
+const tracked = lsFiles([]);
+if (tracked.length === 0) {
+  indeterminate([
+    `git ls-files returned no tracked files at ${repo}.`,
+    "Every set below would be empty and the comparison would pass without proving anything.",
+  ]);
+}
+
+const included = new Set();
+for (const spec of includeSpecs) {
+  const matched = lsFiles([spec]);
+  if (matched.length === 0) {
+    indeterminate([
+      `include pathspec ${JSON.stringify(spec)} matches no tracked file.`,
+      "A pathspec that has stopped matching narrows the scope without changing the rule's text,",
+      "which is how a gate goes quietly green. Fix or remove it.",
+    ]);
+  }
+  for (const f of matched) included.add(f);
+}
+
+const excluded = new Set();
+for (const spec of excludeSpecs) {
+  const matched = lsFiles([spec]);
+  if (matched.length === 0) {
+    indeterminate([
+      `exclude pathspec ${JSON.stringify(spec)} matches no tracked file.`,
+      "It documents an exception to nothing and misleads the next reader about what is covered.",
+    ]);
+  }
+  if (!matched.some((f) => included.has(f))) {
+    indeterminate([
+      `exclude pathspec ${JSON.stringify(spec)} subtracts nothing: no file it matches is in the include set.`,
+      "This is exactly the state issue 178 found, where an inert \"CHANGELOG.md\" entry read like",
+      "the reason the changelog was unchecked. Delete it, or widen include so it means something.",
+    ]);
+  }
+  for (const f of matched) excluded.add(f);
+}
+
+const inScope = new Set([...included].filter((f) => !excluded.has(f)));
+
+const explained = new Set();
+for (const [i, exception] of SCOPE_EXCEPTIONS.entries()) {
+  const where = `SCOPE_EXCEPTIONS[${i}] (${JSON.stringify(exception.pathspec)})`;
+  if (typeof exception.reason !== "string" || exception.reason.trim() === "") {
+    indeterminate([`${where} has no written reason.`, "An undocumented carve-out is the defect, not the fix."]);
+  }
+  const matched = lsFiles([exception.pathspec]);
+  if (matched.length === 0) {
+    indeterminate([`${where} matches no tracked file.`, "A stale exception hides which files are really uncovered."]);
+  }
+  const outOfScope = matched.filter((f) => !inScope.has(f));
+  if (outOfScope.length === 0) {
+    indeterminate([
+      `${where} explains nothing: every file it matches is already in scope.`,
+      "Delete it, so the table lists only real carve-outs.",
+    ]);
+  }
+  for (const f of outOfScope) explained.add(f);
+}
+
+const gaps = tracked.filter((f) => !inScope.has(f) && !explained.has(f));
+if (gaps.length > 0) {
+  console.error(`check:em-dash-scope FAILED (exit ${EXIT_GAP}): ${gaps.length} tracked file(s) outside the "${RULE_ID}" rule with no recorded reason.`);
+  for (const f of gaps) console.error(`  - ${f}`);
+  console.error("");
+  console.error("  Either widen the rule's include list in aahp.config.json so these are covered,");
+  console.error("  or add each one to SCOPE_EXCEPTIONS in scripts/check-em-dash-scope.mjs with a");
+  console.error("  reason a stranger auditing this repository can evaluate.");
+  process.exit(EXIT_GAP);
+}
+
+console.log(
+  `check:em-dash-scope OK - ${inScope.size} of ${tracked.length} tracked file(s) in the "${RULE_ID}" rule's scope, ` +
+    `${explained.size} excluded with a written reason, 0 uncovered.`,
+);
+process.exit(EXIT_OK);

--- a/src/__tests__/beacon-miner.test.ts
+++ b/src/__tests__/beacon-miner.test.ts
@@ -172,7 +172,7 @@ describe("Network Beacon and Crypto Miner Detection (T-008)", () => {
     });
 
     it("should detect mining configuration keys", async () => {
-      // Note: notFilePattern skips .json — use .js to test mining config detection
+      // Note: notFilePattern skips .json - use .js to test mining config detection
       fs.writeFileSync(
         path.join(tempDir, "miner-config.js"),
         `const cfg = {"wallet":"4Abc123xyzabc","pool_address":"pool.minexmr.com:4444","worker":"worker1"};`,

--- a/src/__tests__/context-aware.test.ts
+++ b/src/__tests__/context-aware.test.ts
@@ -16,7 +16,7 @@ describe("Context-Aware False Positive Elimination (v5.0.0)", () => {
 
   // ── README_LURE rules only fire in markdown/README files ──────────
 
-  describe("README_LURE rules — onlyFilePattern", () => {
+  describe("README_LURE rules - onlyFilePattern", () => {
     it("should NOT fire README_LURE_CRACK on .ts source files containing 'nolimit'", async () => {
       fs.writeFileSync(
         path.join(tempDir, "rate-limiter.ts"),
@@ -65,7 +65,7 @@ describe("Context-Aware False Positive Elimination (v5.0.0)", () => {
 
   // ── SHAI_HULUD rules skip YAML workflow files ─────────────────────
 
-  describe("SHAI_HULUD rules — notFilePattern (.yml)", () => {
+  describe("SHAI_HULUD rules - notFilePattern (.yml)", () => {
     it("should NOT fire SHAI_HULUD_WORM on .yml file containing 'npm publish'", async () => {
       fs.mkdirSync(path.join(tempDir, ".github", "workflows"), { recursive: true });
       fs.writeFileSync(
@@ -123,7 +123,7 @@ describe("Context-Aware False Positive Elimination (v5.0.0)", () => {
 
   // ── Minified files do not trigger context-unaware patterns ────────
 
-  describe("Minified file exclusion — notFilePattern (.min.js)", () => {
+  describe("Minified file exclusion - notFilePattern (.min.js)", () => {
     it("should NOT fire PROXY_HANDLER_TRAP on .min.js files", async () => {
       fs.writeFileSync(
         path.join(tempDir, "htmx.min.js"),
@@ -167,7 +167,7 @@ describe("Context-Aware False Positive Elimination (v5.0.0)", () => {
 
   // ── JSON files do not trigger miner config keys ───────────────────
 
-  describe("JSON file exclusion — MINER_CONFIG_KEYS", () => {
+  describe("JSON file exclusion - MINER_CONFIG_KEYS", () => {
     it("should NOT fire MINER_CONFIG_KEYS on bootstrap-icons.json with 'coin' icon names", async () => {
       fs.writeFileSync(
         path.join(tempDir, "bootstrap-icons.json"),
@@ -189,7 +189,7 @@ describe("Context-Aware False Positive Elimination (v5.0.0)", () => {
 
   // ── IAC_HARDCODED_SECRET skips test files and dummy values ────────
 
-  describe("IAC_HARDCODED_SECRET — notTestFile + pattern tightening", () => {
+  describe("IAC_HARDCODED_SECRET - notTestFile + pattern tightening", () => {
     it("should NOT fire IAC_HARDCODED_SECRET on conftest.py with dummy api_key", async () => {
       fs.writeFileSync(
         path.join(tempDir, "conftest.py"),
@@ -211,7 +211,7 @@ describe("Context-Aware False Positive Elimination (v5.0.0)", () => {
 
   // ── VIDAR_BROWSER_THEFT requires OS-specific browser paths ────────
 
-  describe("VIDAR_BROWSER_THEFT — pattern precision", () => {
+  describe("VIDAR_BROWSER_THEFT - pattern precision", () => {
     it("should NOT fire VIDAR_BROWSER_THEFT on 'History' word in Prisma schema", async () => {
       fs.writeFileSync(
         path.join(tempDir, "schema.prisma"),
@@ -267,7 +267,7 @@ describe("Context-Aware False Positive Elimination (v5.0.0)", () => {
       );
       const report = await scan({ target: tempDir, format: "text" });
       const hasMeta = report.findings.find((f) => f.rule === "CRITICAL_FINDING_NO_OWNER");
-      // Score must not be inflated by meta-finding — CRITICAL_FINDING_NO_OWNER fires
+      // Score must not be inflated by meta-finding - CRITICAL_FINDING_NO_OWNER fires
       // because MINER_STRATUM_PROTOCOL is critical, but should NOT add to the score itself.
       // Real findings: MINER_STRATUM_PROTOCOL (critical=25). Meta adds 0.
       if (hasMeta) {
@@ -280,7 +280,7 @@ describe("Context-Aware False Positive Elimination (v5.0.0)", () => {
 
   // ── PROXY_BACKCONNECT requires SOCKS5/protocol indicators ─────────
 
-  describe("PROXY_BACKCONNECT — pattern precision", () => {
+  describe("PROXY_BACKCONNECT - pattern precision", () => {
     it("should NOT fire PROXY_BACKCONNECT on array .reverse() method", async () => {
       fs.writeFileSync(
         path.join(tempDir, "utils.ts"),

--- a/src/__tests__/dependency-confusion.test.ts
+++ b/src/__tests__/dependency-confusion.test.ts
@@ -304,7 +304,7 @@ describe("Dependency Confusion Heuristics (unit)", () => {
 
 // ─── v4.9 new feature unit tests ──────────────────────────────────────────
 
-describe("PyPI confusion detection — parseRequirementsTxt (v4.9)", () => {
+describe("PyPI confusion detection - parseRequirementsTxt (v4.9)", () => {
   let tmpDir: string;
   beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "scg-pypi-test-")); });
   afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
@@ -332,7 +332,7 @@ describe("PyPI confusion detection — parseRequirementsTxt (v4.9)", () => {
       "python-utils-helper\nrequests\n",
     );
     // Findings should include DEP_HALLUCINATED_PACKAGE for python-utils-helper
-    // (works offline — no network call needed for hallucinated packages)
+    // (works offline - no network call needed for hallucinated packages)
     const findings = await scanPypiDependencyConfusion(tmpDir);
     expect(findings.some((f) => f.rule === "DEP_HALLUCINATED_PACKAGE" && f.match === "python-utils-helper")).toBe(true);
   });

--- a/src/__tests__/em-dash-scope.test.ts
+++ b/src/__tests__/em-dash-scope.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Regression tests for the em-dash SCOPE checker (scripts/check-em-dash-scope.mjs).
+ *
+ * Why this exists: https://github.com/homeofe/supply-chain-guard/issues/178. The
+ * repository held 77 em dashes across 17 files while the `forbidden-patterns`
+ * gate reported "no matches" and exited 0 on every pull request, inside a
+ * required status check. Nothing was broken and nothing lied. The `em-dash`
+ * rule's `include` list named six pathspecs; those six matched none of the 17
+ * files; "no matches" was the truthful answer to the question the rule actually
+ * asked.
+ *
+ * That defect is invisible to the content gate by construction, because a gate
+ * cannot report on files it was never pointed at. So the guard against it is a
+ * separate question, asked here: does the rule's scope still cover the
+ * repository? The first test below is the one that goes red if the scope ever
+ * narrows again. The rest pin the checker's own verdicts, so that a green first
+ * test means the checker still knows how to say no.
+ *
+ * Exit codes are asserted EXACTLY, never merely as non-zero, because the whole
+ * failure class here is a check that returns the wrong kind of answer: 0 means
+ * covered, 1 means a tracked file is uncovered and unexplained, 2 means the
+ * question could not be answered at all.
+ */
+describe("em-dash rule scope", () => {
+  const repoRoot = path.resolve(__dirname, "..", "..");
+  const checker = path.join(repoRoot, "scripts", "check-em-dash-scope.mjs");
+
+  /** Run the checker against `cwd`'s tree and return its exit code plus output. */
+  const run = (scriptPath: string): { status: number; out: string } => {
+    const res = spawnSync(process.execPath, [scriptPath], { encoding: "utf8" });
+    return { status: res.status ?? -1, out: `${res.stdout ?? ""}${res.stderr ?? ""}` };
+  };
+
+  it("covers every tracked file in this repository", () => {
+    // DELETE THE "*" ENTRY FROM the em-dash rule's `include` array in
+    // aahp.config.json TO TURN THIS RED. Replacing it with a list of specific
+    // pathspecs, which is what the rule carried before 2026-08-22, reddens it
+    // the same way and is the exact shape of issue 178.
+    const { status, out } = run(checker);
+    expect(out).toContain("0 uncovered");
+    expect(status).toBe(0);
+  });
+
+  describe("fixture trees", () => {
+    let tmp: string;
+
+    /**
+     * A throwaway git tree shaped like this repository: a file the rule covers,
+     * a file it could miss, the binary asset and the verbatim handoff archive
+     * that SCOPE_EXCEPTIONS names. The checker resolves its repo root as
+     * dirname(script)/.., so a copy of the script at <tmp>/scripts/ makes <tmp>
+     * a complete, isolated fixture.
+     */
+    const writeConfig = (rule: Record<string, unknown>): void => {
+      fs.writeFileSync(
+        path.join(tmp, "aahp.config.json"),
+        JSON.stringify({ forbiddenPatterns: [{ id: "em-dash", pattern: "\\u2014", flags: "g", ...rule }] }, null, 2),
+      );
+      spawnSync("git", ["-C", tmp, "add", "-A"], { encoding: "utf8" });
+    };
+
+    const fixtureChecker = (): string => path.join(tmp, "scripts", "check-em-dash-scope.mjs");
+
+    beforeEach(() => {
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scg-em-dash-scope-"));
+      for (const dir of ["scripts", "src", "assets", path.join(".ai", "handoff")]) {
+        fs.mkdirSync(path.join(tmp, dir), { recursive: true });
+      }
+      fs.copyFileSync(checker, fixtureChecker());
+      fs.writeFileSync(path.join(tmp, "README.md"), "prose\n");
+      fs.writeFileSync(path.join(tmp, "CHANGELOG.md"), "history\n");
+      fs.writeFileSync(path.join(tmp, "src", "scanner.ts"), "export const x = 1;\n");
+      fs.writeFileSync(path.join(tmp, "assets", "demo.gif"), Buffer.from([0x47, 0x49, 0x46, 0x38]));
+      fs.writeFileSync(path.join(tmp, ".ai", "handoff", "LOG-ARCHIVE.md"), "archived\n");
+      spawnSync("git", ["-C", tmp, "init", "-q"], { encoding: "utf8" });
+      spawnSync("git", ["-C", tmp, "add", "-A"], { encoding: "utf8" });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it("exits 0 when the scope is opt-out and every exclusion is explained", () => {
+      writeConfig({ include: ["*"], exclude: ["assets/demo.gif", ".ai/handoff/LOG-ARCHIVE.md"] });
+      const { status, out } = run(fixtureChecker());
+      expect(out).toContain("0 uncovered");
+      expect(status).toBe(0);
+    });
+
+    it("exits 1 when an opt-in include list leaves a tracked file uncovered", () => {
+      // The pre-2026-08-22 shape: an include list that names files rather than
+      // the tree, so src/scanner.ts and CHANGELOG.md are outside the rule and
+      // nothing says why.
+      writeConfig({
+        include: ["README.md", "assets/demo.gif", ".ai/handoff/LOG-ARCHIVE.md"],
+        exclude: ["assets/demo.gif", ".ai/handoff/LOG-ARCHIVE.md"],
+      });
+      const { status, out } = run(fixtureChecker());
+      expect(out).toContain("src/scanner.ts");
+      expect(out).toContain("CHANGELOG.md");
+      expect(status).toBe(1);
+    });
+
+    it("exits 2 on an exclude entry that subtracts nothing, the inert-line shape from issue 178", () => {
+      writeConfig({
+        include: ["README.md", "assets/demo.gif", ".ai/handoff/LOG-ARCHIVE.md"],
+        exclude: ["assets/demo.gif", ".ai/handoff/LOG-ARCHIVE.md", "CHANGELOG.md"],
+      });
+      const { status, out } = run(fixtureChecker());
+      expect(out).toContain("subtracts nothing");
+      expect(status).toBe(2);
+    });
+
+    it("exits 2 when the rule states no include list, rather than inheriting the CLI default", () => {
+      writeConfig({ exclude: ["assets/demo.gif", ".ai/handoff/LOG-ARCHIVE.md"] });
+      const { status, out } = run(fixtureChecker());
+      expect(out).toContain("no explicit non-empty include list");
+      expect(status).toBe(2);
+    });
+
+    it("exits 2 on an include pathspec that has stopped matching", () => {
+      writeConfig({ include: ["*", "docs/*.md"], exclude: ["assets/demo.gif", ".ai/handoff/LOG-ARCHIVE.md"] });
+      const { status, out } = run(fixtureChecker());
+      expect(out).toContain("matches no tracked file");
+      expect(status).toBe(2);
+    });
+  });
+});

--- a/src/__tests__/scanner.test.ts
+++ b/src/__tests__/scanner.test.ts
@@ -22,7 +22,7 @@ describe("Core Scanner", () => {
     });
 
     // v4.9: SLSA_LEVEL_0 (info severity, score=1) is emitted for directories
-    // without any build scripts — this is a posture finding, not a security alert.
+    // without any build scripts - this is a posture finding, not a security alert.
     // Verify no actual security/malware findings are present.
     const securityFindings = report.findings.filter(
       (f) => !f.rule.startsWith("SLSA_"),

--- a/src/continuous-monitor.ts
+++ b/src/continuous-monitor.ts
@@ -98,7 +98,7 @@ export function analyzeRiskTrend(
     }
   }
 
-  // Stagnation at high risk — require at least 5 history entries to avoid
+  // Stagnation at high risk - require at least 5 history entries to avoid
   // false alarms from new projects that haven't been remediated yet
   if (history.length >= 5 && recent.every((h) => h.score > 50) && recent.length >= 3) {
     findings.push({

--- a/src/correlation-engine.ts
+++ b/src/correlation-engine.ts
@@ -1,5 +1,5 @@
 /**
- * Correlation engine (v4.2) — CORE FEATURE.
+ * Correlation engine (v4.2) - CORE FEATURE.
  *
  * Aggregates individual findings into incident-level clusters.
  * Links related findings, boosts confidence, generates attack narratives,

--- a/src/dependency-confusion.ts
+++ b/src/dependency-confusion.ts
@@ -476,7 +476,7 @@ function buildDescription(result: DependencyResult): string {
   }
 
   if (result.flags.includes("version-cooldown")) {
-    return `Version of "${result.name}" used in this project was published to npm less than ${VERSION_COOLDOWN_DAYS} days ago. Security vendors typically need 7 days to detect malicious packages — using brand-new versions carries elevated risk.`;
+    return `Version of "${result.name}" used in this project was published to npm less than ${VERSION_COOLDOWN_DAYS} days ago. Security vendors typically need 7 days to detect malicious packages - using brand-new versions carries elevated risk.`;
   }
 
   if (result.flags.includes("scoped-public-npm") && result.flags.includes("no-readme")) {
@@ -2334,7 +2334,7 @@ export async function scanPypiDependencyConfusion(projectDir: string): Promise<F
     if (AI_HALLUCINATED_PYPI_PACKAGES.has(normalizedName)) {
       findings.push({
         rule: "DEP_HALLUCINATED_PACKAGE",
-        description: `PyPI package "${name}" matches a known AI-hallucinated package name. LLMs frequently suggest this non-existent package — it may be squatted on PyPI.`,
+        description: `PyPI package "${name}" matches a known AI-hallucinated package name. LLMs frequently suggest this non-existent package - it may be squatted on PyPI.`,
         severity: "high",
         file: manifest,
         match: name,

--- a/src/github-actions-scanner.ts
+++ b/src/github-actions-scanner.ts
@@ -106,7 +106,7 @@ export const WORKFLOW_PATTERNS: Array<
     rule: "GHA_ATOB_USAGE",
   },
 
-  // Environment variable exfiltration — requires secrets/env passed as DATA (not as URL)
+  // Environment variable exfiltration - requires secrets/env passed as DATA (not as URL)
   {
     pattern: "curl\\b[^'\"\\n]*(?:-d|--data|--data-raw|-H|--header)[^'\"\\n]*\\$\\{\\{\\s*(?:secrets|env)\\.",
     description: "Secret or env variable passed as curl request data/header (potential exfiltration)",
@@ -162,7 +162,7 @@ export const WORKFLOW_PATTERNS: Array<
   {
     pattern: "(?:echo|tee|cat|cp|mv|write).*\\.github[\\\\/]workflows[\\\\/]",
     description:
-      "Workflow writes to .github/workflows/ — this can persist malicious code by modifying CI pipeline files (supply chain worm pattern)",
+      "Workflow writes to .github/workflows/ - this can persist malicious code by modifying CI pipeline files (supply chain worm pattern)",
     severity: "critical",
     rule: "GHA_SELF_MODIFY",
     correlatedMatcher: WORKFLOW_BROAD_GAP_MATCHERS.SELF_MODIFY,
@@ -177,11 +177,11 @@ validatePatternSet("WORKFLOW_PATTERNS", WORKFLOW_PATTERNS);
  * Sources: GitHub Security Advisories, supply chain incident reports.
  */
 const KNOWN_MALICIOUS_ACTION_SHAS = new Map<string, string>([
-  // tj-actions/changed-files — compromised September 2025 (GHSA-2025-tj-actions)
+  // tj-actions/changed-files - compromised September 2025 (GHSA-2025-tj-actions)
   // Exfiltrated CI secrets to attacker-controlled server via public build logs
   ["d8462b4fc879d893f8f3b49843bde065f3f07b82", "tj-actions/changed-files (Sep 2025 compromise)"],
   ["0e58ed8671d6b60d0890c21b07f8835ace038e67", "tj-actions/changed-files (Sep 2025 compromise variant)"],
-  // reviewdog/action-setup — compromised as part of tj-actions attack chain
+  // reviewdog/action-setup - compromised as part of tj-actions attack chain
   ["3f401fe1d58fe77e10d665ab713057369b8cdfe4", "reviewdog/action-setup (Sep 2025 attack chain)"],
 ]);
 
@@ -270,7 +270,7 @@ function scanWorkflowContent(
   // and (for PPE) to workflows whose trigger grants the elevated context.
   checkInterpolationSinkRules(content, relativePath, findings);
 
-  // v5.7: structural, trigger-aware rules (Cordyceps class) — these need to
+  // v5.7: structural, trigger-aware rules (Cordyceps class) - these need to
   // know which event fires the workflow and what its token can do, which the
   // line-by-line passes above are blind to.
   checkWorkflowAstRules(content, relativePath, findings);
@@ -685,7 +685,7 @@ function checkWorkflowAstRules(
   const triggerSet = new Set(ast.triggers);
   const privileged = PRIVILEGED_TRIGGERS.filter((t) => triggerSet.has(t));
 
-  // GHA_PRIVILEGED_TRIGGER — the workflow runs in an elevated context.
+  // GHA_PRIVILEGED_TRIGGER - the workflow runs in an elevated context.
   if (privileged.length > 0) {
     findings.push({
       rule: "GHA_PRIVILEGED_TRIGGER",
@@ -701,7 +701,7 @@ function checkWorkflowAstRules(
     });
   }
 
-  // GHA_PWN_REQUEST_CHECKOUT — privileged trigger checks out attacker PR/head code.
+  // GHA_PWN_REQUEST_CHECKOUT - privileged trigger checks out attacker PR/head code.
   const hasPwnTrigger = ast.triggers.some((t) => PWN_CHECKOUT_TRIGGERS.includes(t));
   if (hasPwnTrigger) {
     for (const job of ast.jobs) {
@@ -727,7 +727,7 @@ function checkWorkflowAstRules(
     }
   }
 
-  // GHA_GITHUB_SCRIPT_INJECTION — untrusted context eval'd as JS by github-script.
+  // GHA_GITHUB_SCRIPT_INJECTION - untrusted context eval'd as JS by github-script.
   for (const job of ast.jobs) {
     for (const step of job.steps) {
       if (
@@ -749,7 +749,7 @@ function checkWorkflowAstRules(
     }
   }
 
-  // GHA_PERMS_WRITE_ALL — the token is granted every scope.
+  // GHA_PERMS_WRITE_ALL - the token is granted every scope.
   if (ast.permissions.writeAll || ast.jobs.some((j) => j.permissions.writeAll)) {
     findings.push({
       rule: "GHA_PERMS_WRITE_ALL",
@@ -765,7 +765,7 @@ function checkWorkflowAstRules(
     });
   }
 
-  // GHA_PERMS_DEFAULT_BROAD — privileged trigger with no explicit least-privilege.
+  // GHA_PERMS_DEFAULT_BROAD - privileged trigger with no explicit least-privilege.
   // Fire when there is no top-level permissions block AND at least one job runs
   // without its own block (inheriting the broad repo default). A single sibling
   // job declaring permissions must not silence the rule for the jobs that don't.
@@ -1025,7 +1025,7 @@ function checkActionReferences(
     const ref = actionRef.substring(atIndex + 1);
     const owner = actionPath.split("/")[0] ?? "";
 
-    // Check against known malicious SHAs (highest priority — always critical)
+    // Check against known malicious SHAs (highest priority - always critical)
     if (SHA_PATTERN.test(ref) && KNOWN_MALICIOUS_ACTION_SHAS.has(ref)) {
       findings.push({
         rule: "GHA_KNOWN_MALICIOUS_SHA",

--- a/src/ioc-blocklist.ts
+++ b/src/ioc-blocklist.ts
@@ -665,7 +665,7 @@ export const KNOWN_MALICIOUS_HASHES: Record<string, string> = {
   "0d58616c750fc8530a7e90eee18398ddedd08cc0f4908c863ab650673b9819dd": "MacSync Stealer variant (SHA256)",
   "86d0c50cab4f394c58976c44d6d7b67a7dfbbb813fbcf622236e183d94fd944f": "MacSync Stealer variant (SHA256)",
 
-  // TCLBANKER Brazilian banking trojan (May 2026) — REF3076 / trojanized Logitech AI Prompt Builder
+  // TCLBANKER Brazilian banking trojan (May 2026) - REF3076 / trojanized Logitech AI Prompt Builder
   "701d51b7be8b034c860bf97847bd59a87dca8481c4625328813746964995b626": "TCLBANKER component (SHA256)",
   "8a174aa70a4396547045aef6c69eb0259bae1706880f4375af71085eeb537059": "TCLBANKER component (SHA256)",
   "668f932433a24bbae89d60b24eee4a24808fc741f62c5a3043bb7c9152342f40": "TCLBANKER component (SHA256)",
@@ -2589,7 +2589,7 @@ export function checkBadVersion(
   if (entry.versions.includes(version)) {
     return {
       rule: "IOC_KNOWN_BAD_VERSION",
-      description: `Known compromised package version: ${name}@${version} — ${entry.description}`,
+      description: `Known compromised package version: ${name}@${version} - ${entry.description}`,
       severity: "critical",
       recommendation: `Remove ${name}@${version} immediately. This version contains known malware. Upgrade to a clean version.`,
     };

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -20,7 +20,7 @@ import {
 import { hasBroadUnboundedConsumingGap } from "./regex-complexity.js";
 export { isPatternApplicableToFile } from "./pattern-applicability.js";
 
-/** Matches the scanner's own source files — used to prevent self-scan false positives. */
+/** Matches the scanner's own source files - used to prevent self-scan false positives. */
 const SCANNER_SRC = /(?:patterns|scanner|playbooks|correlation-engine|ioc-blocklist|threat-intel|remediation-engine|secret-simulator|workflow-modeler|config-scanner|install-hook-scanner|github-trust-scanner|dependency-confusion|attack-graph|reporter|active-validation|solana-monitor|solana-watchlist|slsa-verifier|sbom-generator)\.(ts|js)$/;
 
 // v5.2.21: documentation files (.md/.markdown/.txt/.rst) legitimately discuss

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -270,7 +270,7 @@ function formatText(report: ScanReport): string {
       lines.push(boxBlank());
     } else if (totalFindings === 0) {
       lines.push(boxBlank());
-      lines.push(boxRow(`  \x1b[32m${BOLD}✓  No findings — clean${RESET}`));
+      lines.push(boxRow(`  \x1b[32m${BOLD}✓  No findings - clean${RESET}`));
       lines.push(boxBlank());
     } else {
       const maxCount = Math.max(
@@ -317,7 +317,7 @@ function formatText(report: ScanReport): string {
       const avail  = W - label.length - 4;              // content width after indent
 
       lines.push(boxRow(`  ${color}${BOLD}${label}${RESET}  ${BOLD}${trunc(f.rule, avail)}${RESET}`));
-      // Description — word-wrapped
+      // Description - word-wrapped
       for (const dl of wrapText(f.description, avail)) {
         lines.push(boxRow(`  ${indent}${dl}`));
       }
@@ -325,7 +325,7 @@ function formatText(report: ScanReport): string {
         const loc = f.line ? `${f.file}:${f.line}` : f.file;
         lines.push(boxRow(`  ${indent}${DIM}${trunc(loc, avail)}${RESET}`));
       }
-      // Match — word-wrapped, first line gets "match  " tag
+      // Match - word-wrapped, first line gets "match  " tag
       if (f.match) {
         const matchTag = "match  ";
         const matchPad = " ".repeat(matchTag.length);
@@ -335,7 +335,7 @@ function formatText(report: ScanReport): string {
           lines.push(boxRow(`  ${indent}${DIM}${matchPad}${RESET}${matchLines[ml]}`));
         }
       }
-      // Fix — word-wrapped, first line gets "fix    " tag
+      // Fix - word-wrapped, first line gets "fix    " tag
       const fixTag = "fix    ";
       const fixPad = " ".repeat(fixTag.length);
       const fixLines = wrapText(f.recommendation, avail - fixTag.length);

--- a/src/sbom-generator.ts
+++ b/src/sbom-generator.ts
@@ -1,5 +1,5 @@
 /**
- * SBOM Generator — CycloneDX 1.6
+ * SBOM Generator - CycloneDX 1.6
  *
  * Generates a proper Software Bill of Materials from a project's
  * package.json + package-lock.json (npm v2+), including VEX statements

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -748,7 +748,7 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
   // the snapshot before later filters can hide a coverage-breaking warning.
   partialScan ||= hasPartialScanFinding(findings);
 
-  // v4.2: Correlation engine — link findings into incidents
+  // v4.2: Correlation engine - link findings into incidents
   const correlation = correlateFindings(findings);
 
   // v4.2: Trust breakdown (for directory/github scans with package.json)
@@ -1851,7 +1851,7 @@ function calculateSummary(
  * Each unique rule contributes at most once (its highest severity instance),
  * preventing repeated instances of the same moderate rule from dominating the score.
  */
-// Meta/governance findings that fire because other findings exist — excluded from
+// Meta/governance findings that fire because other findings exist - excluded from
 // score to prevent circular inflation (they don't represent independent risk signals).
 export const SCORE_EXCLUDED_RULES: ReadonlySet<string> = new Set([
   "CRITICAL_FINDING_NO_OWNER",
@@ -1859,7 +1859,7 @@ export const SCORE_EXCLUDED_RULES: ReadonlySet<string> = new Set([
 ]);
 
 function calculateScore(findings: Finding[]): number {
-  // Deduplicate by rule — take the highest-severity instance per rule.
+  // Deduplicate by rule - take the highest-severity instance per rule.
   // Skip meta-governance findings that would circularly inflate the score.
   const maxByRule = new Map<string, Severity>();
   for (const finding of findings) {
@@ -2185,7 +2185,7 @@ function generateRecommendations(
   }
   if (rules.has("DROPPER_TEMP_EXEC")) {
     recommendations.push(
-      "CRITICAL: Dropper/loader behavior detected — writing and executing files in temporary directories.",
+      "CRITICAL: Dropper/loader behavior detected - writing and executing files in temporary directories.",
     );
   }
 
@@ -2214,7 +2214,7 @@ function generateRecommendations(
   }
   if (rules.has("README_LURE_CRACK") || rules.has("RELEASE_NAME_LURE")) {
     recommendations.push(
-      "This repository uses piracy/crack language — a strong indicator of malware distribution. Do not download or use.",
+      "This repository uses piracy/crack language - a strong indicator of malware distribution. Do not download or use.",
     );
   }
 

--- a/src/sla-engine.ts
+++ b/src/sla-engine.ts
@@ -58,7 +58,7 @@ export function checkSlaCompliance(
     if (age > slaMs) {
       findings.push({
         rule: "SLA_BREACH_CRITICAL",
-        description: `SLA breached for "${d.findingRule}" — open for ${Math.round(age / (24 * 60 * 60 * 1000))} days (SLA: ${slaMs / (24 * 60 * 60 * 1000)}d). Owner: ${d.owner ?? "unassigned"}.`,
+        description: `SLA breached for "${d.findingRule}" - open for ${Math.round(age / (24 * 60 * 60 * 1000))} days (SLA: ${slaMs / (24 * 60 * 60 * 1000)}d). Owner: ${d.owner ?? "unassigned"}.`,
         severity: "critical",
         confidence: 1.0,
         category: "trust",
@@ -67,7 +67,7 @@ export function checkSlaCompliance(
     } else if (age > slaMs * 0.8) {
       findings.push({
         rule: "SLA_AT_RISK",
-        description: `SLA at risk for "${d.findingRule}" — ${Math.round((slaMs - age) / (60 * 60 * 1000))} hours remaining. Owner: ${d.owner ?? "unassigned"}.`,
+        description: `SLA at risk for "${d.findingRule}" - ${Math.round((slaMs - age) / (60 * 60 * 1000))} hours remaining. Owner: ${d.owner ?? "unassigned"}.`,
         severity: "high",
         confidence: 1.0,
         category: "trust",

--- a/src/slsa-verifier.ts
+++ b/src/slsa-verifier.ts
@@ -5,10 +5,10 @@
  * based on build configuration, GitHub Actions workflows, and attestation files.
  *
  * Levels:
- *   0 — No evidence of any build process
- *   1 — Build script present (Dockerfile, CI workflow)
- *   2 — Signed build or slsa-github-generator action used
- *   3 — Hermetic build + a VALID parsed provenance statement
+ *   0 - No evidence of any build process
+ *   1 - Build script present (Dockerfile, CI workflow)
+ *   2 - Signed build or slsa-github-generator action used
+ *   3 - Hermetic build + a VALID parsed provenance statement
  *
  * Scope (v5.15.0): provenance files are now PARSED and structurally validated
  * (in-toto Statement / DSSE envelope / Sigstore bundle -> SLSA predicate type +
@@ -404,7 +404,7 @@ export function verifySLSA(dir: string): Finding[] {
     findings.push({
       rule: "SLSA_LEVEL_0",
       description:
-        "No build script or CI workflow found — project has no verifiable build process (SLSA Level 0)",
+        "No build script or CI workflow found - project has no verifiable build process (SLSA Level 0)",
       severity: "info",
       recommendation:
         "Add a GitHub Actions workflow or Dockerfile to establish a reproducible build. " +
@@ -437,7 +437,7 @@ export function verifySLSA(dir: string): Finding[] {
         "workflow (`workflow_call`) and attach the `provenance.intoto.jsonl` to each release.",
     });
   }
-  // Level 3: no findings — fully compliant
+  // Level 3: no findings - fully compliant
 
   return findings;
 }

--- a/src/threat-intel.ts
+++ b/src/threat-intel.ts
@@ -14186,7 +14186,7 @@ export function checkThreatIntel(
 
       findings.push({
         rule: "THREAT_INTEL_MATCH",
-        description: `Threat intelligence match: ${ioc.type} "${ioc.value}"${ioc.family ? ` (${ioc.family})` : ""}${ioc.campaign ? ` — ${ioc.campaign}` : ""}`,
+        description: `Threat intelligence match: ${ioc.type} "${ioc.value}"${ioc.family ? ` (${ioc.family})` : ""}${ioc.campaign ? ` - ${ioc.campaign}` : ""}`,
         severity: ioc.severity,
         file: relativePath,
         confidence,


### PR DESCRIPTION
Reported in <https://github.com/homeofe/supply-chain-guard/issues/178>.

## The finding, and the half of it that was wrong

The issue reported "77 em dashes across 17 files, 28 of them in the published CHANGELOG,
with no check enforcing the rule". The counts are exact and were re-derived three ways.
The enforcement claim is not: a check existed, ran on every pull request, and sat inside a
required status check. It was green, and it was telling the truth.

The `em-dash` rule's `include` list named six pathspecs. Those six matched none of the 17
files that carried an em dash. `no matches` was the correct answer to the question the
rule was asking. The question had drifted away from the rule.

## Root cause

Three causes, in the order they matter.

1. **Opt-in scope fails open.** Every file created after the rule was written sat outside
   it by default and in silence. All 77 occurrences lived in files the rule could not see,
   and running the new scope checker against the rule exactly as it shipped reports 248
   tracked files with no coverage and no recorded reason.
2. **A config line read like a mechanism and was not one.** `exclude` held `CHANGELOG.md`,
   which reads as the reason the changelog went unchecked. It was inert: a non-empty
   `include` REPLACES the gate's default file set, so `CHANGELOG.md` was never in scope
   for `exclude` to remove. Deleting that entry on its own changes nothing.
3. **The only written statement of the rule was the gate's own `message` field**, and it
   said "banned in docs". Under that wording the 49 source occurrences were not
   violations, so no config edit could be made without first settling a question nobody
   had written down.

## What changed

- **Scope is now opt-out.** The `em-dash` rule's `include` is the single pathspec `*`, so
  a file is covered the moment git tracks it. **267 of 269** tracked files are in scope,
  measured on this branch. (This bullet said "265 of 267" until it was re-run: those
  figures were captured before this pull request's own two new files,
  `scripts/check-em-dash-scope.mjs` and `src/__tests__/em-dash-scope.test.ts`, were
  tracked. `git ls-tree -r --name-only origin/main | wc -l` is 267 and `git ls-files | wc
  -l` on this branch is 269, and those two files are the entire difference. The two
  exclusions and the zero uncovered are unchanged, which is the part the bullet is about:
  the checker counts what git tracks, so a branch that adds files necessarily moves both
  numbers.)
- **The inert `exclude` entry is gone.** The two remaining exclusions each carry a written
  reason in `SCOPE_EXCEPTIONS` in `scripts/check-em-dash-scope.mjs`: the binary demo GIF,
  because a chance byte sequence inside compressed image data is not prose, and the
  handoff archive, because its own header declares its entries preserved verbatim. Both
  hold zero occurrences today, so both preserve rather than suppress.
- **All 77 occurrences are corrected.** Every one of the 77 was the same shape, a space
  followed by U+2014 followed by a space, verified before the edit; each became a plain
  hyphen and no wording changed. The diff is exactly 77 lines added and 77 removed. This
  includes the 11 inside strings the CLI prints, one of which is reachable on a scan of a
  directory containing only a `package.json` and appears twice in that scan's SARIF
  output, which is what adopters upload to GitHub code scanning.
- **A second gate keeps the scope honest.** `scripts/check-em-dash-scope.mjs` runs inside
  `check:aahp`, immediately before the AAHP gates, and therefore inside `npm run build`,
  the `compat` job, and the required `Build and Test` check. No new workflow and no new
  required context.
- **The rule is written down.** `CONTRIBUTING.md` gains a "No em dashes in tracked files"
  section stating the scope, the two narrower scopes that were rejected and why, how to
  exempt a file, and what each exit code means.

The new script is deliberately **not** a second em-dash checker. It never reads the
content of a tracked file and never searches for U+2014. `aahp.config.json` stays the
single source of truth for the rule; the script answers the one question that rule cannot
ask about itself, which is whether its scope still covers the repository.

## Regression test

`src/__tests__/em-dash-scope.test.ts`. The guard against this exact defect is the first
test, `covers every tracked file in this repository`. **The line a reviewer deletes to
redden it is the `"*"` entry of the `em-dash` rule's `include` array in
`aahp.config.json`.** The other five tests pin the checker's own verdicts in throwaway git
fixtures, so a green first test means the checker still knows how to say no.

Every exit code is asserted exactly, never as merely non-zero, because the failure class
here is a check that returns the wrong kind of answer.

## Mutation proofs

Each mutation was applied, then the file on disk was re-read and searched for the mutated
form AND for the absence of the original, then the check was run. Steps are sequenced with
`;` and never with `&&`, so no short-circuit can report a failed chain as a pass. Every
mutation was reverted and the revert verified.

**1. Deleting the named line reddens the regression test.** With `"*"` deleted, leaving an
empty `include` array:

```
em-dash include now: []
mutated form present  (empty include array): True
original form present ("*" in include)   : False

check:em-dash-scope INDETERMINATE (exit 2):
  the "em-dash" rule has no explicit non-empty include list of strings.
  Without one the gate falls back to the pinned CLI's own default file set, which excludes *.ts
  and can change with a dependency bump. State the scope here instead.
CHECKER_EXIT=2

 FAIL  src/__tests__/em-dash-scope.test.ts > em-dash rule scope > covers every tracked file in this repository
AssertionError: expected 'check:em-dash-scope INDETERMINATE (ex...' to contain '0 uncovered'
 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

**2. The new checker, run against the rule exactly as it shipped, names the defect.** The
rule was restored to its pre-change include and exclude lists:

```
include: ['README.md', 'CONTRIBUTING.md', 'SECURITY.md', 'CODE_OF_CONDUCT.md', 'docs/*.md', '.ai/handoff/*.md']
exclude: ['CHANGELOG.md', '.ai/handoff/LOG-ARCHIVE.md']
mutated form present  (pre-fix include+exclude): True
original form present ("*" / assets/demo.gif) : False

check:em-dash-scope INDETERMINATE (exit 2):
  exclude pathspec "CHANGELOG.md" subtracts nothing: no file it matches is in the include set.
  This is exactly the state issue 178 found, where an inert "CHANGELOG.md" entry read like
  the reason the changelog was unchecked. Delete it, or widen include so it means something.
CHECKER_EXIT=2
```

Removing that inert entry, so the config is coherent but still opt-in, gives the other
non-zero answer and states the gap as a number:

```
exclude: ['.ai/handoff/LOG-ARCHIVE.md']
mutated form present  (exclude == LOG-ARCHIVE only): True
original form present (CHANGELOG.md in exclude)    : False

check:em-dash-scope FAILED (exit 1): 248 tracked file(s) outside the "em-dash" rule with no recorded reason.
  - CHANGELOG.md
  - src/scanner.ts
  - src/slsa-verifier.ts
  (248 lines in total)
CHECKER_EXIT=1
```

**3. The content gate now turns red on the two files it used to pass.** One U+2014 put
into `CHANGELOG.md`, which the gate passed before this change:

```
mutated form present  (U+2014 count): 1
original form present (0 U+2014)    : False

  PASS   changelog-format: Changelog format OK: 139 release(s), Keep a Changelog + SemVer, top=[5.28.1] matches package.json.
  FAIL   forbidden-patterns: Forbidden-pattern check failed (1 match(es)).
Governance FAILED: forbidden-patterns.
AAHP_EXIT=1
```

The `changelog-format` line is included so it is clear the red came from
`forbidden-patterns` and not from a malformed changelog. And one U+2014 put back into
`src/scanner.ts`, which the gate also passed before this change:

```
mutated form present  ("rule <U+2014> take"): True
original form present ("rule - take")       : False
U+2014 count in file: 1

  FAIL   forbidden-patterns: Forbidden-pattern check failed (1 match(es)).
Governance FAILED: forbidden-patterns.
AAHP_EXIT=1
```

After reverting that one:

```
mutated form present  ("rule <U+2014> take"): False
original form present ("rule - take")       : True
U+2014 count in file: 0
```

## The original reproduction no longer reproduces

The issue's own probe, plus the two independent methods the reproduction used, all run
against this branch.

Method A, the script from the issue body, decoding every tracked file as UTF-8:

```
files scanned      : 269
files with U+2014  : 0
total U+2014       : 0
unreadable/non-utf8: 1 [('assets/demo.gif', 'UnicodeDecodeError')]
```

Method B, raw count of the UTF-8 byte sequence `E2 80 94` with no decode step, so binary
files are included and a decode bug cannot hide a match:

```
files: 0 occurrences: 0 (scanned 269 files, binary included)
```

Method C, git's own search with a PCRE code point escape:

```
$ git grep -P -c -e '\x{2014}' -- .
GIT_GREP_EXIT=1        (git grep exits 1 when there is no match)
```

Two positive controls, because a search that has silently stopped matching also reports
clean. The same method C invocation against the commit the issue names still finds all 77:

```
$ git grep -P -c -e '\x{2014}' 1a141fe8322345dbd8ec3c449a402eedc3c6d83f -- . | awk -F: '{s+=$NF} END {print s}'
77
```

and the same apparatus pointed at U+2013, which is deliberately out of scope, still finds
the 16 the reproduction counted, on this branch:

```
CHANGELOG.md:1
src/__tests__/cli.test.ts:4
src/__tests__/reporter.test.ts:10
src/slsa-verifier.ts:1
```

So the zero above is a real absence, not a probe that stopped working.

## Decisions and assumptions, recorded in the repository

None of this lives only in this pull request.

- **The scope decision and the two rejected alternatives**: `CONTRIBUTING.md`, section
  "No em dashes in tracked files".
- **Why `include` is `*`, why the inert entry was removed, and where the exclusion reasons
  live**: the `message` field of the `em-dash` rule in `aahp.config.json`, which a reader
  meets at the moment they consider editing it.
- **The reason for each exclusion, and the assumption one of them rests on**: the
  `SCOPE_EXCEPTIONS` table in `scripts/check-em-dash-scope.mjs`. The handoff-archive
  exclusion is labelled in place as an inference from that file's own header rather than
  from a written policy, with the instruction for anyone who disagrees.
- **What the check refuses to answer and why**: the exit-code block in that script's
  header, repeated in `CONTRIBUTING.md`.
- **The session record, including what was deliberately left for the owner**:
  `.ai/handoff/STATUS.md`.

## Bounds and numbers, stated

- **Exit codes are 0, 1 and 2 and nothing else.** 1 keeps the meaning it already has in
  the AAHP gates and in `scripts/check-aahp-pin.mjs`, a policy failure. 2 is the next
  value, claimed by no Node or npm convention, and it means the question could not be
  answered. Both are non-zero, so CI fails either way. The reasoning is in the script
  header.
- **No minimum length is imposed on an exclusion reason.** Any threshold would be
  arbitrary and satisfied by padding. The check is that a reason exists; what makes it
  real is a human reading it in the pull request that adds it. Stated where the table is
  defined.
- **`*` is one pathspec and covers every tracked file, nested paths included**, because a
  git pathspec `*` crosses `/`. That is why no `src/__tests__/*.ts` style entry is needed.
- No timeout, size limit, retry count or tolerance is introduced anywhere by this change.

## Deliberately not in this change

The gate implementation in the pinned AAHP CLI reads each file inside
`try { readFileSync } catch { continue }`, so a file it cannot read is skipped in silence
rather than failing. That is the same fail-open class this issue is about, it ships to
every consumer of that CLI, and it is not this repository's file to fix. It belongs
upstream as its own piece of work, and the note is recorded in `.ai/handoff/STATUS.md` so
it is not lost. A second repository-local em-dash content check was deliberately not added
as a workaround: two sources of truth that can drift is a worse outcome than the hole it
would patch.

The en dash U+2013 is a separate character, is not covered, and that is now written down
as a choice in `CONTRIBUTING.md` rather than left as an apparent oversight.

## How this was verified

Everything below was run in a fresh full clone of this public repository, never in a
working checkout, on Node v24.14.1 with `npm ci --ignore-scripts` and the pinned AAHP CLI
v3.9.2. The branch was cut from `origin/main` at
`1a141fe8322345dbd8ec3c449a402eedc3c6d83f`, which is the exact commit the issue names, so
there is no drift between the audit and this fix.

| what | result |
| --- | --- |
| `npx --no-install aahp check .` on the corrected tree | 7 gates ran, no failures, exit 0 |
| `node scripts/check-em-dash-scope.mjs` | `check:em-dash-scope OK - 267 of 269 tracked file(s) in the "em-dash" rule's scope, 2 excluded with a written reason, 0 uncovered.`, exit 0 (re-run on the branch as it stands; the row read `265 of 267` from a run taken before this branch's own two new files were tracked) |
| `npx tsc --noEmit` | exit 0 |
| `npx vitest run src/__tests__/em-dash-scope.test.ts` | 6 passed, exit 0 |
| `npx vitest run src/__tests__/reporter.test.ts src/__tests__/slsa-verifier.test.ts` | 105 passed, exit 0 |

The full suite was deliberately not run locally; Linux CI is the authoritative full-suite
verdict, and this change touches no logic.

Two reasons no existing assertion can be broken by the character swap, stated because
"the tests pass" is a weaker claim than "they could not have failed":

1. **No test can be asserting the old form.** There are now zero U+2014 anywhere in the
   tree, tests included, verified by all three methods above. An assertion on the old text
   would itself have had to contain the character.
2. **The swap is length preserving.** U+2014 and `-` are each one UTF-16 code unit, so the
   width arithmetic in the text reporter's box drawing is unchanged. `reporter.test.ts` is
   in the run above for that reason, and its two relevant assertions,
   `toContain("No findings")` and `not.toMatch(/No findings[^\n]*clean/i)`, are
   dash-insensitive in any case.

The reproduction's own probe is answered by execution rather than by a static proxy: the
issue asked for `CHANGELOG.md` to contain zero U+2014 and for a check that turns red when
one is added, and both are demonstrated above by running the gate, not by inspecting the
config.

### The authoritative verdict, from CI

Linux CI on this branch, run
<https://github.com/homeofe/supply-chain-guard/actions/runs/32586372611>: `compat (Node 20)`
and `compat (Node 22)` both pass, which is where `npm run build` executes `check:aahp` and
therefore the new scope checker, and `Build and Test`, `aahp-verify`, `PR metadata policy`
and `Docker build and smoke` all pass. That is the full suite on both supported Node
majors, run on the platform the project ships from.

