### PR TITLE
fix(docker): base image pinning is decided by a parser, not five tag words (#174)

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,10 +11,10 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1b0b50a17bc818e59d1773fea20c421633d2e6ea1de520f92f33a0d259a17b6e",
+      "checksum": "sha256:b8ca130f2957040d82fce41bd2b5f85489a235dcf310771e1bf77e1b1a438af3",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2727,
-      "summary": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump."
+      "lines": 2810,
+      "summary": "Model: claude-opus-5. Branch fix/issue-174-docker-base-image-pinning. Issue"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:19814e5e643030be8d6538df50287b6f96331fbc10fa8064c5c05ef842f55823",
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump. Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Model: claude-opus-5. Branch fix/issue-174-docker-base-image-pinning. Issue Five tasks are ready, one owner decision is blocked, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 32959,
-    "full_read": 44621
+    "manifest_plus_core": 34424,
+    "full_read": 46086
   }
   ,"next_task_id": 20
   ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -6,6 +6,89 @@
 
 ---
 
+## Docker base image pinning: one parser, three verdicts (2026-08-22, unreleased)
+
+Model: claude-opus-5. Branch fix/issue-174-docker-base-image-pinning. Issue
+https://github.com/homeofe/supply-chain-guard/issues/174. No version bump.
+
+`DOCKER_UNPINNED_BASE` was one regex and it was narrower than its own five tag
+words. Measured on the released rule over 19 representative `FROM` lines: 5
+flagged, and those 5 were exactly the five bare literal words. Three shapes
+inside the rule's own stated scope scanned clean:
+
+- `FROM --platform=$BUILDPLATFORM node:latest`, because `\S+` bound to the flag
+  token. End to end through the CLI: risk score 2, zero high findings,
+  `--fail-on high` exit 0, on a line carrying a literal `:latest`.
+- `node:lts-alpine`, `nginx:stable-alpine`, `nginx:mainline-alpine`,
+  `node:current-slim`, because the alternation ended at `(?:\s|$)`. The suffixed
+  forms are the upstream rolling tags and the ones people write.
+- `FROM scratch-base:latest` and `FROM scratchpad:latest`, because `(?!scratch)`
+  had no token boundary.
+
+Widening the regex was not available: two of the three misses are structural,
+and `validatePatternSet` rejects the obvious widened forms at module load as a
+broad unbounded consuming gap. All three `FROM` rules now share one
+`correlatedMatcher`. It strips instruction flags, joins backslash continuations,
+drops comment lines, tracks `AS <stage>` names in file order, and exempts
+`scratch` only as a whole token. Because the three rules read the same parse,
+they can no longer disagree about what a build-stage reference is.
+
+### The two decisions, both recorded in the repository
+
+Both are written into `docs/ARCHITECTURE.md`, "Base Image Pinning (decision
+record)", and summarised next to the code in `src/dockerfile-scanner.ts`. Neither
+lives only in a pull request.
+
+1. **Tiering.** The issue asked for one rule at `high` for every `FROM` line
+   without a digest. Not taken. `high` is what the default gate fails on
+   (`getReportExitCode` returns 1 when `summary.high > 0`), so one high tier
+   flips every ordinary version-tagged Dockerfile in every consumer from pass to
+   fail in one release, for a risk that has not changed. Instead
+   `DOCKER_UNPINNED_BASE` stays `high` for a moving channel tag and the new
+   `DOCKER_TAG_NOT_DIGEST` reports a tag without a digest at `low`, mirroring
+   `GHA_UNPINNED_ACTION` / `GHA_TAG_NOT_SHA`. Default gate, `--fail-on high` and
+   `--fail-on medium` unchanged; `--fail-on low`, `--fail-on info` and the risk
+   score do change.
+2. **Compose.** `image:` values stay out of scope, said out loud in each rule's
+   `description`, in README.md and in `docs/ARCHITECTURE.md`. Nine of nine
+   Docker rules are anchored on a Dockerfile instruction keyword, so a Compose
+   file returns nothing from the Docker rule set while the README used to list
+   it as a scanned Docker target. The blocker for implementing it is recorded:
+   a service that also declares `build:` uses `image:` to name what it BUILDS,
+   and telling the two apart needs service-block structure, which this project
+   has no YAML parser for.
+
+### Deliberate behaviour changes a consumer will see
+
+- Newly reported at `high`: `--platform` lines carrying a channel tag, suffixed
+  channel tags, `scratch`-prefixed names, and `FROM ubuntu AS base` (no tag).
+- Newly reported at `low`: every `FROM` line with a tag and no digest.
+- No longer reported: a build-stage reference (`FROM builder`), a commented-out
+  `FROM`, and `FROM` appearing inside another instruction.
+- A `FROM` line carrying an embedded carriage return still classifies. Writing
+  the instruction regex the obvious way, anchored with `$`, would have made
+  `FROM node:latest\rEXTRA` scan clean, because JavaScript's `.` stops at a line
+  terminator. The released regex did report it, so this would have been a
+  regression introduced by the fix rather than a gap left in place. Caught while
+  reading the finished parser, not by the test suite, which is the argument for
+  reading a structural rewrite line by line before shipping it.
+- The report-level "pin base images by digest" recommendation in `src/scanner.ts`
+  now also fires for `DOCKER_TAG_NOT_DIGEST`, so a report whose only base-image
+  finding is the new tier is not left without a recommendation.
+- This repository's own `Dockerfile` stays clean: both `FROM` lines are digest
+  pinned, and a self-scan reports zero `DOCKER_*` findings.
+
+### Open for the owner
+
+Nothing blocks the merge. One judgement is worth a second opinion: whether
+`DOCKER_TAG_NOT_DIGEST` should ship at `low` or at `medium`. `low` was chosen
+because it matches the in-repo Actions precedent and leaves every existing gate
+where it was. `medium` would make it visible to `--fail-on medium` consumers and
+is a one-word change in `src/dockerfile-scanner.ts`; the trade-off is written out
+in `docs/ARCHITECTURE.md`.
+
+---
+
 ## The required handoff gate compared main to itself on every push (2026-08-22, unreleased)
 
 Model: claude-opus-5. Branch fix/aahp-verify-explicit-base. No version bump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ## [Unreleased]
 
