### PR TITLE
chore(git): STATUS.md is an append-log, so declare merge=union

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,9 +11,9 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:578a2ad3f6aa68ea00829af82de013f587c78c9213ba9cfc4b98ff7785b0fccd",
+      "checksum": "sha256:ff2324905d573f406f68f6d92d6cca9ad0d769993eb304ec1d3230a034e441bc",
       "updated": "2026-08-22T20:51:49Z",
-      "lines": 2791,
+      "lines": 2805,
       "summary": "Branch fix/release-ancestry-gate. No version bump. Closes the ancestry half of the"
     },
     "NEXT_ACTIONS.md": {
@@ -82,7 +82,95 @@
     "manifest_only": 85,
     "manifest_plus_core": 34272,
     "full_read": 45934
+  },
+  "next_task_id": 20,
+  "tasks": {
+    "T-008": {
+      "title": "Adopt AAHP 3.9.1 and close verified scanner and CI defects",
+      "status": "done",
+      "priority": "high",
+      "depends_on": [],
+      "created": "2026-08-04T08:00:00Z",
+      "completed": "2026-08-04T08:15:48Z"
+    },
+    "T-009": {
+      "title": "Implement full offline sigstore verification",
+      "status": "ready",
+      "priority": "high",
+      "depends_on": [],
+      "created": "2026-08-04T08:00:00Z"
+    },
+    "T-010": {
+      "title": "Add a first-class known-bad VS Code extension ID IOC type",
+      "status": "ready",
+      "priority": "high",
+      "depends_on": [],
+      "created": "2026-08-04T08:00:00Z"
+    },
+    "T-011": {
+      "title": "Verify remaining Digest-78 indicators before ingestion",
+      "status": "ready",
+      "priority": "medium",
+      "depends_on": [],
+      "created": "2026-08-04T08:00:00Z"
+    },
+    "T-012": {
+      "title": "Profile structural matcher cost under V8 coverage",
+      "status": "ready",
+      "priority": "low",
+      "depends_on": [],
+      "created": "2026-08-04T08:00:00Z"
+    },
+    "T-013": {
+      "title": "Move to Babel 8 and a supported Node line",
+      "status": "blocked",
+      "priority": "medium",
+      "depends_on": [],
+      "blocked_by": "Owner decision on raising package engines and both CI jobs together",
+      "created": "2026-08-04T08:00:00Z"
+    },
+    "T-014": {
+      "title": "Remove external zip dependency from VS Code test fixtures",
+      "status": "ready",
+      "priority": "low",
+      "depends_on": [],
+      "created": "2026-08-04T10:00:00Z"
+    },
+    "T-015": {
+      "title": "Fix packaged self-scan own-definition false positive",
+      "status": "done",
+      "priority": "high",
+      "depends_on": [],
+      "created": "2026-08-04T09:24:00Z",
+      "completed": "2026-08-04T09:27:00Z"
+    },
+    "T-016": {
+      "title": "Version-pinned npm IOCs match on a directory scan via the lockfile path",
+      "status": "done",
+      "priority": "high",
+      "depends_on": [],
+      "created": "2026-08-06T09:00:00Z"
+    },
+    "T-017": {
+      "title": "Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC",
+      "status": "done",
+      "priority": "medium",
+      "depends_on": [],
+      "created": "2026-08-06T09:30:00Z"
+    },
+    "T-018": {
+      "title": "Match known-malware hashes against real file digests, not just digest text in content",
+      "status": "done",
+      "priority": "high",
+      "depends_on": [],
+      "created": "2026-08-12T09:00:00Z"
+    },
+    "T-019": {
+      "title": "Dropped-persistence detection (tranches 1 and 2)",
+      "status": "done",
+      "priority": "high",
+      "depends_on": [],
+      "created": "2026-08-12T09:00:00Z"
+    }
   }
