### PR TITLE
fix(scan): SLA findings reach the report, and riskTrend includes now

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -16,7 +16,7 @@ Current package inventory and CI gate wiring are generated below.
 | Version | 5.28.1 |
 | Node engines | >=22.0.0 |
 | Source modules | 75 under `src/` |
-| Test files | 134 under `src/__tests__/` |
+| Test files | 135 under `src/__tests__/` |
 | tsconfig `types: ["node"]` | yes |
 | Build / test / audit gates | enforced in required CI - see below |
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,84 +3,84 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787477210",
-    "timestamp": "2026-08-23T09:26:50Z",
-    "commit": "0e9c827",
+    "session_id": "cli-1787477814",
+    "timestamp": "2026-08-23T09:36:54Z",
+    "commit": "6e60e6f",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:cbce0af8de3a05380c47c101ad6c85b8f3c83e37fecd643a4738bca9af66636c",
-      "updated": "2026-08-23T09:25:51Z",
-      "lines": 4431,
-      "summary": "Independent re-read of the four leftovers on #221:"
+      "checksum": "sha256:1dca2d23ce0d686fbb0b21f6d5a329eaf3942c5a5b1f7e48a9a7e96c7bf6c2ab",
+      "updated": "2026-08-23T09:36:10Z",
+      "lines": 4451,
+      "summary": "closes they implied: 167, 168, 194, 201, 202, 203, 206, 208. #179 was already"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:b1a3c171d239cca496bd0bc581edebc8597d34d92a2bcb2c33948e9218817b16",
-      "updated": "2026-08-23T01:56:04Z",
+      "updated": "2026-08-23T09:34:11Z",
       "lines": 250,
       "summary": "Five tasks are ready, two are blocked on owner decisions, and T-008/T-015/T-016/T-017/T-018/T-019 are complete."
     },
     "LOG.md": {
       "checksum": "sha256:3c1c0e5847ede7c2d648a3cba6ded0cb8d11faaea2442ca743c0331714530cd3",
-      "updated": "2026-08-23T09:26:50Z",
+      "updated": "2026-08-23T09:36:53Z",
       "lines": 156,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:e566ec8a4b80bba4b488aa69c5bf0e2a4ef1753046f18b81afe80a6846c73149",
-      "updated": "2026-08-23T01:56:04Z",
+      "updated": "2026-08-23T09:34:11Z",
       "lines": 132,
       "summary": "**Agent:** Claude Opus 4.8 (claude-opus-4-8)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:94b2e7524ade23f11edc97075afc33bc9884288661336bb6ce279d6928d22c62",
-      "updated": "2026-08-23T01:56:04Z",
+      "updated": "2026-08-23T09:34:11Z",
       "lines": 11,
       "summary": "{"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:ab0f21167aed0c8fd44fdc1c6be0541de1a170f22e214f6d2b21f112575ee2ab",
-      "updated": "2026-08-23T09:26:50Z",
+      "checksum": "sha256:2ccd74c6f2925d3f0b637e2da531c8089314ddd17c6dab3c8cbc044e2174e915",
+      "updated": "2026-08-23T09:36:53Z",
       "lines": 75,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
-      "checksum": "sha256:be03b49a74d7288c1f7fd631c13682d5c345852eff67bce469f242353a1fb1b2",
-      "updated": "2026-08-23T09:26:50Z",
+      "checksum": "sha256:b3e762ed8591c7a2c975379bf5b3924c8527de830b82b03f4f98c7b88a267781",
+      "updated": "2026-08-23T09:36:53Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:a0af51f3eeaa9a4536aecf030f0174437b7648f3e71acacc5aab137811935a65",
-      "updated": "2026-08-23T01:56:04Z",
+      "updated": "2026-08-23T09:34:11Z",
       "lines": 256,
       "summary": "- All code, comments, commits, and documentation in **English only**"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:60261845b207a16068d9d520b25cd16522b0b52f459fb97e8ad0bf892f10fca1",
-      "updated": "2026-08-23T01:56:04Z",
+      "updated": "2026-08-23T09:34:11Z",
       "lines": 165,
       "summary": "MANIFEST.json tasks is the authoritative machine-readable task graph."
     },
     "GROUNDING.md": {
       "checksum": "sha256:d3744f97b8190fbc73b3fbd44df70cc343d23b99cdc1e92eee686929212b151e",
-      "updated": "2026-08-23T01:56:04Z",
+      "updated": "2026-08-23T09:34:11Z",
       "lines": 209,
       "summary": "This register extends AAHP machinery without replacing it."
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-23T01:56:04Z",
+      "updated": "2026-08-23T09:34:11Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "Independent re-read of the four leftovers on #221: Five tasks are ready, two are blocked on owner decisions, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "closes they implied: 167, 168, 194, 201, 202, 203, 206, 208. #179 was already Five tasks are ready, two are blocked on owner decisions, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 54227,
-    "full_read": 66011
+    "manifest_plus_core": 54434,
+    "full_read": 66218
   }
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,18 +3,18 @@
   "project": "supply-chain-guard",
   "last_session": {
     "agent": "handoff-refresh",
-    "session_id": "cli-1787477814",
-    "timestamp": "2026-08-23T09:36:54Z",
-    "commit": "6e60e6f",
+    "session_id": "cli-1787478577",
+    "timestamp": "2026-08-23T09:49:37Z",
+    "commit": "0b65472",
     "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:1dca2d23ce0d686fbb0b21f6d5a329eaf3942c5a5b1f7e48a9a7e96c7bf6c2ab",
-      "updated": "2026-08-23T09:36:10Z",
-      "lines": 4451,
-      "summary": "closes they implied: 167, 168, 194, 201, 202, 203, 206, 208. #179 was already"
+      "checksum": "sha256:2c6ca856042b7658e9d2a91b7c3bff80cdb2f5199a90dacaa7c0597292d7c7b7",
+      "updated": "2026-08-23T09:49:35Z",
+      "lines": 4484,
+      "summary": "Do not start v6.0.0. Zero-open-issues is not met."
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:b1a3c171d239cca496bd0bc581edebc8597d34d92a2bcb2c33948e9218817b16",
@@ -24,7 +24,7 @@
     },
     "LOG.md": {
       "checksum": "sha256:3c1c0e5847ede7c2d648a3cba6ded0cb8d11faaea2442ca743c0331714530cd3",
-      "updated": "2026-08-23T09:36:53Z",
+      "updated": "2026-08-23T09:49:37Z",
       "lines": 156,
       "summary": "This generated journal lists every release derived from CHANGELOG.md, newest first."
     },