+### Added
+
+- **`DOCKER_TAG_NOT_DIGEST` (low): a base image referenced by tag rather than by
+  an immutable digest.** This is the tier that makes the digest policy visible
+  without changing anyone's gate. `high` is what the default gate fails on, so
+  reporting every version-tagged `FROM` line at `high` would have flipped every
+  ordinary Dockerfile in every consumer from pass to fail in one release, for a
+  risk that had not changed. The split mirrors the precedent already in this
+  codebase for the same question about GitHub Actions references
+  (`GHA_UNPINNED_ACTION` medium, `GHA_TAG_NOT_SHA` low). The default gate,
+  `--fail-on high` and `--fail-on medium` are unchanged; `--fail-on low`,
+  `--fail-on info` and the risk score are not. Disable it with
+  `rules.disable: [DOCKER_TAG_NOT_DIGEST]` if it is not your policy. The full
+  decision record, the option not taken and the stated bounds are in
+  `docs/ARCHITECTURE.md`. The report-level "pin base images by digest"
+  recommendation now also fires for this rule, so a report whose only base-image
+  finding is the new tier still tells the reader what to do about it.
+
+### Fixed
+
+- **`DOCKER_UNPINNED_BASE` was narrower than its own five tag words, so a
+  literal `:latest` could pass a `--fail-on high` gate with exit 0.** The rule
+  was one regex,
+  `FROM\s+(?!scratch)\S+:(?:latest|stable|lts|current|mainline)(?:\s|$)`, and it
+  missed three shapes inside its own stated scope. `\S+` bound to the first
+  token after `FROM`, so `FROM --platform=$BUILDPLATFORM node:latest` scanned
+  clean end to end (risk score 2, zero high findings, `--fail-on high` exit 0).
+  The alternation ended at `(?:\s|$)`, so `node:lts-alpine`,
+  `nginx:stable-alpine`, `nginx:mainline-alpine` and `node:current-slim` escaped
+  while their bare forms flagged, and the suffixed forms are the ones people
+  write. `(?!scratch)` had no token boundary, so `FROM scratch-base:latest` and
+  `FROM scratchpad:latest` scanned clean. Measured over 19 representative `FROM`
+  lines on the released rule: 5 flagged, and those 5 were exactly the five bare
+  literal words.
+
+  Widening the regex could not fix it. Two of the three misses are structural,
+  and this project's own denial-of-service guard rejects the obvious widened
+  forms at module load. The three `FROM` rules now share one structural parser
+  (`correlatedMatcher`, the mechanism this file already used for
+  `DOCKER_CURL_PIPE` and `DOCKER_APT_NO_VERIFY`), which strips instruction
+  flags, joins backslash continuations, drops comment lines, tracks
+  `AS <stage>` names in file order and exempts `scratch` only as a whole token.
+
+- **`DOCKER_NO_TAG` reported a build-stage reference as an untagged image.**
+  `FROM builder`, after an earlier `FROM ... AS builder`, names a stage in the
+  same build, not a registry image, and a stage cannot be pinned. It is no
+  longer reported. The same parser closes the mirror gap: `FROM ubuntu AS base`
+  is now reported, where the old `\s*$` anchor let a stage-declaring line with
+  no tag through.
+
+- **A `FROM` line carrying an embedded carriage return still classifies.**
+  `FROM node:latest\rEXTRA` is a shape the other Docker rules in this file
+  already guard against, and it would have become a way to hide a literal
+  `:latest` from the new parser, because JavaScript's `.` stops at a line
+  terminator. The instruction regex is deliberately left unanchored so the
+  reference is read up to the terminator and judged.
+
+- **Both `FROM` rules stopped matching text that is not an instruction.**
+  `# FROM node:latest` and `RUN echo FROM node:latest` were reported, because
+  the old regex matched `FROM` anywhere in a line. Conversely, the second line
+  of `RUN echo x \` / `FROM node:latest` is an argument to `RUN` and was read as
+  an instruction. Both are now parsed the way the daemon parses them.
+
+  Two tests asserted the old behaviour and were rewritten rather than deleted:
+  one called `FROM node:20-alpine` "pinned" and required a clean result, and a
+  second, stricter one asserted zero findings for a Dockerfile whose `FROM` line
+  carried a version tag. Verified on this repository's own `Dockerfile`, whose
+  two `FROM` lines are digest pinned: zero Docker findings under the new rules.
+
 ### Changed
 
 - **Benchmark evidence in this project's own artefacts now carries counts, never

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ For a deep dive into how GlassWorm infiltrates the software supply chain and the
 ### Infrastructure & CI/CD
 - GitHub Actions: unpinned actions, secrets exfiltration, encoded payloads, curl piping
 - Agentic workflows (GitLost class): AI-agent steps and gh-aw `.github/workflows/*.md` that ingest untrusted issue/PR text, hold a cross-repo token, and can post publicly - the prompt-injection data-leak posture
-- Dockerfile: curl pipe, unpinned base images, hardcoded secrets, SUID bits
+- Dockerfile / Containerfile: curl pipe, base images on a moving channel tag or without a digest,
+  hardcoded secrets, SUID bits. Compose `image:` values are out of scope for every Docker rule
+  (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#base-image-pinning-decision-record))
 - Terraform/IaC: inline scripts, external modules, hardcoded secrets
 - Package manager configs (.npmrc, .yarnrc, pip.conf): HTTP registries, exposed tokens
 - Git hooks and submodule security
@@ -566,7 +568,7 @@ supply-chain-guard scan ./project --baseline .scg-baseline.json
 | RubyGems | `scan` | Gemfile, Gemfile.lock (malicious-gem IOCs, http/git sources) |
 | Composer/PHP | `scan` | composer.json, composer.lock (malicious-package IOCs, http repos) |
 | NuGet/.NET | `scan` | packages.lock.json, *.csproj, nuget.config (malicious-package IOCs, http feeds) |
-| Docker | `scan` | Dockerfile, docker-compose.yml, Containerfile |
+| Docker | `scan` | Dockerfile, Dockerfile.*, Containerfile. `docker-compose.yml` is read, but every Docker rule is anchored on a Dockerfile instruction keyword, so Compose `image:` values are not covered |
 | Terraform | `scan` | .tf, .hcl files (provisioners, modules, secrets) |
 | VS Code | `vscode` | .vsix files, activation events, dangerous APIs |
 | GitHub Actions | `scan` | .github/workflows/*.yml |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,3 +42,92 @@ For the current module and test-file counts, see DASHBOARD.md (gate-kept fresh).
 - **Threat intel is data, not code**: IOCs live in `threat-intel.ts` /
   `ioc-blocklist.ts` and the published `feed.json`, versioned with the release.
 - **SARIF + SBOM** for GitHub Security tab and supply-chain inventory integration.
+
+## Base Image Pinning (decision record)
+
+`src/dockerfile-scanner.ts` parses every `FROM` instruction with one structural
+matcher and sorts the reference into exactly one verdict. This section records
+the two policy choices behind that, the options that were not taken, and why, so
+that a later reader can revisit them on the same evidence rather than guess.
+
+### Two tiers, not one
+
+| Reference | Verdict | Rule | Severity |
+|-----------|---------|------|----------|
+| `FROM node:22-alpine@sha256:<64 hex>` | pinned | none | none |
+| `FROM scratch` | reserved empty image | none | none |
+| `FROM ubuntu` | no tag, no digest | `DOCKER_NO_TAG` | high |
+| `FROM node:lts-alpine` | moving channel tag | `DOCKER_UNPINNED_BASE` | high |
+| `FROM node:20-alpine` | tag, but no digest | `DOCKER_TAG_NOT_DIGEST` | low |
+
+The option not taken was a single rule at `high` for every `FROM` line without a
+digest. It was rejected on a measured consequence, not on taste: `high` is what
+the DEFAULT gate fails on, because `getReportExitCode` in `src/reporter.ts`
+returns exit 1 when `summary.high > 0`. One high tier would therefore flip every
+ordinary version-tagged Dockerfile in every consumer from pass to fail in a
+single release, for a risk that has not changed since the previous release.
+
+The split follows the precedent this codebase already set for the same question
+about GitHub Actions references: `src/github-actions-scanner.ts` reports a
+branch-like ref as `GHA_UNPINNED_ACTION` (medium) and a version tag that is not a
+commit SHA as `GHA_TAG_NOT_SHA` (low). `DOCKER_TAG_NOT_DIGEST` is the Docker
+analogue of `GHA_TAG_NOT_SHA` and carries the same `low`.
+
+What that costs, stated so nobody has to discover it: the default gate,
+`--fail-on high` and `--fail-on medium` are unchanged by the new tier.
+`--fail-on low`, `--fail-on info` and the risk score are not, because a `low`
+finding weighs 1 point (`SEVERITY_WEIGHTS` in `src/risk-engine.ts`). A project
+that wants the digest policy enforced raises its gate to `--fail-on low`. A
+project that does not want the tier at all disables it in
+`.supply-chain-guard.yml`:
+
+```yaml
+rules:
+  disable: [DOCKER_TAG_NOT_DIGEST]
+```
+
+### Compose `image:` values are out of scope
+
+`isDockerFile()` admits `docker-compose.yml` and `docker-compose.yaml`, so those
+files are opened and read. Every rule in `DOCKERFILE_PATTERNS` is anchored on a
+Dockerfile instruction keyword (`FROM`, `RUN`, `ADD`, `COPY`, `ENV`, `ARG`), and
+none of them can match Compose syntax. A Compose file therefore returns nothing
+from the Docker rule set, whatever it contains.
+
+That is now said out loud in each `FROM` rule's `description`, in README.md and
+here, because a file that is read by rules which structurally cannot match it
+looks like coverage and is not.
+
+The option not taken was an `image:` matcher scoped to `docker-compose.ya?ml`.
+It was deferred rather than rejected, for one reason that needs solving first: in
+Compose, a service that also declares `build:` uses `image:` to name the tag it
+BUILDS, not an image it pulls. Reporting that as an unpinned base image would be
+a false positive on a line the author cannot pin, and this project has one
+runtime dependency and no YAML parser, so distinguishing the two cases means
+tracking service-block structure by hand. A rule that fires on correct
+configuration gets the whole tool switched off, which costs more than the gap it
+closes. Anyone picking this up should start from that constraint.
+
+### Stated bounds
+
+- **`MAX_FROM_INSTRUCTION_CHARS = 1024`.** How much of one `FROM` instruction is
+  parsed, and how much of a backslash-continuation chain is joined. It is
+  roughly double the longest instruction the reference grammar can produce (an
+  image name is capped at 255 characters, a tag at 128, a sha512 digest costs
+  136 with its separator, `--platform=linux/arm64/v8` about 25), so no legal
+  instruction reaches it. Its job is to keep the matcher linear on a single
+  attacker-supplied multi-megabyte line and on a file of a million continuation
+  lines. Beyond the bound an instruction produces no finding.
+- **A digest counts as a pin only at full length**: `sha256` with 64 hex
+  characters or `sha512` with 128, the two algorithms the OCI image
+  specification registers. A truncated placeholder such as `@sha256:abc...`
+  identifies no image and the daemon rejects it, so reading it as pinned would
+  report a broken reference as safe.
+- **A reference that is WHOLLY a variable** (`FROM $BASE`, `FROM ${BASE}`)
+  produces no finding in either direction. Its value is not visible to a
+  file-local scan and may itself carry a digest. The `ARG` default in the same
+  file is deliberately not resolved, because `--build-arg` overrides it at build
+  time, so the default is not authoritative.
+- **Build stages are resolved in file order**, matching the daemon: a reference
+  is treated as a stage only when an earlier `FROM ... AS <name>` declared it.
+  A forward reference is not a stage and is still classified.

--- a/src/__tests__/dockerfile-scanner.test.ts
+++ b/src/__tests__/dockerfile-scanner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
 import {
   scanDockerFile,
   isDockerFile,
@@ -24,6 +25,13 @@ function normalizePatternMatches(
     return { line: hit.line, start: absoluteStart, evidence: hit.text };
   });
 }
+
+/**
+ * A syntactically valid, obviously synthetic sha256 digest (64 hex characters).
+ * The length matters: PINNED_DIGEST_RE rejects a truncated placeholder, because
+ * a truncated digest identifies no image and the daemon refuses it.
+ */
+const TEST_DIGEST = `sha256:${"0123456789abcdef".repeat(4)}`;
 
 describe("Dockerfile Scanner", () => {
   it("should identify Docker-related filenames", () => {
@@ -62,11 +70,20 @@ describe("Dockerfile Scanner", () => {
     expect(findings.some((f) => f.rule === "DOCKER_NO_TAG")).toBe(true);
   });
 
-  it("should not flag pinned images", () => {
-    const content = 'FROM node:20-alpine';
-    const findings = scanDockerFile(content, "Dockerfile");
-    expect(findings.some((f) => f.rule === "DOCKER_UNPINNED_BASE")).toBe(false);
-    expect(findings.some((f) => f.rule === "DOCKER_NO_TAG")).toBe(false);
+  it("treats a version tag as unpinned and a digest as pinned", () => {
+    // This test used to assert the opposite: it called FROM node:20-alpine
+    // "pinned" and required a clean result, which is the assertion issue 174
+    // reports as holding the gap open. A version tag is mutable (the image
+    // behind it is rebuilt), so it is a low-severity reproducibility finding,
+    // NOT the high-severity moving-channel finding and NOT clean.
+    const tagged = scanDockerFile("FROM node:20-alpine", "Dockerfile");
+    expect(tagged.some((f) => f.rule === "DOCKER_TAG_NOT_DIGEST")).toBe(true);
+    expect(tagged.find((f) => f.rule === "DOCKER_TAG_NOT_DIGEST")?.severity).toBe("low");
+    expect(tagged.some((f) => f.rule === "DOCKER_UNPINNED_BASE")).toBe(false);
+    expect(tagged.some((f) => f.rule === "DOCKER_NO_TAG")).toBe(false);
+
+    const pinned = scanDockerFile(`FROM node:22-alpine@${TEST_DIGEST}`, "Dockerfile");
+    expect(pinned).toHaveLength(0);
   });
 
   it("should detect HTTP ADD source", () => {
@@ -100,8 +117,12 @@ describe("Dockerfile Scanner", () => {
   });
 
   it("should return empty findings for clean Dockerfile", () => {
+    // The FROM line was `FROM node:20-alpine AS builder` and this test asserted
+    // zero findings, which is the second assertion that locked issue 174 in
+    // place. A clean Dockerfile is a digest-pinned one, so that is what it now
+    // uses; the rest of the fixture is unchanged.
     const content = [
-      "FROM node:20-alpine AS builder",
+      `FROM node:22-alpine@${TEST_DIGEST} AS builder`,
       "WORKDIR /app",
       "COPY package*.json ./",
       "RUN npm ci --production",
@@ -266,6 +287,226 @@ describe("Dockerfile Scanner", () => {
     expect(npmHits.coverage.regexAttempts).toBe(1);
 
     expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Base image pinning (issue 174). One structural parser, three verdicts.
+  //
+  // Every case below is a shape the released five-word regex got wrong, or a
+  // shape the replacement must not start getting wrong. Deleting any single
+  // expectation reddens nothing else, which is the point: each one is the only
+  // test that covers its branch of classifyBaseImageReference().
+  // -------------------------------------------------------------------------
+
+  function pinningVerdict(content: string): string[] {
+    return scanDockerFile(content, "Dockerfile")
+      .filter((f) =>
+        f.rule === "DOCKER_UNPINNED_BASE" ||
+        f.rule === "DOCKER_NO_TAG" ||
+        f.rule === "DOCKER_TAG_NOT_DIGEST"
+      )
+      .map((f) => `${f.rule}@${f.line}`)
+      .sort();
+  }
+
+  it("flags a moving channel tag in every shape the five-word regex missed", () => {
+    const cases: Array<[string, string]> = [
+      // The bare forms the released rule already caught. Kept as the control:
+      // a regression here means the widening lost ground rather than gained it.
+      ["FROM node:latest", "bare latest"],
+      ["FROM node:stable", "bare stable"],
+      ["FROM node:lts", "bare lts"],
+      ["FROM node:current", "bare current"],
+      ["FROM nginx:mainline", "bare mainline"],
+      // Miss 1: an instruction flag bound \S+ to the flag token, so a literal
+      // :latest scanned clean and passed --fail-on high with exit 0.
+      ["FROM --platform=$BUILDPLATFORM node:latest AS build", "--platform flag"],
+      ["FROM --platform=linux/amd64 nginx:stable", "--platform, literal value"],
+      // Miss 2: the alternation ended at (?:\s|$), so the suffixed upstream
+      // channel tags escaped while their bare forms flagged.
+      ["FROM node:lts-alpine", "lts-alpine"],
+      ["FROM nginx:stable-alpine", "stable-alpine"],
+      ["FROM nginx:mainline-alpine", "mainline-alpine"],
+      ["FROM node:current-slim", "current-slim"],
+      // Miss 3: (?!scratch) had no token boundary.
+      ["FROM scratch-base:latest", "scratch-prefixed name"],
+      ["FROM scratchpad:latest", "scratch-prefixed name, no hyphen"],
+      // Shapes the parser must keep getting right.
+      ["FROM registry.example.com:5000/team/app:latest", "registry port plus tag"],
+      ["FROM node:LATEST", "tag case is not significant"],
+      ["from node:latest", "instruction case is not significant"],
+      ["  FROM node:latest", "indented instruction"],
+    ];
+
+    for (const [content, label] of cases) {
+      expect(pinningVerdict(content), label).toEqual(["DOCKER_UNPINNED_BASE@1"]);
+    }
+  });
+
+  it("flags a tag without a digest at low severity, separately from a channel tag", () => {
+    const cases: Array<[string, string]> = [
+      ["FROM node:20-alpine", "version tag"],
+      ["FROM postgres:16-alpine", "version tag"],
+      ["FROM python:3.12-slim", "version tag"],
+      ["FROM owasp/modsecurity-crs:apache", "arbitrary non-version tag"],
+      ["FROM registry.example.com:5000/team/app:1.2.3", "registry port plus version tag"],
+      [`FROM node:20@${TEST_DIGEST.slice(0, 20)}`, "truncated digest is not a pin"],
+      ["FROM node:${NODE_TAG}", "variable tag on a concrete name"],
+    ];
+
+    for (const [content, label] of cases) {
+      expect(pinningVerdict(content), label).toEqual(["DOCKER_TAG_NOT_DIGEST@1"]);
+    }
+    expect(
+      scanDockerFile("FROM node:20-alpine", "Dockerfile")
+        .find((f) => f.rule === "DOCKER_TAG_NOT_DIGEST")?.severity,
+    ).toBe("low");
+  });
+
+  it("flags a base image with no tag and no digest, in a stage declaration too", () => {
+    expect(pinningVerdict("FROM ubuntu")).toEqual(["DOCKER_NO_TAG@1"]);
+    // New: the released regex ended at \s*$, so a stage-declaring FROM with no
+    // tag scanned clean. It defaults to :latest exactly like the bare form.
+    expect(pinningVerdict("FROM ubuntu AS base")).toEqual(["DOCKER_NO_TAG@1"]);
+  });
+
+  it("reports nothing for a reference that is pinned, reserved, or not an image", () => {
+    const cases: Array<[string, string]> = [
+      [`FROM node:22-alpine@${TEST_DIGEST}`, "tag plus digest"],
+      [`FROM ubuntu@${TEST_DIGEST}`, "digest without a tag"],
+      [`FROM registry.example.com:5000/team/app@${TEST_DIGEST}`, "registry port plus digest"],
+      ["FROM scratch", "the reserved empty image"],
+      ["FROM SCRATCH", "reserved image, case insensitive"],
+      // A stage reference is not a registry image and cannot be digest pinned.
+      // Without stage tracking this line reads as an untagged image.
+      [`FROM node:22-alpine@${TEST_DIGEST} AS builder\nFROM builder AS runtime`, "stage reference"],
+      [`FROM node:22-alpine@${TEST_DIGEST} AS Builder\nFROM builder`, "stage names are case insensitive"],
+      // Wholly variable: the value is not visible here and may carry a digest.
+      ["FROM $NODE_IMAGE", "whole reference is a variable"],
+      ["FROM ${NODE_IMAGE}", "whole reference is a braced variable"],
+      ["FROM ${NODE_IMAGE:-fallback}", "braced variable with a default"],
+      // Not instructions at all. The released regex matched FROM anywhere in
+      // the line, so both of these were reported.
+      ["# FROM node:latest", "commented out instruction"],
+      ["RUN echo FROM node:latest", "FROM inside another instruction"],
+    ];
+
+    for (const [content, label] of cases) {
+      expect(pinningVerdict(content), label).toEqual([]);
+    }
+  });
+
+  it("resolves a stage only when it is declared above the reference", () => {
+    // Docker resolves stages declared ABOVE the instruction. A forward
+    // reference is not a stage, so it must not be silenced as one.
+    const forward = [
+      "FROM runtime",
+      `FROM node:22-alpine@${TEST_DIGEST} AS runtime`,
+    ].join("\n");
+    expect(pinningVerdict(forward)).toEqual(["DOCKER_NO_TAG@1"]);
+  });
+
+  it("parses a FROM instruction split across continuation lines", () => {
+    // Reported on the line the instruction STARTS on, which is where a reader
+    // and a code-review annotation both look.
+    expect(pinningVerdict("FROM \\\n  node:latest")).toEqual([
+      "DOCKER_UNPINNED_BASE@1",
+    ]);
+    expect(pinningVerdict("FROM \\\n# a comment inside the instruction\n  node:latest")).toEqual([
+      "DOCKER_UNPINNED_BASE@1",
+    ]);
+    // The mirror image: a continuation line that merely BEGINS with FROM is an
+    // argument to the previous instruction, not an instruction.
+    expect(pinningVerdict("RUN echo hello \\\nFROM node:latest")).toEqual([]);
+  });
+
+  it("classifies a FROM instruction carrying an embedded line terminator", () => {
+    // JavaScript's `.` stops at a line terminator, so a `$`-anchored
+    // instruction regex fails to match at all on these and the literal :latest
+    // scans clean. The released five-word regex DID report them, because \r is
+    // whitespace to \s, so getting this wrong would be a regression rather than
+    // an unchanged gap. The same evasion is guarded elsewhere in this file.
+    for (const terminator of ["\r", "\u2028", "\u2029"]) {
+      expect(
+        pinningVerdict(`FROM node:latest${terminator}EXTRA`),
+        JSON.stringify(terminator),
+      ).toEqual(["DOCKER_UNPINNED_BASE@1"]);
+    }
+  });
+
+  it("does not classify a FROM instruction longer than the parse bound", () => {
+    // MAX_FROM_INSTRUCTION_CHARS is 1024, about double the longest instruction
+    // the reference grammar can produce. Beyond it the instruction is not a
+    // legal reference and is not classified; the bound is what keeps this
+    // matcher linear on an attacker-supplied line. Asserted so the limit is a
+    // documented behaviour rather than a surprise.
+    const within = `FROM --platform=${"a".repeat(900)} node:latest`;
+    expect(pinningVerdict(within), "inside the bound").toEqual([
+      "DOCKER_UNPINNED_BASE@1",
+    ]);
+    const beyond = `FROM --platform=${"a".repeat(1200)} node:latest`;
+    expect(pinningVerdict(beyond), "beyond the bound").toEqual([]);
+  });
+
+  it("keeps this repository's own Dockerfile clean under the new rules", () => {
+    // Acceptance criterion 3 of the issue. Both FROM lines are digest pinned,
+    // so if this ever reddens the rule is wrong, not the Dockerfile.
+    const dockerfile = readFileSync(
+      new URL("../../Dockerfile", import.meta.url),
+      "utf-8",
+    );
+    expect(pinningVerdict(dockerfile)).toEqual([]);
+  });
+
+  it("fully scans 5 MiB of FROM-shaped near misses in linear time", { timeout: 15_000 }, () => {
+    const size = 5 * 1024 * 1024;
+    const started = Date.now();
+
+    // An unbounded continuation chain: 5 MiB of lines that each ask to be
+    // joined to the next. The join budget, not the file, has to bound the work.
+    const continuation = "RUN x \\\n";
+    const continued = continuation.repeat(
+      Math.floor(size / continuation.length),
+    );
+    // One enormous physical line. The per-instruction parse bound, not the
+    // line length, has to bound the work.
+    const single = `FROM --platform=${"a".repeat(size)} node:latest`;
+
+    for (const rule of ["DOCKER_UNPINNED_BASE", "DOCKER_NO_TAG", "DOCKER_TAG_NOT_DIGEST"]) {
+      const pattern = DOCKERFILE_PATTERNS.find((entry) => entry.rule === rule)!;
+
+      const continuedHits = matchPatternInContent(pattern, continued, "i");
+      expect(continuedHits, `${rule}: continuations`).toHaveLength(0);
+      expect(continuedHits.coverage.regexAttempts, rule).toBe(1);
+
+      const singleHits = matchPatternInContent(pattern, single, "i");
+      expect(singleHits, `${rule}: single long line`).toHaveLength(0);
+      expect(singleHits.coverage.complete, rule).toBe(true);
+      expect(singleHits.coverage.regexAttempts, rule).toBe(1);
+    }
+
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  it("loads DOCKERFILE_PATTERNS with all three FROM rules bound to a matcher", () => {
+    // validatePatternSet() runs at module load. When it throws, vitest reports
+    // "no tests" for this file rather than a failed assertion, so a suite that
+    // never ran looks very much like a suite that passed. This test fails
+    // loudly instead, and it is also the guard on the rule-id surface: a
+    // renamed or dropped rule id is a breaking change for every consumer that
+    // has it in rules.disable or in a SARIF baseline.
+    for (const rule of ["DOCKER_UNPINNED_BASE", "DOCKER_NO_TAG", "DOCKER_TAG_NOT_DIGEST"]) {
+      const entry = DOCKERFILE_PATTERNS.find((p) => p.rule === rule);
+      expect(entry, rule).toBeDefined();
+      expect(typeof entry!.correlatedMatcher, rule).toBe("function");
+      expect(entry!.description, rule).toMatch(/Compose image: values are out of scope/);
+    }
+    expect(
+      DOCKERFILE_PATTERNS.find((p) => p.rule === "DOCKER_TAG_NOT_DIGEST")!.severity,
+    ).toBe("low");
+    expect(
+      DOCKERFILE_PATTERNS.find((p) => p.rule === "DOCKER_UNPINNED_BASE")!.severity,
+    ).toBe("high");
   });
 
   it("should have patterns array", () => {

--- a/src/dockerfile-scanner.ts
+++ b/src/dockerfile-scanner.ts
@@ -303,6 +303,321 @@ const dockerNpmGlobalMatcher: NonNullable<
   });
 
 // ---------------------------------------------------------------------------
+// FROM instructions: one structural parser, three pinning verdicts
+// ---------------------------------------------------------------------------
+
+/**
+ * WHY A PARSER AND NOT A WIDER REGEX.
+ *
+ * The released rule was one regex,
+ * `FROM\s+(?!scratch)\S+:(?:latest|stable|lts|current|mainline)(?:\s|$)`, and it
+ * was narrower than its own five words:
+ *
+ * - `\S+` binds to the FIRST token after FROM, so
+ *   `FROM --platform=$BUILDPLATFORM node:latest` scanned clean despite carrying
+ *   a literal `:latest`, and passed `--fail-on high` with exit code 0.
+ * - the alternation ended at `(?:\s|$)`, so the suffixed upstream channel tags
+ *   (`node:lts-alpine`, `nginx:stable-alpine`, `nginx:mainline-alpine`) scanned
+ *   clean while their bare forms flagged. The suffixed forms are the ones people
+ *   actually write.
+ * - `(?!scratch)` had no token boundary, so `FROM scratch-base:latest` and
+ *   `FROM scratchpad:latest` scanned clean.
+ *
+ * Measured on the released rule over 19 representative FROM lines: 5 flagged,
+ * and the 5 were exactly the five bare literal words.
+ *
+ * Widening the regex cannot fix this. Two of the three misses are structural (a
+ * flag token, a build-stage name), and this repository's own denial-of-service
+ * guard, `validatePatternSet` in src/patterns.ts, refuses the obvious widened
+ * forms at module load because they contain a broad unbounded consuming gap.
+ * `correlatedMatcher` is the mechanism this file already uses for exactly that
+ * reason (DOCKER_CURL_PIPE, DOCKER_APT_NO_VERIFY), so the FROM rules use it too.
+ * One parser produces all three verdicts, which is why the rules can no longer
+ * disagree about what a build-stage reference is.
+ */
+
+/**
+ * TIERING AND SEVERITY. This is an owner-level policy choice, recorded here
+ * because this is where the next reader meets it. The options and the reasoning
+ * are in docs/ARCHITECTURE.md, "Base image pinning".
+ *
+ * A base image reference is sorted into exactly one verdict:
+ *
+ *   digest pinned      `FROM node:22-alpine@sha256:<64 hex>`  no finding
+ *   scratch            `FROM scratch`                         no finding
+ *   no tag, no digest  `FROM ubuntu`             DOCKER_NO_TAG          high
+ *   moving channel tag `FROM node:lts-alpine`    DOCKER_UNPINNED_BASE   high
+ *   tag, but no digest `FROM node:20-alpine`     DOCKER_TAG_NOT_DIGEST  low
+ *
+ * The alternative was one rule at `high` for every FROM line without a digest.
+ * It was not taken, for a measured reason: `high` is what the DEFAULT gate fails
+ * on (`getReportExitCode` in src/reporter.ts returns 1 when `summary.high > 0`),
+ * so a single high tier would flip every ordinary version-tagged Dockerfile in
+ * every consumer from pass to fail in one release, for a risk that has not
+ * changed. The split follows the precedent this codebase already set for the
+ * same question about GitHub Actions references: src/github-actions-scanner.ts
+ * reports a branch-like ref as GHA_UNPINNED_ACTION (medium) and a version tag
+ * that is not a commit SHA as GHA_TAG_NOT_SHA (low). DOCKER_TAG_NOT_DIGEST is
+ * the Docker analogue of GHA_TAG_NOT_SHA and carries the same `low`.
+ *
+ * What that costs and who pays it: the default gate, `--fail-on high` and
+ * `--fail-on medium` are unchanged by this tier; `--fail-on low`,
+ * `--fail-on info` and the risk score (weight 1 per finding, see
+ * SEVERITY_WEIGHTS in src/risk-engine.ts) are not. A consumer who wants the
+ * digest policy enforced raises the gate to `--fail-on low`; a consumer who does
+ * not want the tier at all sets `rules.disable: [DOCKER_TAG_NOT_DIGEST]` in
+ * .supply-chain-guard.yml, or reassigns it through `rules.severityOverrides`.
+ */
+
+/**
+ * DELIBERATE SCOPE LIMIT: Compose `image:` values.
+ *
+ * `isDockerFile()` admits docker-compose.yml, so the file is opened and read,
+ * but every rule in DOCKERFILE_PATTERNS is anchored on a Dockerfile instruction
+ * keyword and none of them can match Compose syntax. That is stated in each
+ * FROM rule's `description`, in README.md and in docs/ARCHITECTURE.md rather
+ * than left to be discovered, because a file that is read by rules which
+ * structurally cannot match it looks like coverage and is not.
+ */
+
+/** Tag words that name a MOVING CHANNEL rather than a specific release. */
+const MUTABLE_CHANNEL_TAGS: ReadonlySet<string> = new Set([
+  "latest",
+  "stable",
+  "lts",
+  "current",
+  "mainline",
+]);
+
+/**
+ * A digest that actually pins.
+ *
+ * The OCI image specification writes a digest as `algorithm ":" encoded`, and
+ * registers exactly two algorithms: sha256 (64 hex characters) and sha512 (128).
+ * The length is part of the test on purpose, so a truncated placeholder such as
+ * `@sha256:abc...` is NOT read as a pin. It identifies no image and the daemon
+ * rejects it, so treating it as pinned would report a broken reference as safe.
+ */
+const PINNED_DIGEST_RE =
+  /^(?:sha256:[0-9a-fA-F]{64}|sha512:[0-9a-fA-F]{128})$/;
+
+/**
+ * How many characters of one FROM instruction are parsed, and how much of a
+ * continuation chain is joined.
+ *
+ * The bound exists so that a single attacker-supplied multi-megabyte line, or a
+ * file of a million continuation lines, cannot turn this matcher superlinear.
+ * 1024 is roughly double the longest FROM instruction the reference grammar can
+ * produce: an image name is capped at 255 characters, a tag at 128, a sha512
+ * digest costs 136 with its separator, `--platform=linux/arm64/v8` about 25,
+ * and ` AS <stage>` a few dozen more, which totals under 600. An instruction
+ * longer than this bound is therefore not a legal reference; it is parsed as far
+ * as the bound and then produces no finding, which is asserted by the test
+ * "does not classify a FROM instruction longer than the parse bound".
+ */
+const MAX_FROM_INSTRUCTION_CHARS = 1024;
+
+/** A Dockerfile comment line. Docker removes these before joining continuations. */
+const DOCKER_COMMENT_LINE_RE = /^[ \t]*#/;
+
+/**
+ * `FROM` as the instruction of the line. Group 1 is the indent, group 2 the rest.
+ *
+ * Deliberately NOT anchored with `$`. JavaScript's `.` stops at a line
+ * terminator, so `FROM node:latest\rEXTRA` would fail a `$`-anchored match
+ * entirely and the literal `:latest` would scan clean. Without the anchor the
+ * reference is read up to the terminator and still classified, which is the
+ * same evasion the other rules in this file guard against (see hasDotTerminator
+ * above). Covered by "classifies a FROM instruction carrying an embedded line
+ * terminator".
+ */
+const FROM_INSTRUCTION_RE = /^([ \t]*)FROM[ \t]+(.*)/i;
+
+/** A FROM instruction flag, for example `--platform=linux/amd64`. */
+const FROM_FLAG_RE = /^--[A-Za-z][A-Za-z0-9-]*(?:=.*)?$/;
+
+/**
+ * A reference that is WHOLLY a build argument or environment variable. Its value
+ * is not visible to a file-local scan and may itself carry a digest, so
+ * classifying it would be a guess. The ARG default is deliberately not resolved
+ * either: `--build-arg` overrides it at build time, so the default is not
+ * authoritative. Such a reference produces no finding, in either direction.
+ */
+const WHOLLY_VARIABLE_REF_RE = /^\$(?:\{[^{}]*\}|[A-Za-z_][A-Za-z0-9_]*)$/;
+
+/** A line continued by a trailing backslash. */
+const LINE_CONTINUATION_RE = /\\[ \t]*$/;
+
+interface DockerLogicalLine {
+  /** Offset of the first character of the instruction's first physical line. */
+  start: number;
+  /** Offset just past that first physical line, so evidence never spans lines. */
+  firstLineEnd: number;
+  /** Comment lines removed, continuations joined, length bounded. */
+  text: string;
+}
+
+/**
+ * Yield logical Dockerfile lines: comment lines dropped, backslash
+ * continuations joined, in that order, which is the order the daemon applies.
+ *
+ * Tracking continuations is not a nicety. Without it, the second line of
+ * `RUN echo x \` / `FROM node:latest` reads as a FROM instruction when it is an
+ * argument to RUN.
+ */
+function* iterateDockerLogicalLines(
+  content: string,
+): Iterable<DockerLogicalLine> {
+  let index = 0;
+  let pending: DockerLogicalLine | undefined;
+
+  for (;;) {
+    if (index > content.length) break;
+    const newline = content.indexOf("\n", index);
+    const lineEnd = newline === -1 ? content.length : newline;
+    let rawEnd = lineEnd;
+    if (rawEnd > index && content.charCodeAt(rawEnd - 1) === 0x0d) rawEnd--;
+    const raw = content.slice(index, rawEnd);
+
+    if (!DOCKER_COMMENT_LINE_RE.test(raw)) {
+      const continues = LINE_CONTINUATION_RE.test(raw);
+      const body = continues ? raw.replace(LINE_CONTINUATION_RE, "") : raw;
+      pending ??= { start: index, firstLineEnd: rawEnd, text: "" };
+      const budget = MAX_FROM_INSTRUCTION_CHARS - pending.text.length;
+      if (budget > 0) pending.text += body.slice(0, budget);
+      if (!continues) {
+        yield pending;
+        pending = undefined;
+      }
+    }
+
+    if (newline === -1) break;
+    index = newline + 1;
+  }
+
+  if (pending !== undefined) yield pending;
+}
+
+interface FromInstruction {
+  /** Offset of the FROM keyword. */
+  start: number;
+  /** Offset just past the reported evidence, always on the FROM keyword's line. */
+  end: number;
+  /** The image reference token with FROM flags removed, "" when absent. */
+  reference: string;
+  /** Lower-cased build-stage name this instruction declares, if any. */
+  stage: string | undefined;
+}
+
+function parseFromInstruction(
+  line: DockerLogicalLine,
+): FromInstruction | undefined {
+  const match = FROM_INSTRUCTION_RE.exec(line.text);
+  if (match === null) return undefined;
+
+  const start = line.start + match[1]!.length;
+  const end = Math.min(
+    line.firstLineEnd,
+    start + MAX_FROM_INSTRUCTION_CHARS,
+  );
+  if (end <= start) return undefined;
+
+  const tokens = match[2]!.split(/[ \t]+/).filter((token) => token !== "");
+  let cursor = 0;
+  while (cursor < tokens.length && FROM_FLAG_RE.test(tokens[cursor]!)) cursor++;
+
+  // Docker stage names are matched case-insensitively, so normalise once here.
+  const stage =
+    tokens.length > cursor + 2 && tokens[cursor + 1]!.toLowerCase() === "as"
+      ? tokens[cursor + 2]!.toLowerCase()
+      : undefined;
+
+  return { start, end, reference: tokens[cursor] ?? "", stage };
+}
+
+type BaseImagePinning =
+  | "digest-pinned"
+  | "scratch"
+  | "no-tag"
+  | "mutable-channel"
+  | "tag-without-digest";
+
+/**
+ * Sort one image reference into exactly one pinning verdict, or undefined when
+ * the reference cannot be judged from the file alone.
+ *
+ * Reference grammar: `[registry[:port]/]name[:tag][@digest]`. The port colon is
+ * distinguished from the tag colon by requiring the tag colon to come after the
+ * last `/`, which is why `registry.example.com:5000/team/app` is not read as a
+ * tag of `5000/team/app`.
+ */
+function classifyBaseImageReference(
+  reference: string,
+): BaseImagePinning | undefined {
+  if (reference === "") return undefined;
+  if (WHOLLY_VARIABLE_REF_RE.test(reference)) return undefined;
+
+  const at = reference.lastIndexOf("@");
+  const namePart = at === -1 ? reference : reference.slice(0, at);
+  if (at !== -1 && PINNED_DIGEST_RE.test(reference.slice(at + 1))) {
+    return "digest-pinned";
+  }
+
+  const slash = namePart.lastIndexOf("/");
+  const colon = namePart.lastIndexOf(":");
+  const tagged = colon > slash;
+  const tag = tagged ? namePart.slice(colon + 1) : "";
+  const name = tagged ? namePart.slice(0, colon) : namePart;
+
+  // `scratch` is the reserved empty image and cannot be pinned. It is exempt
+  // only as a WHOLE token, which is what `scratch-base` and `scratchpad` broke.
+  if (at === -1 && !tagged && name.toLowerCase() === "scratch") return "scratch";
+  if (at === -1 && !tagged) return "no-tag";
+
+  // A moving channel tag composes as `<channel>-<variant>` upstream
+  // (node:lts-alpine, nginx:stable-alpine), so the FIRST hyphen-separated
+  // component is what decides. Only that leading position counts: a trailing
+  // component is a variant name, not a channel.
+  const channel = tag.split("-", 1)[0]!.toLowerCase();
+  if (MUTABLE_CHANNEL_TAGS.has(channel)) return "mutable-channel";
+
+  // Everything left is referenced by something that is not an immutable digest:
+  // a version tag, an arbitrary tag, or a malformed digest.
+  return "tag-without-digest";
+}
+
+/**
+ * Build the structural matcher for one pinning verdict.
+ *
+ * Build-stage names are collected in file order and a reference resolving to an
+ * already declared stage is skipped: `FROM builder` after `... AS builder` names
+ * a stage in this build, not a registry image, and a stage cannot be digest
+ * pinned. Order matters, because Docker resolves only stages declared ABOVE the
+ * instruction.
+ */
+function fromInstructionMatcher(
+  wanted: BaseImagePinning,
+): NonNullable<PatternEntry["correlatedMatcher"]> {
+  return function* matchFromInstructions(content: string) {
+    const declaredStages = new Set<string>();
+
+    for (const line of iterateDockerLogicalLines(content)) {
+      const instruction = parseFromInstruction(line);
+      if (instruction === undefined) continue;
+
+      const referencesStage = declaredStages.has(
+        instruction.reference.toLowerCase(),
+      );
+      if (instruction.stage !== undefined) declaredStages.add(instruction.stage);
+      if (referencesStage) continue;
+
+      if (classifyBaseImageReference(instruction.reference) !== wanted) continue;
+      yield boundedStructuralMatch(content, instruction.start, instruction.end);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Dockerfile patterns
 // ---------------------------------------------------------------------------
 
@@ -319,21 +634,49 @@ export const DOCKERFILE_PATTERNS: PatternEntry[] = [
   },
   {
     name: "docker-unpinned-base",
+    // Shape only, kept so the rule still reads as a pattern and still passes
+    // validatePatternSet. The verdict comes from fromInstructionMatcher; editing
+    // this string changes nothing that is reported.
     pattern:
-      "FROM\\s+(?!scratch)\\S+:(?:latest|stable|lts|current|mainline)(?:\\s|$)",
+      "FROM\\s+\\S*:(?:latest|stable|lts|current|mainline)",
     description:
-      "Dockerfile uses a mutable tag (e.g. :latest) instead of a pinned digest. The image can change without notice.",
+      "Dockerfile base image is referenced by a moving channel tag (latest, stable, lts, current, mainline, " +
+      "including variant forms such as stable-alpine). The image behind such a tag is replaced without notice, " +
+      "so the same Dockerfile builds different software. Compose image: values are out of scope for every " +
+      "Docker rule; see docs/ARCHITECTURE.md.",
     severity: "high",
     rule: "DOCKER_UNPINNED_BASE",
+    correlatedMatcher: fromInstructionMatcher("mutable-channel"),
   },
   {
     name: "docker-no-tag",
+    // Shape only; see the note on docker-unpinned-base.
     pattern:
       "FROM\\s+(?!scratch)[a-z][a-z0-9._/-]*\\s*$",
     description:
-      "Dockerfile FROM without a tag or digest. Defaults to :latest, which is mutable.",
+      "Dockerfile FROM without a tag or digest. Defaults to :latest, which is mutable. A reference to a build " +
+      "stage declared earlier in the same file is not a registry image and is not reported. Compose image: " +
+      "values are out of scope for every Docker rule; see docs/ARCHITECTURE.md.",
     severity: "high",
     rule: "DOCKER_NO_TAG",
+    correlatedMatcher: fromInstructionMatcher("no-tag"),
+  },
+  {
+    name: "docker-tag-not-digest",
+    // Shape only; see the note on docker-unpinned-base. Kept admissible to
+    // hasBroadUnboundedConsumingGap on its own, so that removing the matcher
+    // shows up as a wrong verdict in the tests rather than as an import error
+    // that vitest reports as "no tests", which reads far too much like a pass.
+    pattern:
+      "FROM\\s+\\S+:\\S+",
+    description:
+      "Dockerfile base image is referenced by tag rather than by an immutable digest, so the same tag can " +
+      "resolve to a different image on the next build. Reported at low severity: it is a reproducibility gap, " +
+      "not a moving channel. Compose image: values are out of scope for every Docker rule; see " +
+      "docs/ARCHITECTURE.md.",
+    severity: "low",
+    rule: "DOCKER_TAG_NOT_DIGEST",
+    correlatedMatcher: fromInstructionMatcher("tag-without-digest"),
   },
   {
     name: "docker-http-source",
@@ -477,9 +820,15 @@ function getDockerRecommendation(rule: string): string {
     DOCKER_CURL_PIPE:
       "Download files to disk first, verify their checksum, then execute. Never pipe remote content to a shell.",
     DOCKER_UNPINNED_BASE:
-      "Pin base images by digest: FROM node:20@sha256:abc... This ensures reproducible builds.",
+      "Replace the channel tag with a specific release and pin it by digest: " +
+      "FROM node:22-alpine@sha256:<64 hex>. A channel tag moves under you, so the build is not reproducible " +
+      "and a compromised republish of that tag lands silently.",
     DOCKER_NO_TAG:
       "Always specify a tag or digest for base images. Using no tag defaults to :latest which is mutable.",
+    DOCKER_TAG_NOT_DIGEST:
+      "Add the digest alongside the tag: FROM node:22-alpine@sha256:<64 hex>. The tag stays readable and the " +
+      "digest makes the build reproducible. Pair it with an automated bump (Dependabot or Renovate) so the pin " +
+      "does not silently freeze, and see docs/ARCHITECTURE.md if this tier is noise for your project.",
     DOCKER_HTTP_SOURCE:
       "Download files in a RUN step with checksum verification instead of using ADD with URLs.",
     DOCKER_SECRETS_BUILD:

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -2077,7 +2077,14 @@ function generateRecommendations(
       "CRITICAL: Dockerfile pipes remote content to shell. Download, verify checksum, then execute.",
     );
   }
-  if (rules.has("DOCKER_UNPINNED_BASE") || rules.has("DOCKER_NO_TAG")) {
+  // All three base-image verdicts share one remediation, so all three must
+  // reach it. DOCKER_TAG_NOT_DIGEST was the tier that could otherwise be the
+  // only finding in a report and leave that report with no recommendation.
+  if (
+    rules.has("DOCKER_UNPINNED_BASE") ||
+    rules.has("DOCKER_NO_TAG") ||
+    rules.has("DOCKER_TAG_NOT_DIGEST")
+  ) {
     recommendations.push(
       "Pin Docker base images by digest (FROM image@sha256:...) to ensure reproducible and tamper-proof builds.",
     );


### PR DESCRIPTION
## Description

Closes https://github.com/homeofe/supply-chain-guard/issues/174.

`DOCKER_UNPINNED_BASE` was one regex,
`FROM\s+(?!scratch)\S+:(?:latest|stable|lts|current|mainline)(?:\s|$)`, and it
was narrower than its own five words. All three `FROM` rules now share one
structural parser instead.

### What was actually broken, measured

Run over 19 representative `FROM` lines against the released rule: **5 flagged**,
and those 5 were exactly the five bare literal words. Three shapes inside the
rule's own stated scope scanned clean:

| Shape | Why it escaped |
|-------|----------------|
| `FROM --platform=$BUILDPLATFORM node:latest` | `\S+` bound to the flag token |
| `node:lts-alpine`, `nginx:stable-alpine`, `nginx:mainline-alpine`, `node:current-slim` | the alternation ended at `(?:\s|$)` |
| `FROM scratch-base:latest`, `FROM scratchpad:latest` | `(?!scratch)` had no token boundary |

The first one is the sharp end. End to end through the CLI, on a line carrying a
literal `:latest`:

```
FROM --platform=$BUILDPLATFORM node:latest AS build
  before   --fail-on high    exit=0    no DOCKER_* finding
  after    --fail-on high    exit=1    DOCKER_UNPINNED_BASE(high)
```

A `--fail-on high` gate went green on `:latest`.

### Why a parser and not a wider regex

Two of the three misses are structural, not lexical: a flag token and a build
stage name. And this project's own denial-of-service guard,
`validatePatternSet`, rejects the obvious widened forms at module load with
"contains a broad unbounded consuming gap and must declare a correlatedMatcher".
`correlatedMatcher` is the mechanism this file already uses for
`DOCKER_CURL_PIPE` and `DOCKER_APT_NO_VERIFY`, so the `FROM` rules use it too.

The parser strips instruction flags, joins backslash continuations, drops
comment lines, tracks `AS <stage>` names in file order, exempts `scratch` only
as a whole token, and then classifies. Because all three rules read the same
parse, they can no longer disagree about what a build-stage reference is.

### Two decisions, both recorded in the repository

Neither lives only in this pull request. Both are in
`docs/ARCHITECTURE.md`, "Base Image Pinning (decision record)", and summarised
next to the code in `src/dockerfile-scanner.ts`.

**1. Two tiers, not one.** Acceptance criterion 1 asked for a single rule at
`high` for every `FROM` line without `@sha256:`. Not taken, on a measured
consequence: `high` is what the DEFAULT gate fails on, because
`getReportExitCode` returns exit 1 when `summary.high > 0`. One high tier would
flip every ordinary version-tagged Dockerfile in every consumer from pass to
fail in a single release, for a risk that had not changed. The split follows the
precedent this codebase already set for the same question about Actions refs
(`GHA_UNPINNED_ACTION` medium, `GHA_TAG_NOT_SHA` low):

| Reference | Rule | Severity |
|-----------|------|----------|
| `FROM node:22-alpine@sha256:<64 hex>` | none | none |
| `FROM scratch` | none | none |
| `FROM ubuntu` | `DOCKER_NO_TAG` | high |
| `FROM node:lts-alpine` | `DOCKER_UNPINNED_BASE` | high |
| `FROM node:20-alpine` | `DOCKER_TAG_NOT_DIGEST` (new) | low |

Measured cost of the new tier, so nobody has to discover it:

```
FROM node:20-alpine
  --fail-on high    exit=0    DOCKER_TAG_NOT_DIGEST(low)
  --fail-on medium  exit=0    DOCKER_TAG_NOT_DIGEST(low)
  --fail-on low     exit=1    DOCKER_TAG_NOT_DIGEST(low)
```

The default gate, `--fail-on high` and `--fail-on medium` are unchanged.
`--fail-on low`, `--fail-on info` and the risk score are not. Projects that do
not want the tier set `rules.disable: [DOCKER_TAG_NOT_DIGEST]`.

**2. Compose `image:` is out of scope, and now says so.** Nine of nine Docker
rules are anchored on a Dockerfile instruction keyword, so a Compose file
returns nothing from the Docker rule set while `README.md` listed it as a
scanned Docker target. That now reads accurately in each rule's `description`,
in `README.md` and in the decision record. The blocker for implementing it is
written down rather than left to be rediscovered: in Compose, a service that
also declares `build:` uses `image:` to name what it BUILDS, and telling the two
apart needs service-block structure, which this project has no YAML parser for.
A rule that fires on correct configuration gets the tool switched off.

### Also fixed, same root cause

- `DOCKER_NO_TAG` reported a build-stage reference (`FROM builder`) as an
  untagged image. A stage cannot be pinned; it is no longer reported. The mirror
  gap closes too: `FROM ubuntu AS base` is now reported, where the old `\s*$`
  anchor let a stage-declaring untagged line through.
- Both rules stopped matching text that is not an instruction: `# FROM
  node:latest` and `RUN echo FROM node:latest` were reported, and the second
  line of `RUN echo x \` / `FROM node:latest` was read as an instruction when it
  is an argument to `RUN`.
- A `FROM` line carrying an embedded carriage return still classifies. Writing
  the instruction regex the obvious way, anchored with `$`, would have made
  `FROM node:latest\rEXTRA` scan clean, because JavaScript's `.` stops at a line
  terminator. The released regex did report it, so anchoring would have been a
  regression introduced by this fix.

### Stated bounds, so none of this is a mystery later

- `MAX_FROM_INSTRUCTION_CHARS = 1024`: how much of one `FROM` instruction is
  parsed and how much of a continuation chain is joined. About double the
  longest instruction the reference grammar can produce (name 255 + tag 128 +
  sha512 digest 136 + `--platform=linux/arm64/v8` about 25 + ` AS <stage>`), so
  no legal instruction reaches it. It is what keeps the matcher linear on a
  single multi-megabyte line and on a file of a million continuation lines.
- A digest counts as a pin only at full length, `sha256` with 64 hex or `sha512`
  with 128, the two algorithms the OCI image specification registers. A
  truncated `@sha256:abc...` identifies no image, so reading it as pinned would
  report a broken reference as safe.
- A reference that is WHOLLY a variable (`FROM $BASE`) produces no finding in
  either direction; its value is not visible to a file-local scan and may carry
  a digest. The `ARG` default is not resolved, because `--build-arg` overrides
  it at build time.
- Build stages resolve in file order, matching the daemon. A forward reference
  is not a stage and is still classified.

### Acceptance criteria from the issue

- [x] The rule flags every mutable base image reference, with `scratch` still
      exempt. Split across two tiers rather than one, with the reasoning and the
      option not taken recorded in `docs/ARCHITECTURE.md`. Criterion 1 as
      written is not implementable: `validatePatternSet` rejects the plain
      pattern form at module load.
- [x] The locking test at `dockerfile-scanner.test.ts` is rewritten so
      `FROM node:20-alpine` is asserted as flagged and a digest-pinned line as
      clean. A **second** locking test asserted the same gap more strictly
      (total of zero findings for a version-tagged Dockerfile) and is rewritten
      too; the issue names only the first.
- [x] This repository's own `Dockerfile` scans clean. `node dist/cli.js scan .
      --no-history -f json` reports **zero** `DOCKER_*` findings; both `FROM`
      lines are digest pinned. There is a test that asserts it against the real
      file, so it cannot silently stop being true.
- [x] The severity decision is recorded next to the pattern and in
      `docs/ARCHITECTURE.md`.
- [x] Compose `image:` coverage explicitly declared out of scope in the rule
      descriptions, `README.md` and the decision record.

### Regression tests, and the mutations proving they bite

The line a reviewer deletes to redden the headline test is
`return "tag-without-digest";` in `classifyBaseImageReference()`. Deleted, the
defect this issue reports comes straight back, and:

```
 × treats a version tag as unpinned and a digest as pinned
   AssertionError: expected false to be true
 × flags a tag without a digest at low severity, separately from a channel tag
   AssertionError: version tag: expected [] to deeply equal [ 'DOCKER_TAG_NOT_DIGEST@1' ]
 Test Files  1 failed (1)
      Tests  2 failed | 27 passed (29)
 exit code 1
```

Four more single-line deletions, each isolating one guard that no other case
exercises, each verified by re-reading the file and confirming the deleted form
is gone and its siblings are not:

| Deleted | Red | Exit |
|---------|-----|------|
| `if (MUTABLE_CHANNEL_TAGS.has(channel)) return "mutable-channel";` | 4 tests, channel tags collapse into the low tier | 1 |
| `while (cursor < tokens.length && FROM_FLAG_RE.test(tokens[cursor]!)) cursor++;` | 3 tests, `--platform` miss returns | 1 |
| `if (instruction.stage !== undefined) declaredStages.add(instruction.stage);` | 1 test, `FROM builder AS runtime` misreported as `DOCKER_NO_TAG@2` | 1 |
| `$` restored on `FROM_INSTRUCTION_RE` | 1 test, `FROM node:latest\rEXTRA` scans clean | 1 |

The suite also imports `DOCKERFILE_PATTERNS` and asserts all three rules load
with a matcher bound, because a `validatePatternSet` throw is reported by vitest
as "Tests no tests", which reads far too much like a pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New detection pattern

## Testing

- [x] Tests pass (`npm test`) - run per file locally; CI gives the full verdict
- [x] Type check passes (`npm run lint`)
- [x] New tests added for new patterns/features
- [x] Tested with real-world samples (if applicable)

12 test files covering the changed modules and their neighbours: 376 passed, 4
skipped. `dockerfile-scanner.test.ts` alone: 30 passed.

## Detection Patterns (if applicable)

- Rule ID: `DOCKER_TAG_NOT_DIGEST` (new), `DOCKER_UNPINNED_BASE` and
  `DOCKER_NO_TAG` (both re-implemented, ids unchanged)
- Severity: low for the new rule, high for the two existing ones
- False positive risk: low. Build-stage references, wholly variable references,
  comment lines and `FROM` inside another instruction are all excluded by the
  parser and each is covered by a test. Two of those were false positives in the
  released rules and are now gone.
- References: OCI image specification (digest form and registered algorithms),
  Dockerfile reference (`FROM [--platform=<platform>] <image> [AS <name>]`,
  comment removal before continuation joining)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added tests that prove my fix/feature works
- [x] `npm run build` is green, including the three governance gate groups it runs before `tsc`
- [x] New and existing tests pass
- [x] `.ai/handoff/STATUS.md` describes this change and the handoff manifest is in sync (`node scripts/scg-handoff-docs.mjs --check` reports "MANIFEST.json in sync")
- [x] No AI/tool attribution in the commits, the title or this body (see CONTRIBUTING.md)
- [x] Any benchmark or measurement evidence above reports counts and classes only, not consumer repository names

### One thing worth a second opinion

Nothing blocks the merge. The single judgement call is whether
`DOCKER_TAG_NOT_DIGEST` should ship at `low` or `medium`. `low` was chosen
because it matches the in-repo Actions precedent and leaves every existing gate
exactly where it was. `medium` would make it visible to `--fail-on medium`
consumers and is a one-word change; the trade-off is written out in
`docs/ARCHITECTURE.md`.