-  ,"next_task_id": 20
-  ,"tasks": {"T-008":{"title":"Adopt AAHP 3.9.1 and close verified scanner and CI defects","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z","completed":"2026-08-04T08:15:48Z"},"T-009":{"title":"Implement full offline sigstore verification","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-010":{"title":"Add a first-class known-bad VS Code extension ID IOC type","status":"ready","priority":"high","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-011":{"title":"Verify remaining Digest-78 indicators before ingestion","status":"ready","priority":"medium","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-012":{"title":"Profile structural matcher cost under V8 coverage","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T08:00:00Z"},"T-013":{"title":"Move to Babel 8 and a supported Node line","status":"blocked","priority":"medium","depends_on":[],"blocked_by":"Owner decision on raising package engines and both CI jobs together","created":"2026-08-04T08:00:00Z"},"T-014":{"title":"Remove external zip dependency from VS Code test fixtures","status":"ready","priority":"low","depends_on":[],"created":"2026-08-04T10:00:00Z"},"T-015":{"title":"Fix packaged self-scan own-definition false positive","status":"done","priority":"high","depends_on":[],"created":"2026-08-04T09:24:00Z","completed":"2026-08-04T09:27:00Z"},"T-016":{"title":"Version-pinned npm IOCs match on a directory scan via the lockfile path","status":"done","priority":"high","depends_on":[],"created":"2026-08-06T09:00:00Z"},"T-017":{"title":"Index matchBareNpmIOC so npm IOC lookup is O(1) like matchPackageIOC","status":"done","priority":"medium","depends_on":[],"created":"2026-08-06T09:30:00Z"},"T-018":{"title":"Match known-malware hashes against real file digests, not just digest text in content","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"},"T-019":{"title":"Dropped-persistence detection (tranches 1 and 2)","status":"done","priority":"high","depends_on":[],"created":"2026-08-12T09:00:00Z"}}
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,17 @@
+## 2026-08-23 - declare merge=union for the handoff append-log
+
+`.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by
+one block and nothing else. Eight sibling repositories in this estate already
+declare `merge=union` for it; this one did not, and the two that lacked it are
+exactly the two where twenty-two rebases on 2026-08-23 each resolved this file by
+hand.
+
+It does not stop a pull request going CONFLICTING - GitHub does not honour merge
+drivers server-side, measured 2026-07-31 - so this removes the hand resolution,
+not the merge. `MANIFEST.json` is deliberately left without a driver: it is
+generated state, and the correct resolution is to take main's copy and recompute
+the changed entries, which no driver can do.
+
 # supply-chain-guard: Current State
 
 > Updated 2026-08-20 (release v5.27.0). This is one current snapshot, not a session

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,17 @@
 # regenerate MANIFEST.json - a required gate for every code commit - so on Windows
 # the handoff check could not be satisfied at all.
 *.sh text eol=lf
+
+# `.ai/handoff/STATUS.md` is an append-log: every pull request prepends its own
+# session note, so two branches almost always differ by one prepended block and
+# nothing else. `union` keeps both sides, which is the correct resolution here
+# and the only one that does not lose somebody's note.
+#
+# Verified for local `git merge`. GitHub does NOT honour merge drivers
+# server-side (measured 2026-07-31 in Shield: two PRs touching STATUS.md still
+# showed as CONFLICTING after a third merged), so a PR touching STATUS.md still
+# needs a local merge before it can land. What this removes is the HAND
+# resolution, not the merge itself. Measured here on 2026-08-23: twenty-two
+# rebases in one session, every one of them resolving this file by hand, in the
+# two repositories that lacked this line while eight siblings had it.
+.ai/handoff/STATUS.md merge=union


### PR DESCRIPTION
`.ai/handoff/STATUS.md` is prepend-only: every pull request adds its own session note at the top, so two branches differ by one block and nothing else. `union` keeps both sides, which is the correct resolution and the only one that cannot lose a note.

**Eight sibling repositories in this estate already carry this line.** This one did not, and the two that lacked it are exactly the two where twenty-two rebases on 2026-08-23 each resolved this file by hand.

**What this does not do**, stated because the sibling repositories' own comment measured it and it would otherwise be over-claimed: GitHub does not honour merge drivers server-side (measured 2026-07-31 in Shield - two pull requests touching STATUS.md still showed CONFLICTING after a third merged). A pull request touching STATUS.md will still go dirty and still needs a local merge before it can land. **This removes the hand resolution, not the merge.**

`.ai/handoff/MANIFEST.json` is deliberately NOT given a driver: it is generated state, so the correct resolution is to take main's copy and recompute the changed entries, which no driver can do.

## Acceptance criteria

- [x] The line matches the wording the eight sibling repositories use
- [x] The comment states what it does not fix, with the date that was measured
- [x] MANIFEST.json is left without a driver, and the reason is written down
- [x] CI green for this head, which is a merge precondition rather than a checkbox