### PR TITLE
fix(ci): run the compat matrix on the current Active LTS and gate it

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,9 +11,9 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:c3d520f853b536bf278ab92e1a6c86c41083b03e84b1e97e64bad69153375486",
+      "checksum": "sha256:ef987ab7fbae3ca091f4191e819df8196284b0805d77cff8a98af480ac9d5e9d",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2786,
+      "lines": 2815,
       "summary": "Model: claude-opus-5. Branch fix/176-compat-matrix-reaches-active-lts. No version bump."
     },
     "NEXT_ACTIONS.md": {
@@ -80,8 +80,8 @@
   "quick_context": "Model: claude-opus-5. Branch fix/176-compat-matrix-reaches-active-lts. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 34158,
-    "full_read": 45820
+    "manifest_plus_core": 34554,
+    "full_read": 46216
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,10 +11,10 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1b0b50a17bc818e59d1773fea20c421633d2e6ea1de520f92f33a0d259a17b6e",
+      "checksum": "sha256:c3d520f853b536bf278ab92e1a6c86c41083b03e84b1e97e64bad69153375486",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2727,
-      "summary": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump."
+      "lines": 2786,
+      "summary": "Model: claude-opus-5. Branch fix/176-compat-matrix-reaches-active-lts. No version bump."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Model: claude-opus-5. Branch fix/176-compat-matrix-reaches-active-lts. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 32959,
-    "full_read": 44621
+    "manifest_plus_core": 34158,
+    "full_read": 45820
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -57,11 +57,40 @@ Both live in `docs/node-support.md` so the next reader meets them at the code:
 - **Why `activeLtsMajor` is hand-copied rather than fetched**, what the gate can and
   cannot catch about a hand-copied fact, and why the deadline is `5.29.0`.
 
+### What adding the third leg exposed, and why it had to be fixed here
+
+The Node 24 leg went red on its first run, and the cause was not Node 24. The perf case
+`keeps exact greedy/lazy endpoints on 5 MiB repeated completions` in
+`src/__tests__/multi-line-pattern-engine.test.ts` timed out at 15,070ms against a bare
+`timeout: 15_000`. Measured across the three legs of that single run: Node 20 8,734ms,
+Node 22 13,622ms, Node 24 15,070ms. The same case had already failed the **Node 22** leg
+on `main` at `1a141fe`, at 15,137ms, with no Node 24 anywhere. The budget sits inside the
+runner's own noise band, so it reports noise, not an algorithmic regression.
+
+Underneath that is a real inconsistency. `npm run test:coverage`, the only command the
+compat legs run, sets `SCG_VITEST_COVERAGE=1` in `vitest.config.ts`, which makes
+`performanceBudget` multiply by five. So the assertion inside that test allowed 50,000ms
+while the harness killed it at 15,000ms: **the guard could never be reached under the
+command CI actually runs.** Both `it` options in that file now use
+`performanceBudget(15_000)`, which is what every sibling perf test already did. Outside a
+coverage run `performanceBudget` is the identity, so `npm test` is bit for bit unchanged,
+and the algorithmic guard, `performanceBudget(10_000)`, is untouched.
+
 ### Open for the owner
 
-Unrelated to this change, observed while measuring: the perf case in
-`src/__tests__/multi-line-pattern-engine.test.ts` timed out at 15000ms on a Node 22 leg
-at the head sha this report was written against. Not touched here.
+The same bare-literal pattern is still elsewhere, deliberately left because it is outside
+this change and touching a dozen test files in a Node matrix pull request would be worse
+than naming it. Counted, not estimated:
+
+- **2 files import `performanceBudget` and still use a bare `timeout:` literal**, which is
+  exactly the inconsistency fixed above: `src/__tests__/core-broad-gap-matchers.test.ts`
+  and `src/__tests__/internal-disclosure.test.ts`.
+- **10 further files use a bare `timeout:` literal** without importing it. Some of those
+  have no scaled assertion to disagree with, so they need reading rather than rewriting.
+
+A gate could assert that no file importing `performanceBudget` also carries a bare
+`timeout:` literal. It is not added here, because it would be red on the two files above
+on the day it landed, and a gate that ships red teaches people to ignore it.
 
 ---
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,65 @@
 
 ---
 
+## The engines floor had no ceiling, so the matrix never ran the Active LTS (2026-08-22, unreleased)
+
+Model: claude-opus-5. Branch fix/176-compat-matrix-reaches-active-lts. No version bump.
+Reported as https://github.com/homeofe/supply-chain-guard/issues/176
+
+### What the report said, and what was actually wrong
+
+The report compared `.github/workflows/ci.yml` against `package.json` and found a
+Node 20 leg below an `engines.node` floor of `>=22.0.0`. Every count in it
+re-derives exactly. Its conclusion does not follow: `docs/node-support.md` declares
+`supportedMajors` and `transitionMajors` as disjoint lists, the gate already asserted
+a transition major is strictly below the floor, and `README.md` tells consumers the
+package requires Node 22 or newer. The Node 20 leg is a dated, gate-enforced
+transition lane, deleted in 5.29.0 by an assertion that fails the build. It stays.
+
+The report's own measurement contained the real defect, one line below its headline:
+**legs above the floor, 0 of 2.** `engines.node` is a floor with no ceiling, so
+`>=22.0.0` claims Node 22 and every major after it, and the matrix stopped at 22. Read
+against the upstream `nodejs/Release` schedule on 2026-08-22, Node 22 had been in
+Maintenance LTS since 2025-10-21 and Node 24 had been Active LTS since 2025-10-28. The
+only major the project supported was the one already in maintenance, and the major
+consumers are migrating onto was claimed and never executed. `@types/node` is on the
+Node 26 API surface, so an API available only above Node 22 would have type-checked
+clean, passed both legs, and failed in a consumer's hands.
+
+### What changed
+
+`docs/node-support.md` gains `activeLtsMajor` (24) and `activeLtsReviewedIn` (5.29.0),
+`supportedMajors` becomes `[22, 24]`, and the `compat` matrix becomes 20, 22 and 24.
+`src/__tests__/node-version-contract.test.ts` gains ten cases: five that assert the
+claim reaches the top of its own range and carries a re-read deadline, and five that
+assert the workflow comment keeps naming the policy vocabulary. That comment called the
+matrix "every Node major this package supports" four lines above a pointer to the policy
+whose subject is that supported and tested are different lists, which is the most
+plausible reason this report exists at all.
+
+Restoring the exact pre-change configuration turns exactly the two new upward cases red
+and leaves the other 36 green, which is the demonstration that nothing in the repository
+could see this before.
+
+### Decisions recorded in the repository, not here
+
+Both live in `docs/node-support.md` so the next reader meets them at the code:
+
+- **Why the bound is the Active LTS**, with the two rejected alternatives and their
+  costs. `engines.node` deliberately keeps no upper bound, so majors above the Active
+  LTS (Node 26 today) are claimed and not executed. That residual is stated, and the
+  alternative that would close it is written out with exactly what to change.
+- **Why `activeLtsMajor` is hand-copied rather than fetched**, what the gate can and
+  cannot catch about a hand-copied fact, and why the deadline is `5.29.0`.
+
+### Open for the owner
+
+Unrelated to this change, observed while measuring: the perf case in
+`src/__tests__/multi-line-pattern-engine.test.ts` timed out at 15000ms on a Node 22 leg
+at the head sha this report was written against. Not touched here.
+
+---
+
 ## The required handoff gate compared main to itself on every push (2026-08-22, unreleased)
 
 Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,27 +48,46 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Complete build and test on every Node major this package supports.
+  # Complete build and test on every Node major this repository RUNS. That is not
+  # the same set as the majors it SUPPORTS, and the difference is deliberate.
   #
-  # The contract: the package must install, pass every governance gate, pass the
-  # FULL suite, and run FROM ITS PACKED TARBALL on each major it claims. There is
+  # THE INVARIANT, so that an edit to either side has something to preserve:
+  #
+  #   this matrix  ==  supportedMajors + transitionMajors  (docs/node-support.md)
+  #
+  #   supportedMajors  majors the package promises to work on. Every one is at or
+  #                    above engines.node in package.json, and the highest reaches
+  #                    at least activeLtsMajor, the upstream Active LTS. Without
+  #                    that upper assertion, engines.node ">=22.0.0" would go on
+  #                    claiming every major above 22 with none of them executed.
+  #   transitionMajors majors still fully tested but BELOW the floor and OUT OF
+  #                    SUPPORT, so a consumer who has not migrated is warned by
+  #                    npm rather than broken. Each one carries the release that
+  #                    deletes it. Node 20 reached end of life on 2026-04-30 and
+  #                    its lane is deleted in 5.29.0.
+  #
+  # So a leg below engines.node is expected here and is not a support claim, and a
+  # leg above engines.node is required here and is not optional coverage.
+  #
+  # The contract each leg proves: the package must install, pass every governance
+  # gate, pass the FULL suite, and run FROM ITS PACKED TARBALL. There is
   # deliberately no reduced smoke lane, because a lane that runs less than the
   # real suite proves less than the real suite, and the difference is exactly
   # where a version incompatibility hides.
   #
-  # This matrix is DERIVED from docs/node-support.md, which is the single
+  # This list is DERIVED from docs/node-support.md, which is the single
   # authoritative policy. Do not treat this list as the source of truth.
-  # src/__tests__/node-version-contract.test.ts fails the build if any other
-  # declaration site in the repo drifts from it. See docs/node-support.md.
+  # src/__tests__/node-version-contract.test.ts fails the build if this matrix,
+  # or any other declaration site in the repo, drifts from that policy.
   compat:
     name: compat (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
     strategy:
-      # Both majors always report. Stopping the 22 leg because 20 failed would
-      # hide the compatibility difference this matrix exists to surface.
+      # Every leg always reports. Stopping the 22 and 24 legs because 20 failed
+      # would hide the compatibility difference this matrix exists to surface.
       fail-fast: false
       matrix:
-        node: ['20', '22']
+        node: ['20', '22', '24']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -204,7 +223,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Per-major name: two matrix legs uploading one artifact name collide.
+          # Per-major name: matrix legs uploading one artifact name collide.
           name: coverage-summary-node${{ matrix.node }}
           path: coverage/coverage-summary.json
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ### Changed
 
+- **The Node compatibility matrix now runs the current Active LTS, and the gate
+  asserts that it does.** `engines.node` is `>=22.0.0`, a floor with no ceiling, so
+  the package claims Node 22 and every major after it. The matrix stopped at 22, so
+  the whole claim above the floor was made and never executed. Read against the
+  upstream `nodejs/Release` schedule on 2026-08-22, that was not academic: Node 22
+  had been in Maintenance LTS since 2025-10-21, while Node 24, Active LTS since
+  2025-10-28, was claimed and never run. Because `@types/node` is on the Node 26 API
+  surface, an API available only above Node 22 would have type-checked clean, passed
+  every leg, and failed in a consumer's hands. `docs/node-support.md` gains
+  `activeLtsMajor`, `src/__tests__/node-version-contract.test.ts` asserts
+  `max(supportedMajors)` reaches it and that the matrix runs a leg at or above it,
+  and the `compat` matrix is now Node 20, 22 and 24. The Node 20 transition lane is
+  unchanged and is still deleted in 5.29.0. Reported as
+  https://github.com/homeofe/supply-chain-guard/issues/176
+- **The comment above the `compat` matrix no longer contradicts the policy it points
+  at.** It described the matrix as "every Node major this package supports" four
+  lines above a pointer to a policy whose subject is that supported and tested are
+  deliberately different lists, so a reader of `.github/workflows/ci.yml` alone
+  concluded the repository disagreed with itself. It now states the invariant in the
+  policy's own vocabulary, and five test cases assert that the comment keeps naming
+  `supportedMajors`, `transitionMajors`, `activeLtsMajor`, the policy document and
+  the test that enforces it.
 - **Benchmark evidence in this project's own artefacts now carries counts, never
   consumer repository names.** Two `CHANGELOG.md` entries (v5.2.40, v5.2.41) cited
   a private repository and an internal issue number as the provenance of a security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
   and the `compat` matrix is now Node 20, 22 and 24. The Node 20 transition lane is
   unchanged and is still deleted in 5.29.0. Reported as
   https://github.com/homeofe/supply-chain-guard/issues/176
+- **A perf test's harness timeout is now scaled the same way its own assertion is, so
+  the guard is reachable under the command CI runs.** `npm run test:coverage` sets
+  `SCG_VITEST_COVERAGE=1`, which makes `performanceBudget` multiply by five. Two cases in
+  `src/__tests__/multi-line-pattern-engine.test.ts` asserted against a scaled 50,000 ms
+  budget while a bare `timeout: 15_000` killed them at 15,000 ms, so the algorithmic
+  guard could never be evaluated and a failure reported runner noise instead. Measured
+  across one CI run: the same case took 8,734 ms on Node 20, 13,622 ms on Node 22 and
+  15,070 ms on Node 24, and it had already failed the Node 22 leg on `main` at 15,137 ms
+  with no Node 24 involved. Outside a coverage run `performanceBudget` is the identity,
+  so `npm test` is unchanged, and the `performanceBudget(10_000)` assertion that catches
+  a real regression is untouched.
 - **The comment above the `compat` matrix no longer contradicts the policy it points
   at.** It described the matrix as "every Node major this package supports" four
   lines above a pointer to a policy whose subject is that supported and tested are

--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ Links individual findings into incident-level attack chains:
 
 ## Installation
 
-**Requires Node.js 22 or newer.** Node 20 reached end of life on
+**Requires Node.js 22 or newer.** Every release runs its complete test suite, and
+installs and executes its own packed tarball, on Node 22 and on Node 24, the current
+Active LTS. Node 20 reached end of life on
 2026-04-30; it still installs and is still covered by CI as a transition lane, but it
 is out of support and that lane is removed in 5.29.0. Full policy, including what the
 package is published from and what the Action and container image run on:

--- a/docs/node-support.md
+++ b/docs/node-support.md
@@ -12,9 +12,11 @@ Change the policy here and the gate names every file that has to follow.
 {
   "baseline": 22,
   "enginesFloor": "22.0.0",
-  "supportedMajors": [22],
+  "supportedMajors": [22, 24],
   "transitionMajors": [20],
   "transitionRemovedIn": "5.29.0",
+  "activeLtsMajor": 24,
+  "activeLtsReviewedIn": "5.29.0",
   "publishMajor": 22,
   "runtimeMajor": 22,
   "devBaseline": 22
@@ -28,6 +30,8 @@ Change the policy here and the gate names every file that has to follow.
 | `supportedMajors` | majors that are supported and fully tested | the `compat` matrix in `ci.yml` |
 | `transitionMajors` | majors still verified but NO LONGER SUPPORTED | the `compat` matrix in `ci.yml` |
 | `transitionRemovedIn` | the release that deletes the transition lane | asserted against `package.json` version |
+| `activeLtsMajor` | the upstream Active LTS major `supportedMajors` must reach | asserted against `supportedMajors` and the `compat` matrix |
+| `activeLtsReviewedIn` | the release by which `activeLtsMajor` must be re-read from upstream | asserted against `package.json` version |
 | `publishMajor` | the major the npm artifact is published from | the `publish` job in `ci.yml` |
 | `runtimeMajor` | the major the published Action and image execute on | `action.yml`, `Dockerfile` |
 | `devBaseline` | what a contributor should develop on | `.devcontainer/devcontainer.json` |
@@ -48,6 +52,86 @@ major is strictly **below** it. A major cannot be in both lists. If a transition
 were allowed at or above the floor it would be indistinguishable from a supported one,
 which is how "temporary" support becomes permanent.
 
+## The support claim has a top as well as a bottom
+
+`engines.node` is a **floor with no ceiling**. `>=22.0.0` is a claim about Node 22 and
+about every major after it, including majors that do not exist yet. Before the
+`activeLtsMajor` field existed, the `compat` matrix stopped at 22, so the entire claim
+above the floor was made and never executed. That is the same defect the floor half of
+this policy exists to prevent, in the opposite direction: a statement about a runtime
+with nothing behind it.
+
+It was not hypothetical. Read against the upstream `nodejs/Release` schedule on
+**2026-08-22**, Node 22 entered **Maintenance** LTS on 2025-10-21 and Node 24 has been
+**Active** LTS since 2025-10-28. So the only major the project supported was the one
+already in maintenance, and the major consumers are actively migrating onto was claimed
+by `engines.node` and never run. The devDependency `@types/node` is on the Node 26 API
+surface, so an API that exists only above Node 22 would type-check clean, pass every
+leg of the matrix, and fail in a consumer's hands.
+
+**The invariant, asserted by the gate:** `max(supportedMajors)` is at or above
+`activeLtsMajor`, and at least one leg of the `compat` matrix is at or above it too.
+
+### Why the bound is the Active LTS and not something else
+
+The claim is unbounded, so it cannot be covered exhaustively; a bound has to be chosen
+and stated. The choices considered, and why this one:
+
+- **At or above the current Active LTS** (chosen). The Active LTS is the major that
+  consumers are moving their CI and their production images onto, and it is the major a
+  security tool is most likely to be invoked under for the next two years. It changes
+  once a year, in October, so the matrix does not churn.
+- **Every LTS major that is not end of life.** Rejected: it grows the matrix without
+  adding a distinct runtime risk, since Maintenance LTS majors receive no new language
+  or API surface. Note that the baseline major stays in the matrix on its own account,
+  so a Maintenance LTS baseline is covered anyway.
+- **Every major upstream currently ships, including the Current line.** Rejected: the
+  Current line turns over every six months, so the matrix would need an edit twice a
+  year to stay green, and a gate that has to be edited on a calendar is a gate people
+  learn to edit without reading.
+
+### The residual this leaves, stated rather than hidden
+
+Majors above `activeLtsMajor` are claimed by `engines.node` and are **not executed**.
+On 2026-08-22 that is Node 26, which is on the Current line and becomes LTS on
+2026-10-28. A consumer running the package on a Current-line major is inside the
+declared range and outside the tested range. That is a deliberate trade, not an
+oversight.
+
+The alternative, **not** chosen, and exactly what to change if a future maintainer
+prefers it: give `engines.node` an upper bound, for example `>=22.0.0 <25.0.0`, and add
+a gate case asserting the ceiling equals `max(supportedMajors) + 1`. That closes the
+residual completely and costs a release every time a new major lands, plus an
+`EBADENGINE` warning for every consumer who upgrades Node before this package cuts that
+release. For a tool that is installed broadly and often run in someone else's CI, the
+warning noise was judged worse than the untested Current line. Revisit that judgement if
+this package ever starts using an API whose behaviour differs across majors.
+
+### `activeLtsMajor` is a fact from upstream, and it goes stale
+
+The field is a **hand-copied constant, verified on 2026-08-22 against the
+`nodejs/Release` schedule**. It is not derived at test time: a gate that resolves an
+upstream fact over the network is a gate whose result depends on a stranger's uptime,
+which is precisely the class of dependency this package exists to flag.
+
+A hand-copied constant goes stale silently, so it carries a deadline in the same shape
+as `transitionRemovedIn`: `activeLtsReviewedIn` is compared against the version in
+`package.json`, and the gate **fails the build** once the project reaches that version.
+Re-read the upstream schedule, correct `activeLtsMajor` if it moved, and move
+`activeLtsReviewedIn` forward in a diff someone reviews.
+
+The gate asserts `activeLtsMajor` is at or above `enginesFloor`, which catches the
+value being dropped far enough to make the invariant vacuous, and catches a floor
+raised above the Active LTS. It cannot catch a **wrong** value that is still at or
+above the floor, because no assertion can check a hand-copied upstream fact without
+going to the network. The deadline is the mitigation, and it is the only one.
+
+Why `5.29.0` for that deadline: it is the next minor, it is the tightest value that
+still lets the current release ship, and it is already the release that deletes the
+Node 20 lane, so both Node policy chores land in the same review rather than in two.
+The next upstream change is Node 26 entering LTS on **2026-10-28**, which is the fact
+the reviewer will be checking for.
+
 ## Node 20 is a transition lane, not a baseline
 
 Node 20 reached end of life on **2026-04-30**, confirmed against the upstream
@@ -65,6 +149,25 @@ tests another, publishing uses a third and distribution executes a fourth.
 warning, not an error**, unless the consumer sets `engine-strict=true`. So a consumer
 still on Node 20 is warned rather than broken, which is exactly what a transition
 period is for.
+
+### Recorded decision: the leg below the floor stays until 5.29.0
+
+A matrix leg below `engines.node` looks like a contradiction when `ci.yml` and
+`package.json` are read side by side without this file, and it was reported as one in
+https://github.com/homeofe/supply-chain-guard/issues/176. The decision, recorded here so
+that the next reader meets it rather than re-derives it: **the Node 20 leg is not
+removed early.**
+
+- It does not claim support. `supportedMajors` and `transitionMajors` are disjoint
+  lists, the gate asserts a transition major is strictly below the floor, and
+  `README.md` tells consumers the package requires Node 22 or newer.
+- Removing it early would delete the only evidence that a consumer who has not migrated
+  can still install and run this package, one minor release before the milestone below
+  deletes the lane anyway.
+- The milestone is enforced by the build, not by memory, so the lane cannot outlive it.
+
+What that report did surface, correctly, is that the matrix tested nothing **above** the
+floor either. That half was a real gap and is fixed by `activeLtsMajor` above.
 
 ## The removal milestone, and why it cannot be forgotten
 
@@ -87,9 +190,9 @@ To extend the deadline instead, `transitionRemovedIn` has to be edited deliberat
 in a diff someone reviews, with a reason. That is the difference between a decision
 and a drift.
 
-## Two invariants that were being violated
+## Three invariants that were being violated
 
-Both are asserted, and both were false before this policy existed:
+All three are asserted, and all three were false before the assertion existed:
 
 - **`runtimeMajor` must be a supported major.** The published Action and the published
   container image both ran on Node 22 while CI built and tested only on Node 20, so the
@@ -97,6 +200,10 @@ Both are asserted, and both were false before this policy existed:
 - **`publishMajor` must be a supported major.** An artifact must not be built by a
   toolchain the suite has never run under. Until v5.28.0 the npm artifact was published
   from Node 20, a third runtime distinct from both the tested one and the executed one.
+- **`supportedMajors` must reach `activeLtsMajor`.** Before this field existed the matrix
+  stopped at the floor, so `>=22.0.0` claimed Node 24 and Node 26 while neither ran,
+  and the only supported major was one that had been in Maintenance LTS since
+  2025-10-21.
 
 ## The npm pin on the publish job
 

--- a/src/__tests__/multi-line-pattern-engine.test.ts
+++ b/src/__tests__/multi-line-pattern-engine.test.ts
@@ -452,7 +452,16 @@ exec(payload)
     },
   );
 
-  it("scans concrete 5 MiB repeated-prefix near misses in practical linear time", { timeout: 15_000 }, () => {
+  // The harness timeout is scaled the same way the assertion inside it is. Without
+  // that, the two disagree under the ONE command CI actually runs. `npm run
+  // test:coverage` sets SCG_VITEST_COVERAGE=1 (vitest.config.ts), which makes
+  // performanceBudget multiply by 5: the assertion below then allows 25s while a bare
+  // `timeout: 15_000` killed the test at 15s, so the guard could never be reached and
+  // the failure reported runner noise rather than an algorithmic regression. Outside a
+  // coverage run performanceBudget is the identity, so this is a no-op for `npm test`.
+  // Measured on one CI run of this file's sibling case: Node 20 8,734ms, Node 22
+  // 13,622ms, Node 24 15,070ms, against a 15,000ms bare ceiling.
+  it("scans concrete 5 MiB repeated-prefix near misses in practical linear time", { timeout: performanceBudget(15_000) }, () => {
     const size = 5 * 1024 * 1024;
     const cases: Array<[string, string, string]> = [
       ["SCRIPT_CURL_EXEC", "curl ", "i"],
@@ -475,7 +484,13 @@ exec(payload)
     expect(Date.now() - started).toBeLessThan(performanceBudget(5_000));
   });
 
-  it("keeps exact greedy/lazy endpoints on 5 MiB repeated completions", { timeout: 15_000 }, () => {
+  // Same scaling, same reason as the case above. This is the case that actually went
+  // red: on main at 1a141fe it timed out on the Node 22 leg at 15,137ms, and on the
+  // pull request that added the Node 24 leg it timed out at 15,070ms, both against the
+  // bare 15,000ms ceiling while the assertion below allowed 50,000ms under coverage.
+  // The algorithmic guard is unchanged: performanceBudget(10_000) below is still what
+  // fails on a real regression.
+  it("keeps exact greedy/lazy endpoints on 5 MiB repeated completions", { timeout: performanceBudget(15_000) }, () => {
     const size = 5 * 1024 * 1024;
     const cases = [
       ["SCRIPT_CURL_EXEC", "curl x | bash ", "bash", 4, "last"],

--- a/src/__tests__/node-version-contract.test.ts
+++ b/src/__tests__/node-version-contract.test.ts
@@ -29,6 +29,24 @@
  * transition lane still exists. The transition cannot outlive its own deadline,
  * because the release that would carry it past cannot be built.
  *
+ * THE CLAIM HAS A TOP TOO
+ * -----------------------
+ * `engines.node` is a floor with no ceiling, so ">=22.0.0" is a promise about Node 22
+ * AND about every major after it. Everything above described only the bottom of that
+ * range, and the matrix used to stop at the floor, so the whole promise above 22 was
+ * made and never executed. On 2026-08-22 that mattered concretely: Node 22 had been in
+ * Maintenance LTS since 2025-10-21 while Node 24, Active LTS since 2025-10-28, was
+ * claimed and never run. `@types/node` is on the Node 26 API surface, so an API that
+ * exists only above 22 would type-check clean, pass every leg, and fail for a consumer.
+ *
+ * So `activeLtsMajor` is asserted from above the way the floor is asserted from below:
+ * max(supportedMajors) must reach it, and the matrix must run a leg at or above it.
+ * It is a hand-copied upstream fact rather than a network lookup, because a gate that
+ * resolves a fact over the wire is a gate that depends on a stranger's uptime. A
+ * hand-copied fact goes stale silently, so it carries `activeLtsReviewedIn`, the same
+ * version-keyed deadline shape `transitionRemovedIn` uses. Reported as
+ * https://github.com/homeofe/supply-chain-guard/issues/176
+ *
  * The policy itself lives in docs/node-support.md as a machine-readable block, so
  * the documentation cannot drift from the configuration either: this test parses
  * that block and holds every declaration site to it.
@@ -47,6 +65,15 @@ interface NodePolicy {
   supportedMajors: number[];
   transitionMajors: number[];
   transitionRemovedIn?: string;
+  /**
+   * The upstream Active LTS major, hand-copied from the nodejs/Release schedule and
+   * verified on 2026-08-22 (Node 24: Active LTS from 2025-10-28, Maintenance from
+   * 2026-10-20). Deliberately NOT resolved over the network at test time.
+   * `activeLtsReviewedIn` is what stops this constant going stale in silence.
+   */
+  activeLtsMajor: number;
+  /** Release by which `activeLtsMajor` must be re-read from upstream. */
+  activeLtsReviewedIn: string;
   publishMajor: number;
   runtimeMajor: number;
   devBaseline: number;
@@ -76,6 +103,21 @@ function cmp(a: string, b: string): number {
     if ((pa[i] ?? 0) !== (pb[i] ?? 0)) return (pa[i] ?? 0) - (pb[i] ?? 0);
   }
   return 0;
+}
+
+/**
+ * The majors the `compat` matrix in ci.yml actually declares, ascending.
+ * Read here rather than inline so the "exactly the lanes" case and the "reaches the
+ * Active LTS" case cannot drift into reading two different things.
+ */
+function compatMatrix(): number[] {
+  const ci = read(".github/workflows/ci.yml");
+  const m = ci.match(/matrix:\s*\n\s*node:\s*\[([^\]]*)\]/);
+  if (!m) throw new Error("no compat matrix found in .github/workflows/ci.yml");
+  return m[1]!
+    .split(",")
+    .map((s) => Number(s.trim().replace(/['"]/g, "")))
+    .sort((a, b) => a - b);
 }
 
 /** `node-version: '20'` / `node-version: "22"` / `node-version: 20`. */
@@ -175,6 +217,109 @@ describe("node version policy", () => {
     });
   });
 
+  describe("the support claim reaches the top of its own range", () => {
+    // `engines.node` is a floor with no ceiling, so every case above this point
+    // constrains only the bottom of the promise. These constrain the top. Without
+    // them the matrix can sit entirely at the floor while `>=22.0.0` goes on
+    // claiming every major above it, which is what
+    // https://github.com/homeofe/supply-chain-guard/issues/176 measured: 0 of 2 legs
+    // above the floor against a declared range of [22, unbounded].
+
+    it("the declared Active LTS is at or above the engines floor", () => {
+      // Ordered first because it is what stops the next two cases passing
+      // vacuously: drop `activeLtsMajor` below the floor and "supported reaches the
+      // Active LTS" becomes true for free. It is also a real defect in its own
+      // right, in the other direction: a floor above the Active LTS would require
+      // every consumer of a supply-chain security tool onto the Current line.
+      //
+      // WHAT THIS CANNOT CATCH, said plainly rather than left as a surprise:
+      // `activeLtsMajor` lowered to exactly the floor still passes here, and the two
+      // cases below then hold trivially. Nothing in a test can tell a correct
+      // hand-copied upstream fact from an incorrect one without asking the network,
+      // and asking the network is the trade this gate refuses. `activeLtsReviewedIn`
+      // is the answer instead: the fact must be re-read on a deadline, in a reviewed
+      // diff, which is a decision rather than a drift.
+      expect(
+        P.activeLtsMajor,
+        `activeLtsMajor ${P.activeLtsMajor} is below the engines floor ${FLOOR}: either the floor demands a runtime newer than the Active LTS, or activeLtsMajor is stale`,
+      ).toBeGreaterThanOrEqual(FLOOR);
+    });
+
+    it("the supported majors reach the current Active LTS", () => {
+      // The Active LTS is the major consumers are migrating their CI and their
+      // production images onto. Claiming it in `engines.node` while never executing
+      // it is the same defect as claiming a floor nothing tests, pointed upward.
+      // Majors ABOVE the Active LTS (the Current line) are a stated, deliberate
+      // residual, not an oversight. See docs/node-support.md.
+      expect(
+        Math.max(...P.supportedMajors),
+        `supportedMajors [${P.supportedMajors}] stops below the Active LTS ${P.activeLtsMajor}, which engines.node "${P.enginesFloor}" and up already claims`,
+      ).toBeGreaterThanOrEqual(P.activeLtsMajor);
+    });
+
+    it("the CI compat matrix runs a leg at or above the current Active LTS", () => {
+      // Redundant with the case above only while the "exactly the lanes" case also
+      // holds. Stated separately because this is the invariant in the form a reader
+      // of ci.yml is looking for, and a reader who cannot find it assumes it is absent.
+      const declared = compatMatrix();
+      expect(
+        declared.filter((m) => m >= P.activeLtsMajor),
+        `compat matrix [${declared}] runs no leg at or above the Active LTS ${P.activeLtsMajor}`,
+      ).not.toEqual([]);
+    });
+
+    it("the Active LTS declaration carries a review milestone", () => {
+      // `activeLtsMajor` is hand-copied from upstream, so it cannot notice that it
+      // has gone stale. An upstream fact with no re-read deadline is exactly the
+      // "note someone has to remember" this policy file exists to avoid.
+      expect(P.activeLtsReviewedIn, "activeLtsMajor without activeLtsReviewedIn is an upstream fact with no expiry").toBeTruthy();
+      expect(P.activeLtsReviewedIn).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it("the project has not passed the Active LTS review milestone", () => {
+      // Same teeth, same shape, same reason as transitionRemovedIn: version-keyed
+      // rather than clock-keyed, so the build never turns red on an unrelated pull
+      // request because a date rolled over.
+      const version = JSON.parse(read("package.json")).version as string;
+      expect(
+        cmp(version, P.activeLtsReviewedIn),
+        `version ${version} has reached the Active LTS review milestone ${P.activeLtsReviewedIn}: re-read the nodejs/Release schedule, correct activeLtsMajor if it moved, and move activeLtsReviewedIn forward deliberately`,
+      ).toBeLessThan(0);
+    });
+  });
+
+  describe("the workflow comment states the invariant instead of contradicting it", () => {
+    // The comment above the compat matrix used to call it "every Node major this
+    // package supports", four lines above a pointer to a policy whose whole subject
+    // is that supported and tested are different lists. A reader of ci.yml alone
+    // concluded the repository contradicted itself, and filed
+    // https://github.com/homeofe/supply-chain-guard/issues/176 saying so.
+    //
+    // Membership, not phrasing: a comment that names both lists cannot also claim the
+    // matrix is only what the package supports, and requiring the names keeps the
+    // pointer to the policy and its gate from being dropped in a later rewrite.
+    const compatHeader = () => {
+      const ci = read(".github/workflows/ci.yml");
+      const start = ci.indexOf("\njobs:");
+      const end = ci.indexOf("\n    steps:");
+      expect(start, "no jobs: block in ci.yml").toBeGreaterThan(-1);
+      expect(end, "no steps: block in the first ci.yml job").toBeGreaterThan(start);
+      return ci.slice(start, end);
+    };
+
+    for (const term of [
+      "supportedMajors",
+      "transitionMajors",
+      "activeLtsMajor",
+      "docs/node-support.md",
+      "src/__tests__/node-version-contract.test.ts",
+    ]) {
+      it(`the compat job comment names ${term}`, () => {
+        expect(compatHeader(), `the comment above the compat matrix no longer names ${term}`).toContain(term);
+      });
+    }
+  });
+
   describe("normative sites match the policy exactly", () => {
     it("package.json engines.node is the declared floor", () => {
       const pkg = JSON.parse(read("package.json"));
@@ -182,14 +327,7 @@ describe("node version policy", () => {
     });
 
     it("the CI compat matrix is exactly the supported plus transition majors", () => {
-      const ci = read(".github/workflows/ci.yml");
-      const m = ci.match(/matrix:\s*\n\s*node:\s*\[([^\]]*)\]/);
-      expect(m, "no compat matrix found in ci.yml").toBeTruthy();
-      const declared = m![1]!
-        .split(",")
-        .map((s) => Number(s.trim().replace(/['"]/g, "")))
-        .sort((a, b) => a - b);
-      expect(declared).toEqual(ALL_LANES);
+      expect(compatMatrix()).toEqual(ALL_LANES);
     });
 
     it("the CI publish job runs on the publish major", () => {


### PR DESCRIPTION
## Description

Addresses https://github.com/homeofe/supply-chain-guard/issues/176. Deliberately **not**
a closing keyword: one of that issue's four acceptance criteria is declined on evidence
rather than implemented, so whether the issue closes is the owner's call, not this pull
request's.

The report asked which of two statements is wrong, the `engines.node` floor or the CI
matrix. Answered from evidence: **the floor is right, and the matrix was wrong at the
top, not at the bottom.**

| acceptance criterion | outcome |
| --- | --- |
| 1. no leg sits below the declared floor | **declined**, with reasoning recorded in `docs/node-support.md`. The Node 20 leg is a dated transition lane, not a support claim, and it deletes itself in 5.29.0 through an assertion that fails the build |
| 2. decide whether to test a major above the floor, record the chosen matrix next to it | **done**. Node 24 added, the decision and its two rejected alternatives written into `docs/node-support.md`, the invariant restated in the workflow comment |
| 3. the comment states the relationship to `engines` | **done**. Rewritten in the policy's own vocabulary, and five cases assert it stays that way |
| 4. a check asserts the invariant and fails when they diverge | **already satisfied** downward before this pull request; **newly satisfied upward** by five new cases here |

### The half of the report that does not hold, and why the leg below the floor stays

Every count in the report re-derives exactly against `1a141fe8322345dbd8ec3c449a402eedc3c6d83f`,
and again here. The conclusion does not follow from them. The independent reproduction
posted on the issue reached the same split:
https://github.com/homeofe/supply-chain-guard/issues/176#issuecomment-5380574887

`docs/node-support.md` already declared `supportedMajors` and `transitionMajors` as
disjoint lists, the gate already asserted that a transition major is strictly **below**
the floor, and `README.md` already told consumers the package requires Node 22 or newer.
The Node 20 leg is therefore not a claim of support. It is a dated transition lane whose
removal in 5.29.0 is enforced by an assertion that fails the build, not by anyone
remembering. Deleting it early would remove the only evidence that a consumer who has
not migrated can still install and run this package, one minor release before the
milestone deletes the lane anyway.

So acceptance criterion 1 is deliberately not implemented, and acceptance criterion 4
was already satisfied before this pull request by
`src/__tests__/node-version-contract.test.ts`. That decision, and the reasoning behind
it, is recorded in `docs/node-support.md` rather than here, because a pull request
comment is not the code.

### The half that does hold, and it is the line below the report's own headline

> Legs above the current LTS: **0 of 2**.

`engines.node` is a floor with **no ceiling**. `>=22.0.0` is a promise about Node 22 and
about every major after it, including majors that do not exist yet. The matrix stopped
at 22, so the entire promise above the floor was made and never executed. That is the
same defect the floor half of the policy exists to prevent, pointed the other way.

Read against the upstream `nodejs/Release` schedule on 2026-08-22, rather than recalled:

| major | LTS start | maintenance start | end of life |
| --- | --- | --- | --- |
| 20 | 2023-10-24 | 2024-10-22 | 2026-04-30 |
| 22 | 2024-10-29 | **2025-10-21** | 2027-04-30 |
| 24 | **2025-10-28** | 2026-10-20 | 2028-04-30 |
| 26 | 2026-10-28 | 2027-10-20 | 2029-04-30 |

Node 24 is the only Active LTS today. Node 22, the project's only supported major, has
been in Maintenance LTS for ten months. So the single major this package supported was
the one already in maintenance, while the major consumers are actively migrating onto
was claimed by `engines.node` and never run. Since `@types/node` is on the Node 26 API
surface, an API available only above Node 22 would have type-checked clean, passed both
legs, and failed in a consumer's hands.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## What changed

- `docs/node-support.md`: `supportedMajors` becomes `[22, 24]`; two new fields,
  `activeLtsMajor` (24) and `activeLtsReviewedIn` (5.29.0); a new section stating the
  upward invariant, the bound and its basis, the residual it leaves and the alternative
  that would close it.
- `.github/workflows/ci.yml`: the `compat` matrix becomes `['20', '22', '24']`, and the
  comment above it is rewritten in the policy's own vocabulary.
- `src/__tests__/node-version-contract.test.ts`: ten new cases, 28 to 38.
- `README.md`: names the majors every release is actually executed on.
- `src/__tests__/multi-line-pattern-engine.test.ts`: two harness timeouts now scaled by
  the same helper their own assertions already use. Cause and evidence below.
- `CHANGELOG.md`, `.ai/handoff/STATUS.md`: the change and the reasoning.

`baseline`, `publishMajor`, `runtimeMajor` and `devBaseline` are unchanged at 22, so
`action.yml`, the `Dockerfile`, the publish job and the dev container are untouched.

## Bounds, and the basis for each number

- **`activeLtsMajor = 24`**: hand-copied from the upstream schedule above, verified
  2026-08-22. Not resolved over the network at test time, because a gate that resolves
  an upstream fact over the wire is a gate whose result depends on a stranger's uptime,
  which is the class of dependency this package exists to flag.
- **Why the Active LTS is the bound at all**: the claim is unbounded, so it cannot be
  covered exhaustively and a bound has to be chosen and stated. Two alternatives were
  considered and rejected in writing in `docs/node-support.md`: every non-EOL LTS major
  (grows the matrix without adding distinct runtime risk), and every major upstream
  currently ships including the Current line (turns over every six months, so the gate
  would need a calendar-driven edit twice a year).
- **The residual, stated rather than hidden**: majors above `activeLtsMajor` are claimed
  by `engines.node` and are **not** executed. Today that is Node 26. The alternative that
  would close it completely, an upper bound on `engines.node`, is written out in
  `docs/node-support.md` with exactly what to change, and why it was not chosen.
- **`activeLtsReviewedIn = 5.29.0`**: a hand-copied fact goes stale in silence, so it
  carries a deadline in the same version-keyed shape as `transitionRemovedIn`, not a
  clock-keyed one, so the build never turns red on an unrelated pull request because a
  date rolled over. 5.29.0 is the next minor, the tightest value that still lets the
  current release ship, and already the release that deletes the Node 20 lane, so both
  Node policy chores land in one review. The next upstream change is Node 26 entering
  LTS on 2026-10-28.
- **What the gate cannot do**, said in the test rather than left as a surprise: it
  cannot tell a wrong hand-copied value from a right one while the value is at or above
  the floor. The deadline is the mitigation, and it is the only one.

## Testing

- [x] Tests pass for the files covering this change
- [x] Type check passes (`npm run lint`)
- [x] New tests added

`src/__tests__/node-version-contract.test.ts` plus `src/__tests__/workflow-trigger-contract.test.ts`,
the two files that read the workflow this change edits: **53 passed, exit code 0**.
`npx tsc --noEmit`: exit code 0. The full suite is left to CI, which is also where the
new Node 24 leg first executes.

### The regression test, and the line that reddens it

The line a reviewer deletes is ` 24` from `"supportedMajors": [22, 24],` in
`docs/node-support.md`. Deleted, re-read and confirmed present in mutated form and
absent in original form, then run:

```
mutated form  '"supportedMajors": [22],'      count = 1
original form '"supportedMajors": [22, 24],'  count = 0

VITEST_EXIT_CODE=1
   x the supported majors reach the current Active LTS
AssertionError: supportedMajors [22] stops below the Active LTS 24, which engines.node
"22.0.0" and up already claims: expected 22 to be greater than or equal to 24
  Tests  2 failed | 36 passed (38)
```

Restored, re-read and confirmed, exit code 0, 38 passed.

The stronger proof is the defect coming back verbatim. Both files put back into their
exact pre-change state, `supportedMajors: [22]` and `node: ['20', '22']`:

```
docs mutated  [22],     count = 1     docs original [22, 24],  count = 0
ci   mutated  20,22     count = 1     ci   original 20,22,24   count = 0

VITEST_EXIT_CODE=1
   x the supported majors reach the current Active LTS
   x the CI compat matrix runs a leg at or above the current Active LTS
  Tests  2 failed | 36 passed (38)
```

Exactly the two new upward cases go red and the other 36 stay green. Those 36 include
every case that existed before this pull request, which is the demonstration that
nothing in the repository could see this defect.

Three further mutations, each applied alone, proven landed by re-reading the file, and
reverted:

| mutation | expected | result |
| --- | --- | --- |
| `activeLtsReviewedIn` 5.29.0 to 5.28.0, below the current version | the deadline fires | exit 1, `1 failed \| 37 passed`, "version 5.28.1 has reached the Active LTS review milestone 5.28.0" |
| `activeLtsMajor` 24 to 20, below the floor | vacuity guard fires | exit 1, `1 failed \| 37 passed`, "activeLtsMajor 20 is below the engines floor 22" |
| the workflow comment restored to its pre-change text | comment guard fires | exit 1, `3 failed \| 35 passed`, one per missing policy term |

Every exit code above is the exact value, not merely non-zero, and each mutation was
sequenced with `;` so no short-circuited chain could report another command's status.

## Proof the finding no longer reproduces, including the part that still does

The check published in the issue was re-run against this branch. **Its first half still
reproduces, and that is correct**, so it is reported rather than worked around:

```
$ node -e "console.log(require('./package.json').engines.node)"
>=22.0.0
$ grep -n -A10 "^  compat:" .github/workflows/ci.yml
        node: ['20', '22', '24']
```

A leg below the floor is still there, deliberately, for the reasons above. A static
probe that asks only "is any leg below the floor" cannot distinguish a false claim of
support from a dated transition lane, so it is settled by re-deriving the issue's own
measurement instead. Before and after, from the same script parsing the same files:

| measurement | before | after |
| --- | --- | --- |
| compat matrix majors | `[20, 22]` | `[20, 22, 24]` |
| legs below the floor | 1 of 2 | 1 of 3 |
| legs above the floor | **0 of 2** | **1 of 3** |
| legs at or above the current Active LTS | **0 of 2** | **1 of 3** |
| `max(supportedMajors)` | 22 | 24 |
| support claim reaches Active LTS 24 | **no, claimed by engines and never executed** | **yes** |

The gate that now enforces the "after" column did not exist in the "before" column, and
the mutation above proves it fails when that column returns.

## Detection Patterns (if applicable)

Not applicable. No scanner rule changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added tests that prove my fix works
- [x] The governance gate groups run before `tsc` are green, each run sequentially:
      `check:aahp-pin` OK, `aahp check .` 7 gates no failures, `check:feed` up to date,
      `check:handoff` in sync, `aahp doctor` 6 gates pass
- [x] New and existing tests pass for the files covering this change
- [x] `.ai/handoff/STATUS.md` describes this change and `npm run handoff:refresh` has been run
- [x] No AI or tool attribution in the commits, the title or this body
- [x] The measurement evidence above reports counts, classes and public upstream dates
      only, no consumer repository names

## What adding the third leg exposed, and why it is fixed here too

The Node 24 leg went red on its first run. **The cause was not Node 24**, and the
evidence is in the same run:

| leg | `keeps exact greedy/lazy endpoints on 5 MiB repeated completions` |
| --- | --- |
| Node 20 | 8,734 ms, pass |
| Node 22 | 13,622 ms, pass |
| Node 24 | 15,070 ms, **timeout at 15,000 ms** |

The same case had already failed the **Node 22** leg on `main` at
`1a141fe8322345dbd8ec3c449a402eedc3c6d83f`, at 15,137 ms, with no Node 24 anywhere in the
matrix. Node 22 measured 13,622 ms in one run and 15,137 ms in another on identical code,
an 11 percent swing, so the ceiling sits inside the runner's own noise band and the leg
that fails is whichever one rolls high.

Underneath is a defect worth naming on its own terms. The coverage script, which is the
only command the compat legs run, sets `SCG_VITEST_COVERAGE=1` in `vitest.config.ts`, and
that makes `performanceBudget` multiply by five. So in that test:

| | harness timeout | assertion it guards |
| --- | --- | --- |
| before, under coverage | **15,000 ms** (bare literal) | 50,000 ms (`performanceBudget(10_000)`) |
| after, under coverage | 75,000 ms (`performanceBudget(15_000)`) | 50,000 ms, unchanged |
| outside coverage, before and after | 15,000 ms | 10,000 ms |

The guard could not be reached under the command CI runs: the harness killed the test at
15 s while the assertion it exists to evaluate allowed 50 s. Both `it` options in
`src/__tests__/multi-line-pattern-engine.test.ts` now use `performanceBudget(15_000)`,
which is what every sibling perf test in this repository already did. **Nothing is
weakened**: `performanceBudget` is the identity outside a coverage run, so the plain test
script is bit for bit unchanged, and `performanceBudget(10_000)`, the assertion that
fails on a real algorithmic regression, is untouched.

## Not fixed here, and why

The same bare-literal pattern is elsewhere. Counted, not estimated: **2 files import
`performanceBudget` and still use a bare `timeout:` literal**
(`src/__tests__/core-broad-gap-matchers.test.ts`,
`src/__tests__/internal-disclosure.test.ts`), and **10 further files use a bare literal**
without importing it, some of which have no scaled assertion to disagree with and need
reading rather than rewriting.

They are named in `.ai/handoff/STATUS.md` rather than changed, because a dozen test files
is the wrong blast radius for a Node matrix change. A gate asserting that no file
importing `performanceBudget` carries a bare `timeout:` literal is the obvious durable
fix, and it is deliberately not added here: it would be red on those two files the day it
landed, and a gate that ships red teaches people to ignore it.
