### PR TITLE
fix(state): a corrupt state store is a reported failure, not a clean baseline (#175)

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.28.1 |
 | Node engines | >=22.0.0 |
 | Source modules | 74 under `src/` |
-| Test files | 118 under `src/__tests__/` |
+| Test files | 119 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,10 +11,10 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1b0b50a17bc818e59d1773fea20c421633d2e6ea1de520f92f33a0d259a17b6e",
+      "checksum": "sha256:e92be2907d7999805a4e3198462c32ba12068bc360221fecae54e003ac689f2f",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2727,
-      "summary": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump."
+      "lines": 2795,
+      "summary": "A corrupt state store no longer reads as a clean baseline in either of the two stores."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
@@ -41,14 +41,14 @@
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:92f74c0dbd4642a38054ab234012c679b8bbe4b21b44806cce01a217244fa39e",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:a3f5ac40cf40fa687ce694aac88db8946d763ef765d0c4cbc64ea2e3c242d49e",
+      "updated": "2026-08-22T16:48:10Z",
       "lines": 72,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:d5ba6fb28d49c8108c61da1a43e48c85805a5828578852395876c3b6ff5e8bf6",
-      "updated": "2026-08-22T13:30:32Z",
+      "checksum": "sha256:660c3678483ebc3b297f209d92edd692b38ecc11dbf8ffc0607c0e5943007a1c",
+      "updated": "2026-08-22T16:48:10Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "A corrupt state store no longer reads as a clean baseline in either of the two stores. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 32959,
-    "full_read": 44621
+    "manifest_plus_core": 34273,
+    "full_read": 45935
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,74 @@
 
 ---
 
+## A corrupt state file was a clean baseline, in both stores (2026-08-22, unreleased)
+
+A corrupt state store no longer reads as a clean baseline in either of the two stores.
+Branch `fix/issue-175-risk-history-unreadable`, no version bump.
+Fixes https://github.com/homeofe/supply-chain-guard/issues/175.
+
+Both readers under `.scg-history/` ended in `catch { return []; }`, the same
+value the absent case returns, so "no history yet" and "the store could not be
+read" were one outcome. Reproduced end to end, then re-run against the branch.
+
+### What was measured
+
+Fixture: a project whose recorded risk climbs over ten scans. Removing the last
+120 bytes of `risk-history.json` took the scan from exit 1, level `high`, three
+trend findings, to exit 0, level `low`, none. The suppressed findings are all
+`high` and the default gate with no `--fail-on` is `summary.high > 0`, so the
+gate stopped detecting a regression it detected the day before, in silence.
+
+The triage store was measured too rather than assumed to be the weaker twin, and
+it is not weaker. A truncated `triage-decisions.json` took the same scan from
+exit 1 with two `high` governance findings to exit 0 with none, and reported
+`metrics.slaComplianceRate` 100 where the intact store gave 0. That number is
+the sharper harm: the corrupt file did not only hide a verdict, it manufactured
+a compliant one. That measurement is why both stores are fixed in one change.
+
+Two on-disk states, `null` and `{}`, never reached either `catch`, because both
+readers ended in an `as` cast. They threw an unhandled `TypeError` and produced
+no report at all. Four cases across the two stores, all closed by validating the
+declared entry shape.
+
+Evidence destruction was real and is closed: the truncated file still held nine
+recoverable entries and the next plain scan replaced it with one.
+
+### Decisions a later reader should not have to re-derive
+
+All of these are written next to the code they constrain, not only here.
+
+- Severity `high` on both new findings is derived, not chosen: the findings each
+  one replaces are `high` and the default gate is `summary.high > 0`, so
+  `medium` would reproduce the defect one layer down. Recorded at
+  `riskHistoryUnreadableFinding` in `src/continuous-monitor.ts`.
+- `saveRiskHistory` throws rather than overwriting an unreadable store;
+  `saveTriageDecisions` deliberately does not. The first does a read, append and
+  write, so refusing preserves recoverable entries; the second replaces the file
+  wholesale from its caller's list, so refusing would remove the only supported
+  repair path while preventing no measured loss. Recorded at both call sites.
+- `loadRiskHistory` and `loadTriageDecisions` are deprecated in place rather
+  than re-typed, because both are published API in `src/index.ts`.
+- The three-way reader lives in `src/state-dir.ts`, next to the directory both
+  stores write into, so a third store does not rediscover the rule.
+
+### Open, and it is an owner decision
+
+`SecurityMetrics.riskTrend` and `SecurityMetrics.slaComplianceRate` still read
+`stable` and 100 when a store is unreadable, because neither type has a member
+meaning "unknown". The report is marked `partialScan` and the finding text says
+in words that the metrics came from an empty store, which is what keeps this
+from being a silent wrong answer. Widening either type is a breaking change for
+library and JSON consumers, so it belongs in a major rather than a defect fix.
+The choice and its cost are recorded on `calculateMetrics` in `src/metrics.ts`.
+
+Separately, `saveRiskHistory` still writes with a plain `writeFileSync` onto the
+live path, with no temp file and rename anywhere in `src/`, so an interrupted
+scan can still manufacture the corruption this change now reports. Reporting it
+is in scope here; making it unmanufacturable is a separate change.
+
+---
+
 ## The required handoff gate compared main to itself on every push (2026-08-22, unreleased)
 
 Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump.

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.28.1 | package.json |
 | Source modules present | 74 | src/ file list |
-| Test files present | 118 | src/__tests__/ file list |
+| Test files present | 119 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,46 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
   against one merge ref, the live-tip selector returned 12 files and the same
   merge ref against a base one merged commit older returned 15.
 
+- **A corrupt scanner state file is now a reported failure instead of a clean
+  empty baseline.** Both stores under `.scg-history/` ended their read in
+  `catch { return []; }`, which is the value the absent case returns, so
+  "no history yet" and "the history could not be read" were indistinguishable.
+  Measured on a fixture whose recorded risk climbed over ten scans: removing the
+  last 120 bytes of `risk-history.json` took the scan from exit 1, risk level
+  `high`, three trend findings, to exit 0, risk level `low`, none, with the
+  scanned code unchanged. The suppressed findings are all `high` and the default
+  gate with no `--fail-on` is `summary.high > 0`, so the gate silently stopped
+  detecting a regression it had detected the day before. The same construct in
+  the triage store behaved the same way: a truncated `triage-decisions.json`
+  took the same scan from exit 1 with two `high` governance findings to exit 0
+  with none, and reported `metrics.slaComplianceRate` 100 where the intact store
+  gave 0, so a corrupt file did not merely hide a verdict, it manufactured a
+  compliant one. A store that exists but cannot be used now raises
+  `RISK_HISTORY_UNREADABLE` or `TRIAGE_STORE_UNREADABLE` at severity `high`,
+  marks the report `partialScan`, and therefore exits nonzero independently of
+  `--fail-on`. An absent store is unchanged and still silent, so a first scan of
+  a new project still exits 0.
+- **A state file that is valid JSON but the wrong shape no longer crashes the
+  scan.** Both readers ended in an `as` cast, which asserts a type without
+  checking it, so `null` and `{}` never reached either `catch` and instead threw
+  an unhandled `TypeError` that produced no report at all: four cases across the
+  two stores. Both readers now validate the declared entry shape and report the
+  file as unreadable, so a scan still produces a report.
+- **A scan no longer destroys the evidence it failed to read.** The truncated
+  history in the measurement above still held nine complete, recoverable entries;
+  the next plain `scan` replaced the file with a single fresh entry, so one more
+  run turned "corrupt" into "gone". History is no longer written while an
+  unreadable-store finding is present, and `saveRiskHistory` now throws
+  `RiskHistoryUnreadableError` rather than overwriting a store it could not read,
+  which also protects library consumers calling it directly.
+- **New `readRiskHistory` and `readTriageDecisions` report which of the three
+  things happened** (`absent`, `ok`, `unreadable`) rather than collapsing two of
+  them. `loadRiskHistory` and `loadTriageDecisions` remain exported and behave as
+  before, deprecated rather than re-typed, because they are published API and a
+  signature change would break library consumers. The shared three-way reader
+  lives in `src/state-dir.ts` next to the directory both stores write into, so a
+  future third store does not have to rediscover the rule.
+
 ## [5.28.1] - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ The scanner writes its risk history to `.scg-history/` in the scanned repo;
 it is not written when `--no-history` is set, which the hook now uses. For
 plain scans without that flag, add the folder to your `.gitignore`.
 
+**If a file in `.scg-history/` cannot be read, the scan says so and fails.** The
+two stores there, `risk-history.json` and `triage-decisions.json`, are the
+baseline that trend, forecast and triage-governance rules compare against. A
+store that is absent is a first scan and stays silent, which is the normal case
+on a fresh checkout or a hosted runner. A store that exists but does not parse,
+because a scan was interrupted mid-write or the file was edited by hand, is lost
+evidence, and the two are deliberately not reported the same way: the scan emits
+`RISK_HISTORY_UNREADABLE` or `TRIAGE_STORE_UNREADABLE` at `high`, sets
+`partialScan: true`, and exits nonzero regardless of `--fail-on`, because an
+unusable baseline is an indeterminate result rather than a clean one. The
+unreadable file is left on disk rather than overwritten, so complete entries can
+still be recovered from it, usually by closing the truncated JSON array by hand.
+Delete the file to start a new baseline once you have decided the old trend is
+expendable. `--no-history` does not silence this: that flag stops the write, not
+the read, so a corrupt store still degrades the verdict and is still reported.
+
 The hook scans the repository root on every commit and fails on high or critical findings.
 
 ### Docker

--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,9 @@ runs:
             or . == "NPM_NO_ARTIFACT"
             or . == "INTERNAL_DENYLIST_UNAVAILABLE"
             or . == "INTERNAL_DENYLIST_INVALID_ENTRY"
-            or . == "POLICY_INVALID_INTERNAL_TERM";
+            or . == "POLICY_INVALID_INTERNAL_TERM"
+            or . == "RISK_HISTORY_UNREADABLE"
+            or . == "TRIAGE_STORE_UNREADABLE";
           type == "object"
           and (.summary | type == "object")
           and (.findings | type == "array")

--- a/src/__tests__/state-store-corruption.test.ts
+++ b/src/__tests__/state-store-corruption.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Regression tests for the two state stores under .scg-history/.
+ *
+ * The defect these lock down: both readers ended in `catch { return []; }`,
+ * which is the same value the absent case returns, so a corrupt store was
+ * reported as a clean first baseline. Measured consequence, identical for both
+ * stores: the default gate flipped from exit 1 to exit 0 with the scanned code
+ * unchanged, because the findings that disappear are `high` and the default
+ * gate is `summary.high > 0`. On top of that, `null` and `{}` parse as valid
+ * JSON, so they never reached either `catch` and instead crashed the scan with
+ * an unhandled TypeError and no report at all.
+ *
+ * These tests drive the real `scan()` over temp fixtures rather than calling
+ * the readers directly, because the claim being defended is about what a scan
+ * REPORTS, not about what a helper returns. A unit test on `readRiskHistory`
+ * alone would stay green if the scanner stopped acting on the status.
+ *
+ * Why the control cases matter as much as the corruption cases: before this
+ * change, six suites mentioned the risk history or the trend rules and 36 of 36
+ * tests stayed green with `return [];` inserted as the first statement of
+ * `loadRiskHistory`, i.e. with the entire read path removed. A suite that only
+ * asserts more findings would surround this code without covering it. The
+ * `valid` and `absent` cases below are what make the corruption assertions
+ * discriminating rather than merely additive.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { scan } from "../scanner.js";
+import { getReportExitCode } from "../reporter.js";
+import {
+  readRiskHistory,
+  saveRiskHistory,
+  RiskHistoryUnreadableError,
+} from "../continuous-monitor.js";
+import { readTriageDecisions } from "../triage-engine.js";
+import { STATE_DIR } from "../state-dir.js";
+import type { ScanReport } from "../types.js";
+
+let tmpDir: string;
+
+/**
+ * Ten scans whose risk climbs and then stays high. This exact shape is what
+ * makes the control meaningful: it is enough entries for the trend rules
+ * (>= 10) and the forecast rules (>= 5) to fire, so a `NONE` in a corruption
+ * case is a real absence rather than a rule that was never eligible.
+ */
+const CLIMBING_SCORES = [10, 12, 14, 16, 18, 55, 60, 65, 70, 75];
+
+function validHistoryJson(): string {
+  const entries = CLIMBING_SCORES.map((score, i) => ({
+    timestamp: new Date(Date.UTC(2026, 7, 1 + i)).toISOString(),
+    score,
+    findingsCount: score,
+    criticalCount: 0,
+  }));
+  return JSON.stringify(entries, null, 2);
+}
+
+/**
+ * One expired risk acceptance and one stale in-remediation decision. Both
+ * produce `high` governance findings, which is what lets the triage assertions
+ * below check the gate rather than only the finding list.
+ */
+function validTriageJson(): string {
+  return JSON.stringify(
+    [
+      {
+        findingRule: "SOME_RULE",
+        status: "accepted-risk",
+        dueDate: "2026-01-01T00:00:00.000Z",
+        decidedAt: "2025-12-01T00:00:00.000Z",
+      },
+      {
+        findingRule: "OTHER_RULE",
+        status: "in-remediation",
+        decidedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    null,
+    2,
+  );
+}
+
+function stateFile(name: string): string {
+  return path.join(tmpDir, STATE_DIR, name);
+}
+
+function writeState(name: string, contents: string): void {
+  fs.mkdirSync(path.join(tmpDir, STATE_DIR), { recursive: true });
+  fs.writeFileSync(stateFile(name), contents);
+}
+
+/** Cut the last `bytes` bytes off, the shape an interrupted write leaves. */
+function truncated(json: string, bytes: number): string {
+  return json.slice(0, json.length - bytes);
+}
+
+function rulesOf(report: ScanReport): string[] {
+  return report.findings.map((f) => f.rule);
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "scg-store-corrupt-"));
+  fs.writeFileSync(
+    path.join(tmpDir, "package.json"),
+    '{ "name": "demo-app", "version": "1.0.0", "dependencies": {} }\n',
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Risk history
+// ---------------------------------------------------------------------------
+
+describe("risk history: the two cases that must never be confused", () => {
+  it("control: an intact history still produces the trend findings", async () => {
+    writeState("risk-history.json", validHistoryJson());
+    const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+
+    // If this control ever goes quiet, every "NONE" assertion below becomes
+    // vacuous, so it asserts the findings are present rather than merely that
+    // the scan ran.
+    expect(rulesOf(report)).toContain("RISK_TREND_INCREASING");
+    expect(rulesOf(report)).toContain("RISK_STAGNATION_HIGH");
+    expect(rulesOf(report)).not.toContain("RISK_HISTORY_UNREADABLE");
+    expect(report.partialScan).toBeUndefined();
+    expect(getReportExitCode(report)).toBe(1);
+  });
+
+  it("an absent history is a first scan: silent, clean, exit 0", async () => {
+    const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+
+    expect(rulesOf(report)).not.toContain("RISK_HISTORY_UNREADABLE");
+    expect(report.partialScan).toBeUndefined();
+    // This is the case the fix must not regress. A first scan of a clean
+    // project has to stay exit 0, or the tool fails every new adopter.
+    expect(getReportExitCode(report)).toBe(0);
+  });
+
+  const unreadableHistories: Array<[string, string]> = [
+    ["zero bytes", ""],
+    ["truncated mid-entry", truncated(validHistoryJson(), 120)],
+    ["not JSON at all", "not json at all"],
+    // The next two parse as valid JSON and so never reached the old `catch`.
+    // Before this change each crashed the scan with an unhandled TypeError and
+    // produced no report at all.
+    ["JSON null", "null"],
+    ["JSON object", "{}"],
+  ];
+
+  for (const [label, contents] of unreadableHistories) {
+    it(`reports an unreadable history (${label}) instead of an empty baseline`, async () => {
+      writeState("risk-history.json", contents);
+      const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+
+      const unreadable = report.findings.filter(
+        (f) => f.rule === "RISK_HISTORY_UNREADABLE",
+      );
+      expect(unreadable).toHaveLength(1);
+      expect(unreadable[0].severity).toBe("high");
+      expect(report.partialScan).toBe(true);
+
+      // Exact code, not "nonzero". 1 is the gate failure; 2 would mean a
+      // critical finding, which an unreadable baseline is not, and 0 is the
+      // defect. Asserting `not.toBe(0)` would pass on all three.
+      expect(getReportExitCode(report)).toBe(1);
+    });
+  }
+
+  it("--fail-on cannot talk the gate back down to 0", async () => {
+    writeState("risk-history.json", truncated(validHistoryJson(), 120));
+    const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+
+    // partialScan is checked in getReportExitCode before the --fail-on branch,
+    // so the strictest available threshold still cannot produce a clean exit.
+    expect(getReportExitCode(report, "critical")).toBe(1);
+  });
+
+  it("an empty JSON array is a well-formed empty store, not a corrupt one", async () => {
+    writeState("risk-history.json", "[]");
+    const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+
+    expect(rulesOf(report)).not.toContain("RISK_HISTORY_UNREADABLE");
+    expect(report.partialScan).toBeUndefined();
+    expect(getReportExitCode(report)).toBe(0);
+  });
+
+  it("an entry with a non-numeric score is unreadable, not a NaN baseline", async () => {
+    // `as RiskHistoryEntry[]` was a cast, not a check. A string score parses,
+    // is an array, and would poison every average and slope with NaN.
+    writeState(
+      "risk-history.json",
+      JSON.stringify([
+        { timestamp: "2026-08-01T00:00:00.000Z", score: "high", findingsCount: 1, criticalCount: 0 },
+      ]),
+    );
+    const read = readRiskHistory(tmpDir);
+    expect(read.status).toBe("unreadable");
+    expect(read.reason).toBe("invalid-entry");
+    expect(read.entries).toEqual([]);
+  });
+
+  it("distinguishes the four unreadable reasons from each other", () => {
+    expect(readRiskHistory(tmpDir).status).toBe("absent");
+
+    writeState("risk-history.json", "not json");
+    expect(readRiskHistory(tmpDir).reason).toBe("not-json");
+
+    writeState("risk-history.json", "null");
+    expect(readRiskHistory(tmpDir).reason).toBe("not-an-array");
+
+    writeState("risk-history.json", "[{}]");
+    expect(readRiskHistory(tmpDir).reason).toBe("invalid-entry");
+  });
+
+  it("no reason value leaks a filesystem path or an account name", () => {
+    // The reason is published inside a scan report. An exception message from
+    // fs or JSON.parse would carry the absolute path, and on a developer
+    // machine that carries the account name.
+    writeState("risk-history.json", "not json");
+    const read = readRiskHistory(tmpDir);
+    expect(read.reason).toBe("not-json");
+    expect(String(read.reason)).not.toContain(path.sep);
+    expect(String(read.reason)).not.toContain(os.homedir());
+  });
+});
+
+describe("risk history: the corrupt file survives the scan that reports it", () => {
+  it("a plain scan does not overwrite a truncated history", async () => {
+    const corrupt = truncated(validHistoryJson(), 120);
+    writeState("risk-history.json", corrupt);
+    const before = fs.readFileSync(stateFile("risk-history.json"), "utf-8");
+
+    // noHistory deliberately NOT set: this is the write-enabled path that used
+    // to replace 1072 bytes holding nine recoverable entries with a 119-byte
+    // file holding one, turning "corrupt" into "gone" on the very next run.
+    await scan({ target: tmpDir, format: "json" });
+
+    const after = fs.readFileSync(stateFile("risk-history.json"), "utf-8");
+    expect(after).toBe(before);
+    expect((after.match(/"score":/g) ?? []).length).toBe(9);
+  });
+
+  it("saveRiskHistory refuses rather than silently overwriting", () => {
+    writeState("risk-history.json", truncated(validHistoryJson(), 120));
+    const report = {
+      timestamp: new Date().toISOString(),
+      score: 0,
+      findings: [],
+      summary: { critical: 0, high: 0, medium: 0, low: 0, info: 0, total: 0, filesScanned: 0, totalFiles: 0 },
+      riskLevel: "low",
+      recommendations: [],
+      target: tmpDir,
+      scanType: "directory",
+      tool: "test",
+      durationMs: 0,
+    } as unknown as ScanReport;
+
+    // A silent no-op here would be the same conflation the reader was fixed
+    // for: the caller could not tell "saved" from "refused".
+    expect(() => saveRiskHistory(tmpDir, report)).toThrow(RiskHistoryUnreadableError);
+    expect(String(new RiskHistoryUnreadableError("not-json"))).not.toContain(os.homedir());
+  });
+
+  it("control: saveRiskHistory still appends to an intact history", () => {
+    writeState("risk-history.json", validHistoryJson());
+    const report = {
+      timestamp: "2026-08-20T00:00:00.000Z",
+      score: 42,
+      findings: [],
+      summary: { critical: 0, high: 0, medium: 0, low: 0, info: 0, total: 0, filesScanned: 0, totalFiles: 0 },
+      riskLevel: "medium",
+      recommendations: [],
+      target: tmpDir,
+      scanType: "directory",
+      tool: "test",
+      durationMs: 0,
+    } as unknown as ScanReport;
+
+    saveRiskHistory(tmpDir, report);
+    const read = readRiskHistory(tmpDir);
+    expect(read.status).toBe("ok");
+    expect(read.entries).toHaveLength(CLIMBING_SCORES.length + 1);
+    expect(read.entries[read.entries.length - 1].score).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Triage decisions: the same construct, measured to have the same consequence
+// ---------------------------------------------------------------------------
+
+describe("triage store: the same two cases, equally separated", () => {
+  it("control: an intact store still produces the governance findings", async () => {
+    writeState("triage-decisions.json", validTriageJson());
+    const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+
+    expect(rulesOf(report)).toContain("RISK_ACCEPTANCE_EXPIRED");
+    expect(rulesOf(report)).toContain("STALE_CRITICAL_FINDING");
+    expect(rulesOf(report)).not.toContain("TRIAGE_STORE_UNREADABLE");
+    expect(report.partialScan).toBeUndefined();
+    expect(getReportExitCode(report)).toBe(1);
+    // The true value for this fixture: two decisions triaged, none resolved.
+    expect(report.metrics?.slaComplianceRate).toBe(0);
+  });
+
+  it("an absent store is silent and clean", async () => {
+    const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+    expect(rulesOf(report)).not.toContain("TRIAGE_STORE_UNREADABLE");
+    expect(getReportExitCode(report)).toBe(0);
+  });
+
+  const unreadableStores: Array<[string, string]> = [
+    ["truncated mid-entry", truncated(validTriageJson(), 60)],
+    ["not JSON at all", "not json at all"],
+    ["JSON null", "null"],
+    ["JSON object", "{}"],
+  ];
+
+  for (const [label, contents] of unreadableStores) {
+    it(`reports an unreadable triage store (${label}) instead of no decisions`, async () => {
+      writeState("triage-decisions.json", contents);
+      const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+
+      const unreadable = report.findings.filter(
+        (f) => f.rule === "TRIAGE_STORE_UNREADABLE",
+      );
+      expect(unreadable).toHaveLength(1);
+      expect(unreadable[0].severity).toBe("high");
+      expect(report.partialScan).toBe(true);
+      expect(getReportExitCode(report)).toBe(1);
+    });
+  }
+
+  it("an unrecognised status is unreadable, not a decision that matches no rule", () => {
+    writeState(
+      "triage-decisions.json",
+      JSON.stringify([{ findingRule: "R", status: "probably-fine", decidedAt: "2026-01-01T00:00:00.000Z" }]),
+    );
+    const read = readTriageDecisions(tmpDir);
+    expect(read.status).toBe("unreadable");
+    expect(read.reason).toBe("invalid-entry");
+  });
+});

--- a/src/continuous-monitor.ts
+++ b/src/continuous-monitor.ts
@@ -8,28 +8,172 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Finding, RiskHistoryEntry, ScanReport } from "./types.js";
-import { STATE_DIR, ensureStateDir } from "./state-dir.js";
+import {
+  STATE_DIR,
+  ensureStateDir,
+  readJsonArrayStore,
+  type StateStoreRead,
+  type StateStoreUnreadableReason,
+} from "./state-dir.js";
 
-const HISTORY_DIR = STATE_DIR;
 const HISTORY_FILE = "risk-history.json";
 const MAX_HISTORY_ENTRIES = 100;
 
+/** The result of reading the persisted risk history. */
+export type RiskHistoryRead = StateStoreRead<RiskHistoryEntry>;
+
+/**
+ * Why a risk history that exists could not be used.
+ *
+ * Enumerated identifiers, never an exception message, because the value is
+ * published inside a scan report. See {@link StateStoreUnreadableReason} in
+ * `src/state-dir.ts` for the reasoning and the members.
+ */
+export type RiskHistoryUnreadableReason = StateStoreUnreadableReason;
+
+/**
+ * Structural check for one persisted history entry.
+ *
+ * The previous reader ended in `as RiskHistoryEntry[]`, which is a cast and not
+ * a check, so two shapes that are valid JSON never reached its `catch` at all
+ * and instead crashed the scan downstream with an unhandled `TypeError`: `null`
+ * at `analyzeRiskTrend`'s `history.length`, and `{}` at its `history.slice(-5)`.
+ * This function checks the shape the cast merely asserted.
+ *
+ * Every field the `RiskHistoryEntry` contract declares is required, with no
+ * partial-credit tier, and that is a deliberate bound rather than arbitrary
+ * strictness. `saveRiskHistory` below is the only writer and it always writes
+ * all four fields together; the interface has never had another shape, having
+ * exactly one touching commit, the v4.8.0 feature commit. So a file missing a
+ * field was not written by this tool, and a store that is not the store this
+ * tool wrote is not evidence of what this tool measured. Accepting it partially
+ * would also publish a `riskHistory` block in the report whose entries do not
+ * satisfy the type the report declares for them.
+ *
+ * `Number.isFinite` rather than `typeof value === "number"`: `NaN` is a number
+ * and would propagate through every average, slope and comparison in this file,
+ * producing a trend verdict that is wrong rather than absent, which is the same
+ * failure class this module is being corrected for.
+ */
+function isRiskHistoryEntry(value: unknown): value is RiskHistoryEntry {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.timestamp === "string" &&
+    Number.isFinite(entry.score) &&
+    Number.isFinite(entry.findingsCount) &&
+    Number.isFinite(entry.criticalCount)
+  );
+}
+
+/**
+ * Read the persisted risk history and say which of the three things happened.
+ *
+ * Prefer this over {@link loadRiskHistory} in any caller that can act on the
+ * difference. `loadRiskHistory` cannot report a failure because its return type
+ * has no room for one, which is the root cause this function exists to remove:
+ * the old `catch` did not decide to hide the corruption, it had no vocabulary
+ * in which to report it.
+ *
+ * The three-way contract, and why the failure branch must not be "simplified"
+ * back into an empty array, is documented on `readJsonArrayStore` in
+ * `src/state-dir.ts`. In this project the caller that acts on `unreadable` is
+ * `src/scanner.ts`, which raises `RISK_HISTORY_UNREADABLE` and marks the report
+ * `partialScan`.
+ */
+export function readRiskHistory(dir: string): RiskHistoryRead {
+  return readJsonArrayStore(dir, HISTORY_FILE, isRiskHistoryEntry);
+}
+
 /**
  * Load risk history from persistent storage.
+ *
+ * @deprecated Use {@link readRiskHistory}, which distinguishes an absent
+ * history from an unreadable one. This wrapper collapses both to `[]` and
+ * therefore cannot tell a caller that evidence was lost. It is kept because it
+ * is published API (`src/index.ts`), so removing or re-typing it would break
+ * library consumers; it is not kept because the behaviour is correct.
  */
 export function loadRiskHistory(dir: string): RiskHistoryEntry[] {
-  const historyPath = path.join(dir, HISTORY_DIR, HISTORY_FILE);
-  if (!fs.existsSync(historyPath)) return [];
+  return readRiskHistory(dir).entries;
+}
 
-  try {
-    return JSON.parse(fs.readFileSync(historyPath, "utf-8")) as RiskHistoryEntry[];
-  } catch {
-    return [];
+/**
+ * Raised instead of overwriting a risk history that could not be read.
+ *
+ * Carries the enumerated reason only. No path, no exception text: see
+ * {@link RiskHistoryUnreadableReason}.
+ */
+export class RiskHistoryUnreadableError extends Error {
+  readonly reason: RiskHistoryUnreadableReason;
+
+  constructor(reason: RiskHistoryUnreadableReason) {
+    super(
+      `Refusing to overwrite an unreadable risk history (${reason}). ` +
+        `Inspect ${STATE_DIR}/${HISTORY_FILE} in the scanned directory and ` +
+        `remove or repair it before recording new measurements.`,
+    );
+    this.name = "RiskHistoryUnreadableError";
+    this.reason = reason;
   }
 }
 
 /**
+ * Build the finding that reports an unusable risk history.
+ *
+ * Severity is `high`, and the number is derived rather than chosen. Every
+ * finding this defect suppresses is `high`: `RISK_TREND_INCREASING` and
+ * `RISK_STAGNATION_HIGH` below, `RISK_FORECAST_CRITICAL` and
+ * `RISK_TRAJECTORY_DEGRADING` in `src/risk-forecast.ts`. The default gate in
+ * `src/reporter.ts` with no `--fail-on` is `summary.high > 0`, so anything
+ * lower would leave that gate green and reproduce this very defect one layer
+ * further down: a corrupt history would still exit 0.
+ *
+ * It is not `critical`, even though `RISK_TREND_SPIKE` is, because `critical`
+ * means CLI exit code 2 and this finding is not a claim that a spike occurred.
+ * It is a claim that the baseline is unavailable, which is exit code 1
+ * territory. The `partialScan` flag the caller sets alongside it already forces
+ * exit 1 independently of `--fail-on`, so the severity is the backstop for a
+ * consumer reading `summary`, not the only thing holding the gate.
+ *
+ * `confidence: 1` because this is not an inference. The file was opened and it
+ * did not parse or did not match the declared shape.
+ */
+export function riskHistoryUnreadableFinding(
+  reason: RiskHistoryUnreadableReason,
+): Finding {
+  return {
+    rule: "RISK_HISTORY_UNREADABLE",
+    description:
+      `The persisted risk history at ${STATE_DIR}/${HISTORY_FILE} exists but could not be used (${reason}). ` +
+      `Trend and forecast analysis therefore ran with no baseline, so this scan cannot report a risk regression ` +
+      `and is not comparable with earlier scans. A previous scan of this directory recorded measurements that are now unreadable.`,
+    severity: "high",
+    confidence: 1,
+    category: "trust",
+    recommendation:
+      `Treat this run as unverified rather than clean. Inspect ${STATE_DIR}/${HISTORY_FILE}: complete entries can often be recovered by ` +
+      `closing the truncated JSON array by hand. Delete the file to start a new baseline, accepting that the old trend is gone. ` +
+      `History is not written while this finding is present, so the file is preserved until it is dealt with.`,
+  };
+}
+
+/**
  * Save current scan result to risk history.
+ *
+ * @throws {RiskHistoryUnreadableError} when a history file exists that could
+ * not be read. Overwriting it would destroy recoverable evidence: a history
+ * truncated mid-write still holds every complete entry before the cut, and this
+ * function would otherwise replace the whole file with a single fresh entry, so
+ * one more scan turns "corrupt" into "gone" and the feature restarts from a
+ * baseline indistinguishable from a genuine first run. Throwing rather than
+ * returning quietly is the point: a silent no-op here would be the same
+ * conflation of "cannot answer" with "answered nothing" that the reader above
+ * was corrected for. `src/scanner.ts` never reaches this throw, because it sets
+ * `partialScan` on an unreadable history and its own save is already gated on
+ * that; the throw is what protects a library consumer calling this directly.
  */
 export function saveRiskHistory(
   dir: string,
@@ -38,9 +182,19 @@ export function saveRiskHistory(
   // An incomplete scan is not a comparable measurement and must never become
   // a deceptively low baseline, even when this public helper is called directly.
   if (report.partialScan) return;
+
+  // Read before ensureStateDir so a refusal does not leave a state directory
+  // behind in a scanned repository that did not have one.
+  const existing = readRiskHistory(dir);
+  if (existing.status === "unreadable") {
+    throw new RiskHistoryUnreadableError(
+      existing.reason ?? "read-failed",
+    );
+  }
+
   const historyDir = ensureStateDir(dir);
 
-  const history = loadRiskHistory(dir);
+  const history = existing.entries;
   history.push({
     timestamp: report.timestamp,
     score: report.score,

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,8 +96,28 @@ export { parseWorkflow } from "./workflow-ast.js";
 export { scanOpenClawPlugin } from "./openclaw-plugin-scanner.js";
 export { checkHoneytokenAccess, getHoneytokenEnv } from "./secret-simulator.js";
 export { calculateOrgPosture } from "./posture-engine.js";
-export { loadRiskHistory, saveRiskHistory, analyzeRiskTrend } from "./continuous-monitor.js";
-export { loadTriageDecisions, saveTriageDecisions, checkTriageGovernance } from "./triage-engine.js";
+// readRiskHistory / readTriageDecisions distinguish an absent store from an
+// unreadable one; loadRiskHistory / loadTriageDecisions are the deprecated
+// wrappers that cannot, kept because they are already published API.
+export {
+  readRiskHistory,
+  loadRiskHistory,
+  saveRiskHistory,
+  analyzeRiskTrend,
+  riskHistoryUnreadableFinding,
+  RiskHistoryUnreadableError,
+} from "./continuous-monitor.js";
+export type { RiskHistoryRead, RiskHistoryUnreadableReason } from "./continuous-monitor.js";
+export {
+  readTriageDecisions,
+  loadTriageDecisions,
+  saveTriageDecisions,
+  checkTriageGovernance,
+  triageStoreUnreadableFinding,
+} from "./triage-engine.js";
+export type { TriageDecisionsRead, TriageDecisionsUnreadableReason } from "./triage-engine.js";
+export { readJsonArrayStore } from "./state-dir.js";
+export type { StateStoreRead, StateStoreStatus, StateStoreUnreadableReason } from "./state-dir.js";
 export { checkSlaCompliance } from "./sla-engine.js";
 export { forecastRisk } from "./risk-forecast.js";
 export { calculateMetrics } from "./metrics.js";

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -9,6 +9,26 @@ import type { Finding, RiskHistoryEntry, TriageDecision, SecurityMetrics } from 
 
 /**
  * Calculate security metrics from findings, history, and triage data.
+ *
+ * KNOWN LIMIT, stated so the next reader does not rediscover it as a defect.
+ * Every field here is a number or a closed string union with no member meaning
+ * "unknown", so an empty `history` and an empty `decisions` produce the same
+ * metrics whether the store was absent or unreadable: `riskTrend` reads
+ * `stable` and `slaComplianceRate` reads 100. When the store could not be read,
+ * both are answers about an empty set rather than about the project.
+ *
+ * What keeps that from being a silent wrong answer is the layer above, not this
+ * one. `src/scanner.ts` raises `RISK_HISTORY_UNREADABLE` or
+ * `TRIAGE_STORE_UNREADABLE` and sets `partialScan`, `src/reporter.ts` then
+ * exits nonzero independently of `--fail-on` and strips clean-verdict
+ * recommendations, and the finding text says in words that these metrics were
+ * computed from an empty store. A consumer reading `metrics` in isolation must
+ * check `partialScan` first; a report with `partialScan: true` is an
+ * indeterminate result and its metrics are not a measurement of the project.
+ *
+ * Widening the types to carry "unknown" was considered and not done here: both
+ * fields are published in `SecurityMetrics`, so it is a breaking change for
+ * library and JSON consumers and belongs in a major, not in a defect fix.
  */
 export function calculateMetrics(
   findings: Finding[],

--- a/src/pattern-scanner.ts
+++ b/src/pattern-scanner.ts
@@ -63,6 +63,13 @@ export const PARTIAL_SCAN_RULES: ReadonlySet<string> = new Set([
   "INTERNAL_DENYLIST_UNAVAILABLE",
   "INTERNAL_DENYLIST_INVALID_ENTRY",
   "POLICY_INVALID_INTERNAL_TERM",
+  // A state store that exists but does not parse is a configured source that
+  // could not be evaluated, which is the exact test above. Trend, forecast and
+  // triage governance silently produce nothing from one, so without these two
+  // entries a report reconstructed from JSON would classify itself as a
+  // complete clean scan.
+  "RISK_HISTORY_UNREADABLE",
+  "TRIAGE_STORE_UNREADABLE",
 ]);
 
 /**

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -91,8 +91,8 @@ import { modelWorkflows } from "./workflow-modeler.js";
 import { scanWorkflowGraph } from "./workflow-graph.js";
 import { scanOpenClawPlugin } from "./openclaw-plugin-scanner.js";
 import { checkRegistryVersionDrift } from "./publishing-anomaly-detector.js";
-import { loadRiskHistory, analyzeRiskTrend, saveRiskHistory, getRiskTrend } from "./continuous-monitor.js";
-import { loadTriageDecisions, checkTriageGovernance } from "./triage-engine.js";
+import { readRiskHistory, riskHistoryUnreadableFinding, analyzeRiskTrend, saveRiskHistory, getRiskTrend } from "./continuous-monitor.js";
+import { readTriageDecisions, triageStoreUnreadableFinding, checkTriageGovernance } from "./triage-engine.js";
 import { forecastRisk } from "./risk-forecast.js";
 import { calculateMetrics } from "./metrics.js";
 import {
@@ -757,16 +757,61 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
 
   // v4.8: Continuous risk monitoring (scores are now post-suppression,
   // matching what saveRiskHistory persists)
-  const riskHistory = loadRiskHistory(scanDir);
+  //
+  // An absent history is a first scan and stays silent. A history file that
+  // exists but cannot be read is lost evidence, and it must not be reported as
+  // the same clean empty baseline: every trend and forecast rule below then
+  // finds nothing while the scan still reports success, which is how a corrupt
+  // state file flipped the default gate from fail to pass with the scanned code
+  // unchanged. This read is deliberately NOT gated on `--no-history`: that flag
+  // suppresses the write only, so a corrupt file still degrades this verdict
+  // and still has to be reported.
+  //
+  // `partialScan` is set here rather than left to `hasPartialScanFinding`
+  // because the second policy pass and the severity filter below both run after
+  // this point and can remove the finding. That is the same reasoning as the
+  // refresh above: a suppression filter may hide a finding, and may never turn
+  // incomplete coverage into a complete clean verdict. Setting the flag here
+  // also keeps the save at the end of this function from overwriting the
+  // unreadable file, which is what preserves the recoverable entries in it.
+  const historyRead = readRiskHistory(scanDir);
+  const riskHistory = historyRead.entries;
+  if (historyRead.status === "unreadable") partialScan = true;
+
   const trendFindings = analyzeRiskTrend(riskHistory, calculateScore(findings));
   findings.push(...trendFindings);
   const forecastFindings = forecastRisk(riskHistory, calculateScore(findings));
   findings.push(...forecastFindings);
 
+  // Pushed after the two analyzers, not before, so the current score they are
+  // given is a score of the scanned project and never includes this finding
+  // about the scanner's own state file. Today that ordering cannot change an
+  // outcome, because an unreadable history yields zero entries and both
+  // analyzers return early on a short history; the ordering is here so that
+  // stays true if either early return is ever relaxed.
+  if (historyRead.status === "unreadable") {
+    findings.push(riskHistoryUnreadableFinding(historyRead.reason ?? "read-failed"));
+  }
+
   // v4.8: Triage governance checks
-  const triageDecisions = loadTriageDecisions(scanDir);
+  //
+  // Same three-way read as the history above, and for the same measured reason:
+  // a truncated triage store took this scan from exit 1 with two high findings
+  // to exit 0 with none, and reported metrics.slaComplianceRate 100 where the
+  // intact store gave 0. See src/triage-engine.ts for the measurement.
+  const triageRead = readTriageDecisions(scanDir);
+  const triageDecisions = triageRead.entries;
+  if (triageRead.status === "unreadable") partialScan = true;
+
   const govFindings = checkTriageGovernance(findings, triageDecisions);
   findings.push(...govFindings);
+
+  // Pushed after checkTriageGovernance for the same reason as the history
+  // finding above: the governance rules read the findings list, so a finding
+  // about the scanner's own state file is kept out of the input they judge.
+  if (triageRead.status === "unreadable") {
+    findings.push(triageStoreUnreadableFinding(triageRead.reason ?? "read-failed"));
+  }
 
   // v5.4.2: Second policy pass over the late-added findings (trend, forecast,
   // governance) so rules like RISK_TREND_SPIKE stay suppressible. Findings

--- a/src/state-dir.ts
+++ b/src/state-dir.ts
@@ -51,3 +51,119 @@ export function ensureStateDir(repoDir: string): string {
 
   return stateDir;
 }
+
+// ---------------------------------------------------------------------------
+// Reading a state store
+// ---------------------------------------------------------------------------
+
+/**
+ * How a state store answered.
+ *
+ * `absent` and `unreadable` mean opposite things and must never collapse to the
+ * same value. An absent store is a first scan and a correct empty baseline. An
+ * unreadable store is lost evidence: everything computed from it silently
+ * produces nothing while the scan still reports success.
+ *
+ * Both stores in this directory previously ended their read in
+ * `catch { return []; }`, which returned the absent answer for the unreadable
+ * case. Measured consequence, identical in both: the default gate flipped from
+ * exit 1 to exit 0 with the scanned code unchanged, because the findings that
+ * disappear are `high` and the default gate is `summary.high > 0`. The triage
+ * store additionally reported `slaComplianceRate: 100` where the intact store
+ * gave 0, so a corrupt file did not merely hide a verdict, it manufactured a
+ * clean one.
+ *
+ * Reading through {@link readJsonArrayStore} is what keeps the two cases apart.
+ * A new store under this directory should use it rather than write a third
+ * `catch` that returns `[]`.
+ */
+export type StateStoreStatus = "absent" | "ok" | "unreadable";
+
+/**
+ * Why a store file that exists could not be used.
+ *
+ * These are fixed identifiers, never an exception message. The reason is
+ * published inside a scan report, and an exception message from `fs` or
+ * `JSON.parse` carries the absolute path of the file, which on a developer
+ * machine carries the account name. `normalizePublicCoveragePath` in
+ * `src/pattern-scanner.ts` exists for the same hazard; here the vocabulary is
+ * enumerated instead, so there is nothing to normalise.
+ */
+export type StateStoreUnreadableReason =
+  /** The file exists but could not be read from disk (permissions, I/O). */
+  | "read-failed"
+  /** The bytes are not valid JSON: truncated mid-write, zero length, garbage. */
+  | "not-json"
+  /** Valid JSON, but not a JSON array: `null`, `{}`, a string, a number. */
+  | "not-an-array"
+  /** A JSON array, but at least one element fails the store's shape check. */
+  | "invalid-entry";
+
+/** The result of reading a state store. */
+export interface StateStoreRead<T> {
+  /** Usable entries. Empty unless `status` is `ok`. */
+  entries: T[];
+  status: StateStoreStatus;
+  /** Set if and only if `status` is `unreadable`. */
+  reason?: StateStoreUnreadableReason;
+}
+
+/**
+ * Read one JSON-array state store and report which of the three things happened.
+ *
+ * Contract, so that a later reader does not "simplify" the failure branch back
+ * into an empty array:
+ *
+ * - no file at all: `absent`, `entries: []`. A genuine first scan, and it must
+ *   stay silent, which is why `fs.existsSync` answers it first.
+ * - readable and well shaped: `ok`, with the entries. An empty JSON array is
+ *   `ok` with zero entries, because an empty array is a store that says, in a
+ *   well formed way, that it holds nothing.
+ * - anything else: `unreadable`, `entries: []`, and a `reason`. The caller is
+ *   responsible for turning that into a reported failure.
+ *
+ * `isEntry` is required rather than optional. The readers this replaces both
+ * ended in an `as` cast, which is an assertion and not a check, so two shapes
+ * that are valid JSON never reached their `catch` at all and instead crashed
+ * the scan downstream with an unhandled `TypeError` and no report: `null` and
+ * `{}` on each of the two stores, four cases in total. An optional predicate
+ * would let a third store re-introduce exactly that.
+ *
+ * Deliberately unbounded: the number of entries and the size of the file. Each
+ * writer already trims its own store, and a read-side cap invented here would
+ * reject stores this tool itself produced under an older limit, converting a
+ * working setup into a failing gate for no evidentiary gain. The file is inside
+ * the tree being scanned, so anyone able to grow it can already edit the code
+ * under scan, which is a strictly stronger position.
+ */
+export function readJsonArrayStore<T>(
+  repoDir: string,
+  fileName: string,
+  isEntry: (value: unknown) => value is T,
+): StateStoreRead<T> {
+  const storePath = path.join(repoDir, STATE_DIR, fileName);
+  if (!fs.existsSync(storePath)) return { entries: [], status: "absent" };
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(storePath, "utf-8");
+  } catch {
+    return { entries: [], status: "unreadable", reason: "read-failed" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { entries: [], status: "unreadable", reason: "not-json" };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { entries: [], status: "unreadable", reason: "not-an-array" };
+  }
+  if (!parsed.every(isEntry)) {
+    return { entries: [], status: "unreadable", reason: "invalid-entry" };
+  }
+
+  return { entries: parsed, status: "ok" };
+}

--- a/src/triage-engine.ts
+++ b/src/triage-engine.ts
@@ -8,27 +8,149 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Finding, TriageDecision, FindingStatus } from "./types.js";
-import { STATE_DIR, ensureStateDir } from "./state-dir.js";
+import {
+  STATE_DIR,
+  ensureStateDir,
+  readJsonArrayStore,
+  type StateStoreRead,
+  type StateStoreUnreadableReason,
+} from "./state-dir.js";
 
-const TRIAGE_DIR = STATE_DIR;
 const TRIAGE_FILE = "triage-decisions.json";
+
+/** The valid values of `TriageDecision.status`. */
+const FINDING_STATUSES: ReadonlySet<string> = new Set<FindingStatus>([
+  "new",
+  "triaged",
+  "accepted-risk",
+  "in-remediation",
+  "resolved",
+  "false-positive",
+]);
+
+/** The result of reading the persisted triage decisions. */
+export type TriageDecisionsRead = StateStoreRead<TriageDecision>;
+
+/**
+ * Why a triage store that exists could not be used.
+ *
+ * See {@link StateStoreUnreadableReason} in `src/state-dir.ts`.
+ */
+export type TriageDecisionsUnreadableReason = StateStoreUnreadableReason;
+
+/**
+ * Structural check for one persisted triage decision.
+ *
+ * `status` is checked against the closed `FindingStatus` set rather than merely
+ * being required to be a string, because every governance rule in
+ * `checkTriageGovernance` below selects on it. An unrecognised status silently
+ * matches no rule, so an entry carrying one would be counted in
+ * `decisions.length` and in the SLA denominator while contributing to no check,
+ * which is a wrong answer rather than an absent one.
+ *
+ * `decidedAt` is required to be a string but is not required to be a parseable
+ * date. The staleness rule below computes `now - new Date(d.decidedAt)`, which
+ * yields `NaN` for an unparseable value, and `NaN > threshold` is `false`, so
+ * an unparseable date fails toward reporting less. That is a real weakness, but
+ * it is a pre-existing one about date handling, it is not the read-path
+ * conflation this store is being corrected for, and tightening it here would
+ * reject stores written by earlier versions that never validated the field.
+ * Stated rather than left for the next reader to rediscover.
+ */
+function isTriageDecision(value: unknown): value is TriageDecision {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const decision = value as Record<string, unknown>;
+  return (
+    typeof decision.findingRule === "string" &&
+    typeof decision.status === "string" &&
+    FINDING_STATUSES.has(decision.status) &&
+    typeof decision.decidedAt === "string"
+  );
+}
+
+/**
+ * Read the persisted triage decisions and say which of the three things happened.
+ *
+ * This store carries the same defect class as the risk history and was measured
+ * to have the same consequence, which is why both are fixed together rather
+ * than one being left as an unremarked twin for the pattern to be copied from.
+ * On a fixture holding one expired risk acceptance and one stale in-remediation
+ * decision, truncating this file took the scan from exit 1 with two `high`
+ * findings to exit 0 with none, and took `metrics.slaComplianceRate` from 0 to
+ * 100. The second number is the sharper harm: a corrupt file did not merely
+ * hide a verdict, it manufactured a perfect compliance score.
+ *
+ * `null` and `{}` additionally crashed the scan outright with
+ * `decisions is not iterable` and no report at all, because the previous reader
+ * ended in `as TriageDecision[]`, which is an assertion and not a check.
+ *
+ * The three-way contract is documented on `readJsonArrayStore` in
+ * `src/state-dir.ts`. The caller that acts on `unreadable` is `src/scanner.ts`,
+ * which raises `TRIAGE_STORE_UNREADABLE` and marks the report `partialScan`.
+ */
+export function readTriageDecisions(dir: string): TriageDecisionsRead {
+  return readJsonArrayStore(dir, TRIAGE_FILE, isTriageDecision);
+}
 
 /**
  * Load triage decisions from persistent storage.
+ *
+ * @deprecated Use {@link readTriageDecisions}, which distinguishes an absent
+ * store from an unreadable one. This wrapper collapses both to `[]` and
+ * therefore cannot tell a caller that governance evidence was lost. It is kept
+ * because it is published API (`src/index.ts`), so removing or re-typing it
+ * would break library consumers; it is not kept because the behaviour is
+ * correct.
  */
 export function loadTriageDecisions(dir: string): TriageDecision[] {
-  const triagePath = path.join(dir, TRIAGE_DIR, TRIAGE_FILE);
-  if (!fs.existsSync(triagePath)) return [];
+  return readTriageDecisions(dir).entries;
+}
 
-  try {
-    return JSON.parse(fs.readFileSync(triagePath, "utf-8")) as TriageDecision[];
-  } catch {
-    return [];
-  }
+/**
+ * Build the finding that reports an unusable triage store.
+ *
+ * Severity `high` on the same derivation as `RISK_HISTORY_UNREADABLE`: the
+ * governance findings this loses (`RISK_ACCEPTANCE_EXPIRED`,
+ * `STALE_CRITICAL_FINDING`, `CRITICAL_FINDING_NO_OWNER`) are `high`, and the
+ * default gate in `src/reporter.ts` with no `--fail-on` is `summary.high > 0`,
+ * so anything lower would leave that gate green and reproduce the defect one
+ * layer down.
+ */
+export function triageStoreUnreadableFinding(
+  reason: TriageDecisionsUnreadableReason,
+): Finding {
+  return {
+    rule: "TRIAGE_STORE_UNREADABLE",
+    description:
+      `The triage decision store at ${STATE_DIR}/${TRIAGE_FILE} exists but could not be used (${reason}). ` +
+      `Governance checks therefore ran against no decisions, so expired risk acceptances, stale remediations and unowned ` +
+      `critical findings cannot be reported, and the SLA compliance rate in this report is computed from an empty store ` +
+      `rather than from the recorded decisions.`,
+    severity: "high",
+    confidence: 1,
+    category: "trust",
+    recommendation:
+      `Treat this run as unverified rather than compliant. Inspect ${STATE_DIR}/${TRIAGE_FILE}: complete entries can often be ` +
+      `recovered by closing the truncated JSON array by hand. Delete the file only if the recorded triage decisions are ` +
+      `genuinely expendable, since they are the record of who accepted which risk and when.`,
+  };
 }
 
 /**
  * Save triage decisions.
+ *
+ * Unlike `saveRiskHistory`, this function does NOT refuse to run when the store
+ * on disk is unreadable, and the asymmetry is deliberate. `saveRiskHistory`
+ * performs a read, append and write, so it would overwrite a corrupt file with
+ * a single fresh entry and destroy the complete entries still recoverable from
+ * it; refusing is what preserves them. This function takes the full decision
+ * list from its caller and replaces the file wholesale, so refusing here would
+ * remove the only supported way to repair a corrupt store through the API,
+ * while preventing no measured loss: no caller in this repository performs a
+ * read-modify-write of this store, and a library consumer that does can use
+ * {@link readTriageDecisions} to see the `unreadable` status before deciding.
  */
 export function saveTriageDecisions(
   dir: string,


### PR DESCRIPTION
Fixes https://github.com/homeofe/supply-chain-guard/issues/175

## The defect

Both state stores under `.scg-history/` ended their read in `catch { return []; }`,
which is the same value the absent case returns. So "no history yet" and "the store
could not be read" were one outcome, and everything computed from the store then
produced nothing while the scan still reported success.

The declared return type is the root cause, not the `catch`. `loadRiskHistory`
returned `RiskHistoryEntry[]`, a type with no room for a status, so the failure path
had no vocabulary in which to report a failure. `fs.existsSync` already answered the
absent case one line above, so the `catch` contributed nothing except the conflation.

There was a second fault at the same site: the readers ended in an `as` cast, which
asserts a type without checking it. Two on-disk states parse as valid JSON, never
reached either `catch`, and instead crashed the scan with an unhandled `TypeError`
and no report at all.

## Measured, before and after

One note on the reproduction first. The issue offers `sed -n '20,42p'
src/continuous-monitor.ts` as its "check that reproduces it". That prints source, it
does not reproduce a behaviour, and no code change can make a line-range print stop
showing lines, so that probe is not the thing to satisfy. The independent
reproduction on the issue supplies an executable script instead, and that script is
what was re-run against this branch. Both tables below come from it, unmodified.

Fixture: a project with a `package.json` and a ten-scan history whose risk climbs and
then stays high. Each row is `scan <fixture> --format json --no-history`.

Before, at `1a141fe8322345dbd8ec3c449a402eedc3c6d83f`:

```
valid      bytes=1192  exit=1 score=31 level=high  trendFindings=RISK_TREND_INCREASING+RISK_STAGNATION_HIGH+RISK_TRAJECTORY_DEGRADING
absent     bytes=-     exit=0 score=1  level=low   trendFindings=NONE
zero       bytes=0     exit=0 score=1  level=low   trendFindings=NONE
truncated  bytes=1072  exit=0 score=1  level=low   trendFindings=NONE
garbage    bytes=15    exit=0 score=1  level=low   trendFindings=NONE
null       bytes=4     exit=1 NO REPORT PRODUCED; stderr: Cannot read properties of null (reading 'length')
object     bytes=2     exit=1 NO REPORT PRODUCED; stderr: history.slice is not a function
```

After, same script, same fixture, this branch:

```
valid      bytes=1192  exit=1 score=31 level=high    trendFindings=RISK_TREND_INCREASING+RISK_STAGNATION_HIGH+RISK_TRAJECTORY_DEGRADING
absent     bytes=-     exit=0 score=1  level=low     trendFindings=NONE
zero       bytes=0     exit=1 score=16 level=medium  reportMentionsUnreadableHistory=true
truncated  bytes=1072  exit=1 score=16 level=medium  reportMentionsUnreadableHistory=true
garbage    bytes=15    exit=1 score=16 level=medium  reportMentionsUnreadableHistory=true
null       bytes=4     exit=1 score=16 level=medium  reportMentionsUnreadableHistory=true
object     bytes=2     exit=1 score=16 level=medium  reportMentionsUnreadableHistory=true
```

`reportMentionsUnreadableHistory` is a regex over the entire serialized JSON report,
not over a summary. It was `false` in every row before and is `true` in every corrupt
row now.

The two rows that did not change are the point. `valid` is the positive control: with
an intact history the same fixture still produces three findings, score 31, exit 1, so
the scan machinery, the trend rules and the JSON reporter all demonstrably execute and
a `NONE` elsewhere is a real absence. `absent` is the case the fix must not regress: a
first scan of a clean project still exits 0 and says nothing.

The same truncated history at the operator level, default text format. Before, this
fixture printed `RISK SCORE 1 / 100 LOW`, `HIGH 0`, exit 0, with no mention of the
unreadable file anywhere on stdout or stderr. Now:

```
  Status    PARTIAL - coverage incomplete
  HIGH      1
  [HIGH]  RISK_HISTORY_UNREADABLE
          ... report a risk regression and is not comparable with earlier scans.
  RECOMMENDATIONS
  >  WARNING: Scan incomplete because one or more configured checks or files ...
exit=1
```

Evidence destruction, write path enabled:

```
before: 1072 bytes, complete entries recoverable: 9
after:  1072 bytes, entries: 9        (was: 119 bytes, entries: 1)
```

## The triage store was measured, not assumed to be the weaker twin

`src/triage-engine.ts` carried the same construct character for character. The issue
notes it as a weaker instance that was not measured end to end. It was measured here,
on a fixture holding one expired risk acceptance and one stale in-remediation decision,
and it is not weaker:

```
              before                                          after
valid      exit=1 high=2 slaComplianceRate=0              exit=1 high=2 slaComplianceRate=0
absent     exit=0 high=0 slaComplianceRate=100            exit=0 high=0 slaComplianceRate=100
truncated  exit=0 high=0 slaComplianceRate=100            exit=1 high=1 partialScan=true
garbage    exit=0 high=0 slaComplianceRate=100            exit=1 high=1 partialScan=true
null       exit=1 NO REPORT: decisions is not iterable    exit=1 high=1 partialScan=true
object     exit=1 NO REPORT: decisions is not iterable    exit=1 high=1 partialScan=true
```

The same gate flip, plus `metrics.slaComplianceRate` reading 100 where the intact store
gives 0. That number is the sharper harm: the corrupt file did not only hide a verdict,
it manufactured a compliant one. That measurement is why both stores are fixed in one
change rather than one being left as an unremarked twin to copy the pattern from.

## What changed

- `src/state-dir.ts` gains `readJsonArrayStore`, a three-way reader returning
  `absent`, `ok` or `unreadable` with an enumerated reason. It lives next to the
  directory both stores write into, so a third store does not rediscover the rule.
  The predicate argument is required, not optional, because an optional one would let
  a new store re-introduce the `as`-cast crash.
- `readRiskHistory` and `readTriageDecisions` report the status.
  `loadRiskHistory` and `loadTriageDecisions` keep their exact signatures and are
  deprecated in place, because both are published API in `src/index.ts` and re-typing
  them would break library consumers.
- An unreadable store raises `RISK_HISTORY_UNREADABLE` or `TRIAGE_STORE_UNREADABLE`
  at severity `high`, sets `partialScan`, and is registered in `PARTIAL_SCAN_RULES`
  and in the Action's coverage schema in `action.yml`, which a gate holds in sync.
- `saveRiskHistory` throws `RiskHistoryUnreadableError` rather than overwriting a
  store it could not read.

## Stated bounds, so none of this is a later reader's mystery

- **Severity `high` is derived, not chosen.** Every finding each new rule replaces is
  `high`, and the default gate with no `--fail-on` is `report.summary.high > 0`, so
  `medium` would leave that gate green and reproduce the defect one layer down. It is
  not `critical`, even though `RISK_TREND_SPIKE` is, because `critical` means exit
  code 2 and this is not a claim that a spike occurred, only that the baseline is
  unavailable.
- **The reason is an enumerated identifier, never an exception message.** The value is
  published inside a scan report, and an `fs` or `JSON.parse` message carries the
  absolute path of the file, which on a developer machine carries the account name.
- **Validation requires the fields the declared entry type declares.** The `as` cast
  asserted that shape, so the fix checks the shape it asserted. `Number.isFinite`
  rather than `typeof === "number"`, because `NaN` is a number and would propagate
  through every average and slope as a wrong answer rather than an absent one.
- **Nothing is size-bounded on read, deliberately.** Each writer already trims its own
  store, and a read-side cap would reject stores this tool itself produced under an
  older limit, converting a working setup into a failing gate for no evidentiary gain.
- **`--no-history` does not silence the report.** That flag stops the write, not the
  read, so a corrupt store still degrades the verdict and is still reported.
- **`saveTriageDecisions` deliberately does not refuse**, unlike `saveRiskHistory`.
  The latter does a read, append and write, so refusing preserves recoverable entries.
  The former replaces the file wholesale from its caller's list, so refusing would
  remove the only supported repair path while preventing no measured loss.
- **Known limit, recorded on `calculateMetrics`.** `metrics.riskTrend` and
  `metrics.slaComplianceRate` still read `stable` and 100 on an unreadable store,
  because neither type has a member meaning "unknown". `partialScan` plus the finding
  text is what keeps that from being a silent wrong answer. Widening either type is a
  breaking change for library and JSON consumers and belongs in a major release.

## Regression test and its mutation proof

New suite `src/__tests__/state-store-corruption.test.ts`, 22 cases, driving the real
`scan()` over temp fixtures rather than calling the readers directly, because the claim
being defended is about what a scan reports. Exit codes are asserted as exact values,
never as "not zero": `expect(getReportExitCode(report)).toBe(1)`. Asserting non-zero
would pass on 2 as well, and 2 means a critical finding, which an unreadable baseline
is not.

This matters because the load path previously had no coverage at all. Six suites
mention the risk history or the trend rules, and all 36 of their tests stayed green
with `return [];` inserted as the first statement of `loadRiskHistory`, that is, with
the entire read path removed.

Five mutations were applied, run, and reverted. The line a reviewer deletes to redden
the suite is the `not-json` return in `readJsonArrayStore`, restoring the original
`catch { return []; }` behaviour:

```
-    return { entries: [], status: "unreadable", reason: "not-json" };
+    return { entries: [], status: "absent" };
```

```
     × reports an unreadable history (zero bytes) instead of an empty baseline
     × reports an unreadable history (truncated mid-entry) instead of an empty baseline
     × reports an unreadable history (not JSON at all) instead of an empty baseline
     × --fail-on cannot talk the gate back down to 0
     × distinguishes the four unreadable reasons from each other
     × no reason value leaks a filesystem path or an account name
     × a plain scan does not overwrite a truncated history
     × saveRiskHistory refuses rather than silently overwriting
     × reports an unreadable triage store (truncated mid-entry) instead of no decisions
     × reports an unreadable triage store (not JSON at all) instead of no decisions
 Tests  10 failed | 12 passed (22)
```

The other twelve stay green, which is what proves the suite discriminates rather than
merely asserting more: the `valid` control, the `absent` case, and the `null` and `{}`
cases that take the `not-an-array` branch this mutation does not touch.

The other three:

- Deleting the `invalid-entry` shape check: 3 red, all on `expected 'ok' to be
  'unreadable'`.
- Lowering the new finding's severity from `high` to `medium`: 5 red, all on
  `expected 'medium' to be 'high'`. The exit code stays 1 under this mutation because
  `partialScan` independently forces it, which is exactly why the suite asserts the
  severity explicitly instead of relying on the exit code alone.
- Deleting the `partialScan` wiring in `src/scanner.ts`: 6 red.

One honest note on that last one. The durability test stays green under it, because
the `saveRiskHistory` refusal independently preserves the file. It goes red only when
both guards are removed together, which was run and confirmed: 8 red including
`a plain scan does not overwrite a truncated history`. The file is defended twice by
design, and that is stated rather than papered over with a single mutation that
happens to look sufficient.

Every mutation was reverted by re-reading the file from disk and grepping for both the
absence of the mutated form and the presence of the original.

## Verification

- `npx tsc --noEmit` clean.
- Focused suites green: `state-store-corruption`, `continuous-monitor`,
  `triage-engine`, `metrics`, `no-history`, `state-dir`, `reporter`, `scanner`,
  `action-partial-scan`, `pattern-applicability`, `bugfix-v5_2_24`, `bugfix-v5_4_2`.
  The full suite is left to CI, which is the authoritative verdict.
- `check:aahp`, `check:feed` and `check:handoff` green, run sequentially.
- The original reproduction was re-run against this branch and no longer reproduces,
  output above.

One disclosure about how `MANIFEST.json` in this commit was produced, because a
reviewer should not have to guess. `aahp-manifest.sh` could not complete on the
Windows host this branch was prepared on: three separate invocations ran for over an
hour each without writing the file, starved by process-creation contention, and each
one left a live orphan tree that would have written into the checkout after it looked
clean. Those were terminated. The file was then written by a transcription of the
canonical writer, taking each field from its definition in the `aahp` package rather
than inferring it: `aahp_checksum`, `aahp_file_mtime`, `aahp_line_count`,
`aahp_auto_summary` and `aahp_estimate_tokens` from `_aahp-lib.sh`, and the document
layout, `quick_context` and `token_budget` from `aahp-manifest.sh`. The result was
validated against the repository's own gate, `check:handoff`, which is the same check
CI runs and which compares the recorded checksums against the files on disk; it
reports the manifest in sync. The diff is 22 lines, only the values that changed, with
the task block and ordering preserved, so re-running the canonical writer on a Linux
runner should be a no-op rather than a reformat. If you would prefer it regenerated by
the tool itself, `npm run handoff:refresh` on CI will do it.

`src/__tests__/self-scan-recognition.test.ts` timed out on this host while the manifest
runs were saturating it, at 5000ms on cases that copy a source tree. It passes 16 of 16
on the same commit once the host is idle, so that was the environment, settled by
re-running rather than by argument.

No version bump: this is a defect fix on an unreleased branch and the release sequence
moves every version site together.