@@ -42,13 +42,13 @@
     },
     "DASHBOARD.md": {
       "checksum": "sha256:2ccd74c6f2925d3f0b637e2da531c8089314ddd17c6dab3c8cbc044e2174e915",
-      "updated": "2026-08-23T09:36:53Z",
+      "updated": "2026-08-23T09:49:37Z",
       "lines": 75,
       "summary": "Current package inventory and CI gate wiring are generated below."
     },
     "TRUST.md": {
       "checksum": "sha256:b3e762ed8591c7a2c975379bf5b3924c8527de830b82b03f4f98c7b88a267781",
-      "updated": "2026-08-23T09:36:53Z",
+      "updated": "2026-08-23T09:49:37Z",
       "lines": 65,
       "summary": "Provenance and status are tracked independently."
     },
@@ -77,10 +77,10 @@
       "summary": "{"
     }
   },
-  "quick_context": "closes they implied: 167, 168, 194, 201, 202, 203, 206, 208. #179 was already Five tasks are ready, two are blocked on owner decisions, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
+  "quick_context": "Do not start v6.0.0. Zero-open-issues is not met. Five tasks are ready, two are blocked on owner decisions, and T-008/T-015/T-016/T-017/T-018/T-019 are complete. ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 54434,
-    "full_read": 66218
+    "manifest_plus_core": 54797,
+    "full_read": 66581
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,36 @@
+## Stopped 2026-08-23: limits, next agent pick-up
+
+Do not start v6.0.0. Zero-open-issues is not met.
+
+### Already on GitHub (no local diff)
+
+Closed-issue acceptance boxes were reconciled against origin/main at 6e60e6f
+by editing the issue bodies. A box was ticked only with an artefact; otherwise
+it stayed open with a one-line reason and a destination. Done for: 205, 188,
+189, 190, 191, 192, 193, 195, 197, 198, 200, 179. Merged PR bodies also
+updated: 209, 207, 186 (runtime-proof box ticked), 218, 221. 185 and 187
+already had destinations (#167, #168).
+
+NOT done: the other August closed issues still show every box open (204, 199,
+196, 180, 178, 177, 176, 175, 174, 173, 172, 171, 170, 169, and older ones).
+Same rule: evidence on main, then tick or leave with a reason. Do not tick a
+box whose artefact is a different design than the box named (example: #204
+asked for SARIF `result.suppressions[]`; what shipped is `policyEffect`
+metadata, and suppressed findings stay out of machine formats).
+
+### Open work
+
+- PR #223 https://github.com/homeofe/supply-chain-guard/pull/223 closes 194
+  and 206. Do not merge until its CI is green AND main CI for 6e60e6f is
+  green. Main CI failed on Node 24 only: `should skip version pins and
+  comments in requirements.txt` timed out at 5s hitting PyPI. Node 20/22
+  passed. That flake is the shape of #201. Remove the worktree at
+  `_scg-wt-closeout` before merging #223.
+- Still open after #223: 167, 168, 201, 202, 203, 208.
+- 167: ancestry gate is already on main. Do not add aahp-verify on tags
+  without a base SHA that is not HEAD-equal; AAHP 3.10.0 blocks that.
+- Remote heads should be only main, v5, and this PR branch.
+
 ## Closeout after #220 and #221: SLA findings reach the report, and riskTrend includes now
 
 #220 and #221 are on main. Remaining open issues after that merge and the

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,23 @@
+## Closeout after #220 and #221: SLA findings reach the report, and riskTrend includes now
+
+#220 and #221 are on main. Remaining open issues after that merge and the
+closes they implied: 167, 168, 194, 201, 202, 203, 206, 208. #179 was already
+done on main (persist-credentials: false on every checkout that does not
+push, delete_branch_on_merge true, AAHP pin 3.10.0) and was closed with that
+evidence.
+
+This change:
+
+- Issue 194: `scan()` calls `checkSlaCompliance` on the triage decisions.
+  A tree whose store is 30 days past SLA now raises `SLA_BREACH_CRITICAL`.
+- Issue 206: `calculateMetrics` takes the current score. Two history rows at
+  40 plus a current score of 0 report `decreasing`; the same history without
+  the current score still reports `stable`.
+
+Not in this change: 167 (ancestry gate already on main; aahp-verify on tags
+would fail because a tag of HEAD is a HEAD-equal base and 3.10.0 blocks
+that), 168 (policy-diff against the base ref), 201, 202, 203, 208.
+
 ## Remaining review findings on the SBOM cluster: they reproduced, and they are closed
 
 Independent re-read of the four leftovers on #221:

--- a/.ai/handoff/TRUST.md
+++ b/.ai/handoff/TRUST.md
@@ -45,7 +45,7 @@ Every participating record carries the Grounded Reflection fields. Expired
 |----------|-------|--------------|
 | package.json version | 5.28.1 | package.json |
 | Source modules present | 75 | src/ file list |
-| Test files present | 134 | src/__tests__/ file list |
+| Test files present | 135 | src/__tests__/ file list |
 | tsconfig `types: ["node"]` | yes | tsconfig.json |
 | Runtime dependency | commander ^14.0.3 | package.json |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,19 @@ top; release tags trigger the CI publish pipeline (npm via OIDC + GitHub Release
 
 ### Fixed
 
+- **`checkSlaCompliance` now runs inside a scan.**
+  ([#194](https://github.com/homeofe/supply-chain-guard/issues/194)) The SLA
+  engine was exported and tested and had no caller, so `SLA_BREACH_CRITICAL`
+  and `SLA_AT_RISK` could never reach a report, an exit code, or the Action.
+  `scan()` now invokes it on the same triage decisions the governance check
+  already reads.
+- **`metrics.riskTrend` includes the current scan.**
+  ([#206](https://github.com/homeofe/supply-chain-guard/issues/206)) The KPI
+  was computed from the history loaded at the start of the scan, before this
+  run was appended, so it described the previous scan. A collapsed current
+  score could sit next to `riskTrend: "increasing"` in the same report while
+  `RISK_TREND_SPIKE` (which already took the current score) fired. The window
+  now includes the current score.
 - **A scan that examined ZERO files is no longer reported as clean.**
   ([#205](https://github.com/homeofe/supply-chain-guard/issues/205)) Measured
   before the change, on an empty directory versus this repository's own two-file

--- a/src/__tests__/issue-194-sla-wired.test.ts
+++ b/src/__tests__/issue-194-sla-wired.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Issue 194: checkSlaCompliance had no caller, so SLA_BREACH_CRITICAL and
+ * SLA_AT_RISK could never reach a scan report. The engine itself worked; the
+ * defect was that scan() never invoked it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { scan } from "../scanner.js";
+import { STATE_DIR } from "../state-dir.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "scg-194-"));
+  fs.writeFileSync(path.join(tmpDir, "package.json"), '{"name":"x","version":"1.0.0"}');
+  fs.writeFileSync(path.join(tmpDir, "index.js"), "module.exports = 1;\n");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+it("a scan of a tree whose triage store is 30 days past SLA raises SLA_BREACH_CRITICAL", async () => {
+  fs.mkdirSync(path.join(tmpDir, STATE_DIR), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, STATE_DIR, "triage-decisions.json"),
+    JSON.stringify(
+      [
+        {
+          findingRule: "EVAL_ATOB",
+          status: "new",
+          decidedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+        },
+      ],
+      null,
+      2,
+    ),
+  );
+
+  const report = await scan({ target: tmpDir, format: "json", noHistory: true });
+  expect(report.findings.map((f) => f.rule)).toContain("SLA_BREACH_CRITICAL");
+});

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -58,6 +58,19 @@ describe("Metrics", () => {
     expect(m.riskTrend).toBe("increasing");
   });
 
+  it("includes the current scan in the trend window (issue 206)", () => {
+    // Two previous scans at 40. Without the current score the window is only
+    // two points and reports stable. With a collapsed current score of 0 the
+    // window is 40, 40, 0 and must report decreasing. That is the moment the
+    // KPI used to disagree with RISK_TREND_SPIKE in the same report.
+    const history: RiskHistoryEntry[] = [
+      { timestamp: "", score: 40, findingsCount: 4, criticalCount: 1 },
+      { timestamp: "", score: 40, findingsCount: 4, criticalCount: 1 },
+    ];
+    expect(calculateMetrics([], history, []).riskTrend).toBe("stable");
+    expect(calculateMetrics([], history, [], undefined, 0).riskTrend).toBe("decreasing");
+  });
+
   it("should identify top risk contributors", () => {
     const findings: Finding[] = [
       { rule: "EVAL_ATOB", description: "", severity: "critical", recommendation: "" },

--- a/src/__tests__/state-store-corruption.test.ts
+++ b/src/__tests__/state-store-corruption.test.ts
@@ -61,7 +61,8 @@ function validHistoryJson(): string {
 
 /**
  * One expired risk acceptance and one stale in-remediation decision. Both
- * produce `high` governance findings, which is what lets the triage assertions
+ * produce `high` governance findings, and the breached in-remediation decision
+ * also produces a `critical` SLA finding, which is what lets the triage assertions
  * below check the gate rather than only the finding list.
  */
 function validTriageJson(): string {
@@ -302,9 +303,10 @@ describe("triage store: the same two cases, equally separated", () => {
 
     expect(rulesOf(report)).toContain("RISK_ACCEPTANCE_EXPIRED");
     expect(rulesOf(report)).toContain("STALE_CRITICAL_FINDING");
+    expect(rulesOf(report)).toContain("SLA_BREACH_CRITICAL");
     expect(rulesOf(report)).not.toContain("TRIAGE_STORE_UNREADABLE");
     expect(report.partialScan).toBeUndefined();
-    expect(getReportExitCode(report)).toBe(1);
+    expect(getReportExitCode(report)).toBe(2);
     // The true value for this fixture under the single SLA definition in
     // src/sla-engine.ts: two measurable decisions, one of them compliant.
     //
@@ -316,8 +318,8 @@ describe("triage store: the same two cases, equally separated", () => {
     // fixture is resolved, which is exactly why the old number was 0.
     //
     // The expired acceptance is still reported: RISK_ACCEPTANCE_EXPIRED is
-    // asserted above and the exit code is 1. The SLA rate is not the channel
-    // that carries it.
+    // asserted above, SLA_BREACH_CRITICAL is emitted (exit code 2). The SLA
+    // rate is not the channel that carries it.
     expect(report.metrics?.slaComplianceRate).toBe(50);
   });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -98,6 +98,7 @@ export function calculateMetrics(
   history: RiskHistoryEntry[],
   decisions: TriageDecision[],
   slaConfig?: SlaConfig,
+  currentScore?: number,
 ): SecurityMetrics {
   // Open findings by severity.
   //
@@ -117,12 +118,20 @@ export function calculateMetrics(
   // SLA compliance rate, from the one definition in src/sla-engine.ts
   const slaComplianceRate = slaComplianceRateOf(decisions, slaConfig);
 
-  // Risk trend
+  // Risk trend. The current scan is part of the window: history is loaded
+  // before this scan is written, so a window of history alone describes the
+  // previous scan. That is how riskTrend reported increasing at the moment
+  // risk collapsed (issue 206). `analyzeRiskTrend` already takes the current
+  // score; this KPI now does too.
   let riskTrend: "increasing" | "stable" | "decreasing" = "stable";
-  if (history.length >= 3) {
-    const recent = history.slice(-3).map((h) => h.score);
-    if (recent[2] > recent[0] + 5) riskTrend = "increasing";
-    else if (recent[2] < recent[0] - 5) riskTrend = "decreasing";
+  const scores =
+    currentScore === undefined
+      ? history.map((h) => h.score)
+      : [...history.map((h) => h.score), currentScore];
+  if (scores.length >= 3) {
+    const recent = scores.slice(-3);
+    if (recent[2]! > recent[0]! + 5) riskTrend = "increasing";
+    else if (recent[2]! < recent[0]! - 5) riskTrend = "decreasing";
   }
 
   // Top risk contributors (most frequent critical/high rules)

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -96,6 +96,7 @@ import { readRiskHistory, riskHistoryUnreadableFinding, analyzeRiskTrend, saveRi
 import { readTriageDecisions, triageStoreUnreadableFinding, checkTriageGovernance } from "./triage-engine.js";
 import { forecastRisk } from "./risk-forecast.js";
 import { calculateMetrics } from "./metrics.js";
+import { checkSlaCompliance } from "./sla-engine.js";
 import {
   OBFUSCATION_V3_PATTERNS,
   PROVENANCE_PATTERNS,
@@ -895,6 +896,12 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
 
   const govFindings = checkTriageGovernance(findings, triageDecisions);
   findings.push(...govFindings);
+  // Issue 194: the SLA engine was exported and tested, and never called.
+  // SLA_BREACH_CRITICAL and SLA_AT_RISK therefore could not reach a scan
+  // report. Same decisions the governance check just read; same default SLA
+  // calculateMetrics uses. A configuration surface, if one is added, must
+  // reach both.
+  findings.push(...checkSlaCompliance(triageDecisions));
 
   // Pushed after checkTriageGovernance for the same reason as the history
   // finding above: the governance rules read the findings list, so a finding
@@ -943,7 +950,7 @@ export async function scan(options: ScanOptions): Promise<ScanReport> {
   // configuration surface is added, it must reach BOTH calculateMetrics and
   // checkSlaCompliance; wiring one and not the other reintroduces the split that
   // made slaComplianceRate contradict the SLA engine.
-  const metrics = calculateMetrics(filteredFindings, riskHistory, triageDecisions);
+  const metrics = calculateMetrics(filteredFindings, riskHistory, triageDecisions, undefined, score);
 
   // Save risk history for trend tracking (skip temp dirs; --no-history lets
   // read-only callers like the pre-commit hook avoid writing state into the


### PR DESCRIPTION
Closes #194. Closes #206.

Two KPI defects that left the scan report describing a different moment than the scan itself.

## #194

`checkSlaCompliance` was exported and tested and had no caller. `SLA_BREACH_CRITICAL` and `SLA_AT_RISK` could not appear in a report, an exit code, or the Action. `scan()` now invokes it on the same triage decisions the governance check already reads.

Measured: a tree whose `.scg-history/triage-decisions.json` holds a 30-day-old `new` decision now raises `SLA_BREACH_CRITICAL`. Deleting the `checkSlaCompliance` call turns that test red.

## #206

`metrics.riskTrend` was computed from the history loaded at the start of the scan, before this run was appended. A collapsed current score could sit next to `riskTrend: "increasing"` in the same JSON as a `RISK_TREND_SPIKE` finding (which already took the current score).

The window now includes the current score. Two history rows at 40 with a current score of 0 report `decreasing`; the same history without the current score still reports `stable`.

## Test scope

Targeted: `issue-194-sla-wired.test.ts`, `metrics.test.ts`, `sla-engine.test.ts` (35 passed). Full suite not run locally; CI is the verdict.

## Remaining open issues, not in this PR

167 (ancestry gate already on main; aahp-verify on tags is a separate decision because a tag of HEAD is a HEAD-equal base and AAHP 3.10.0 blocks that), 168, 201, 202, 203, 208.
